### PR TITLE
Update Racket to 6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ won't be able to use that feature! You can find those interperters here:
 * [LuaBinaries](http://luabinaries.sourceforge.net/download.html) 5.3
 * [Python](https://www.python.org/downloads/) 2.7
 * [Python](https://www.python.org/downloads/) 3.4
-* [Racket](https://download.racket-lang.org/) 6.3
+* [Racket](https://download.racket-lang.org/) 6.4
 * [RubyInstaller](http://rubyinstaller.org/downloads/) 2.2
 
 Make sure that you install the same architecture (32bit/64bit) that matches

--- a/appveyor.bat
+++ b/appveyor.bat
@@ -40,9 +40,9 @@ set PYTHON3_32_DIR=C:\python%PYTHON3_VER%
 set PYTHON3_64_DIR=C:\python%PYTHON3_VER%-x64
 set PYTHON3_DIR=!PYTHON3_%BIT%_DIR!
 :: Racket
-set RACKET_VER=3m_9z0ds0
-set RACKET32_URL=https://mirror.racket-lang.org/releases/6.3/installers/racket-minimal-6.3-i386-win32.exe
-set RACKET64_URL=https://mirror.racket-lang.org/releases/6.3/installers/racket-minimal-6.3-x86_64-win32.exe
+set RACKET_VER=3m_9zltds
+set RACKET32_URL=https://mirror.racket-lang.org/releases/6.4/installers/racket-minimal-6.4-i386-win32.exe
+set RACKET64_URL=https://mirror.racket-lang.org/releases/6.4/installers/racket-minimal-6.4-x86_64-win32.exe
 set RACKET_URL=!RACKET%BIT%_URL!
 set RACKET32_DIR=%PROGRAMFILES(X86)%\Racket
 set RACKET64_DIR=%PROGRAMFILES%\Racket

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,7 +63,7 @@ deploy:
       * [LuaBinaries](http://luabinaries.sourceforge.net/download.html) 5.3
       * [Python](https://www.python.org/downloads/) 2.7
       * [Python](https://www.python.org/downloads/) 3.4
-      * [Racket](https://download.racket-lang.org/) 6.3
+      * [Racket](https://download.racket-lang.org/) 6.4
       * [RubyInstaller](http://rubyinstaller.org/downloads/) 2.2
 
       Make sure that you install the same architecture (32bit/64bit) that matches your Vim installation.


### PR DESCRIPTION
Racket 6.4 was released about 2 months ago, and the default version in the [download page](https://download.racket-lang.org/) is already 6.4.
I think it's better to update Racket to 6.4.