### PR TITLE
Create new archives for the pdb files

### DIFF
--- a/appveyor.bat
+++ b/appveyor.bat
@@ -198,10 +198,10 @@ start /wait cmd /c "setenv /x64 && cd GvimExt && nmake clean all"
 move GvimExt\gvimext.dll GvimExt\gvimext64.dll
 start /wait cmd /c "setenv /x86 && cd GvimExt && nmake clean all"
 :: Create zip packages
+7z a ..\..\gvim_%APPVEYOR_REPO_TAG_NAME:v=%_%ARCH%_pdb.zip *.pdb
 copy /Y ..\README.txt ..\runtime
 copy /Y ..\vimtutor.bat ..\runtime
 copy /Y *.exe ..\runtime\
-copy /Y *.pdb ..\runtime\
 copy /Y xxd\*.exe ..\runtime
 copy /Y tee\*.exe ..\runtime
 mkdir ..\runtime\GvimExt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,8 +33,12 @@ test_script:
 artifacts:
   - path: gvim_*_x86.zip
     name: gVim_x86
+  - path: gvim_*_x86_pdb.zip
+    name: gVim_x86_pdb
   - path: gvim_*_x64.zip
     name: gVim_x64
+  - path: gvim_*_x64_pdb.zip
+    name: gVim_x64_pdb
   - path: gvim_*_x86.exe
     name: gVim_x86_installer
   - path: gvim_*_x64.exe
@@ -57,6 +61,7 @@ deploy:
       archive of the 32bit (_x86) or 64bit versions (_x64). To install it, extract
       the archive and update your PATH variable. The installer will do that
       automatically and provide some additional extensions (e.g. Edit with Vim menu).
+      The gvim...pdb.zip file include pdb files for debugging the binaries.
 
       If you need a dynamic interface to Perl, Python2, Python3, Ruby, TCL, Lua or Racket/MzScheme,
       make sure you also install the following. Vim will work without it, but some Plugin


### PR DESCRIPTION
As requested on vim_use, create two new archives `gvim_*_pdb.zip` that contain only the pdb files for better debugging of the windows binaries.

An example can be seen [here](https://github.com/chrisbra/vim-win32-installer/releases/tag/v7.4.1832)