### PR TITLE
Make Patch URLs Links to actual tag from vim repository

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ artifacts:
     name: gVim_x64_installer
 
 before_deploy:
-  - set /p GITLOG=<gitlog.txt
+  - for /f "delims=" %%i in (gitlog.txt) do set GITLOG=%%i
 
 deploy:
   - provider: GitHub

--- a/scripts/update-repo.sh
+++ b/scripts/update-repo.sh
@@ -51,7 +51,9 @@ fi
 
 # Commit the change and push it
 # replace newline by \n
-echo "$vimlog" | sed ':a;N;$!ba;s/\n/\\n/g' > gitlog.txt
+echo "$vimlog" | sed \
+    -e 's#^\* *\([0-9]\.[0-9]\.[0-9]\+\) #* [\1](https://github.com/vim/vim/releases/tag/v\1) #g' | sed \
+    -e ':a;N;$!ba;s/\n/\\n/g' > gitlog.txt
 git commit -a -m "vim: Import $vimver" -m "$vimlog"
 git tag $vimver
 git push origin master --tags


### PR DESCRIPTION
This change will make links for official patches. A simple example can be seen [here](https://github.com/chrisbra/vim-win32-installer/releases/tag/v7.4.1752)

Also, using `set /p=<file` seems to be restricted to a some bytes (around 1K or so) so output will be truncated if there is a long changelog. Therefore, use the `for /f....` approach which seems to work okay.