### PR TITLE
Show all interface versions

### DIFF
--- a/appveyor.bat
+++ b/appveyor.bat
@@ -179,12 +179,12 @@ popd
 
 :check_executable
 :: ----------------------------------------------------------------------
-.\gvim -silent -register
-.\gvim -u NONE -c "redir @a | ver | 0put a | wq!" ver.txt
+start /wait .\gvim -silent -register
+start /wait .\gvim -u NONE -c "redir @a | ver | 0put a | wq!" ver.txt
 type ver.txt
 .\vim --version
 :: Print interface versions
-.\gvim -S ..\..\if_ver.vim -c quit
+start /wait .\gvim -S ..\..\if_ver.vim -c quit
 type if_ver.txt
 @echo off
 goto :eof

--- a/appveyor.bat
+++ b/appveyor.bat
@@ -183,6 +183,9 @@ popd
 .\gvim -u NONE -c "redir @a | ver | 0put a | wq!" ver.txt
 type ver.txt
 .\vim --version
+:: Print interface versions
+.\gvim -S ..\..\if_ver.vim -c quit
+type if_ver.txt
 @echo off
 goto :eof
 

--- a/appveyor.bat
+++ b/appveyor.bat
@@ -72,6 +72,9 @@ set NSIS_URL=http://downloads.sourceforge.net/nsis/nsis-2.50.zip
 set UPX_URL=http://upx.sourceforge.net/download/upx391w.zip
 :: ----------------------------------------------------------------------
 
+:: Update PATH
+path %PERL_DIR%\bin;%path%;%LUA_DIR%;%TCL_DIR%\bin;%RUBY_DIR%\bin;%RACKET_DIR%;%RACKET_DIR%\lib
+
 if /I "%1"=="" (
   set target=build
 ) else (
@@ -130,8 +133,8 @@ for /d %%i in (C:\nsis*) do move %%i C:\nsis
 curl -f -L %UPX_URL% -o upx.zip || exit 1
 7z e upx.zip *\upx.exe -ovim\nsis > nul
 
-:: Update PATH
-path %PERL_DIR%\bin;%path%;%LUA_DIR%;%TCL_DIR%\bin;%RUBY_DIR%\bin;%RACKET_DIR%;%RACKET_DIR%\lib
+:: Show PATH for debugging
+path
 
 :: Install additional packages for Racket
 raco pkg install --auto r5rs-lib

--- a/if_ver.vim
+++ b/if_ver.vim
@@ -1,0 +1,22 @@
+" Print all interface versions and write the result into if_ver.txt.
+
+redir! > if_ver.txt
+echo "*** Interface versions ***"
+echo "\nLua:"
+lua print(_VERSION)
+" echo "\nLuaJIT:"
+" lua print(jit.version)
+echo "\nMzScheme:"
+mzscheme (display (version))
+echo "\nPerl:"
+perl print $^V
+echo "\nPython 2:"
+python import sys; print sys.version
+echo "\nPython 3:"
+python3 import sys; print(sys.version)
+echo "\nRuby:"
+ruby print RUBY_VERSION
+echo "\nTcl:"
+tcl puts [info patchlevel]
+echo "\n"
+redir END


### PR DESCRIPTION
This enables to show version numbers of all if_xx (mainly for debugging).
Also fixes that $PATH was not set properly when running the tests.

Here is an example output:
https://ci.appveyor.com/project/k-takata/vim-win32-installer/build/33/job/tqbewjwh8ys2dl0a#L746