### PR TITLE
Use build cache for downloaded files

### DIFF
--- a/appveyor.bat
+++ b/appveyor.bat
@@ -4,11 +4,6 @@
 setlocal ENABLEDELAYEDEXPANSION
 cd %APPVEYOR_BUILD_FOLDER%
 
-if /i "%appveyor_repo_tag%"=="false" (
-  echo Skip this build.
-  exit 0
-)
-
 if /I "%ARCH%"=="x64" (
   set BIT=64
 ) else (

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -88,4 +88,7 @@ deploy:
     on:
       appveyor_repo_tag: true
 
+cache:
+  - downloads -> appveyor.bat
+
 # vim: ts=2 sw=2 et


### PR DESCRIPTION
This keeps downloaded files in a cache unless appveyor.bat is changed.
If appveyor.bat is updated the cache should be discarded because the
downloaded files might be outdated.

See: http://www.appveyor.com/docs/build-cache