### PR TITLE
Apply patches before building

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,6 @@ your Vim installation.
 
 Note: The zip archive might be considered unsecure in Windows, causing Windows to display a dialog box "These files might be harmful to your computer...". If you want to disable this warning, you need to "unblock" the zip file. Do that in the properties dialog of the zip file, first tab General and look for the security section and click on "Unblock".
 
+Note: If you want to test some patches, place them in the patch directory with the extension `.patch`. They will be applied before building Vim and the binary will then be tested against the test suite.
+
 See: https://github.com/vim/vim

--- a/appveyor.bat
+++ b/appveyor.bat
@@ -90,6 +90,11 @@ reg copy HKLM\SOFTWARE\Python\PythonCore\2.7 HKLM\SOFTWARE\Python\PythonCore\2.7
 :: Get Vim source code
 git submodule update --init
 
+:: Apply experimental patches
+pushd vim
+for %%i in (..\patch\*.patch) do git apply -v %%i
+popd
+
 if not exist downloads mkdir downloads
 
 :: Lua

--- a/patch/README.md
+++ b/patch/README.md
@@ -1,0 +1,4 @@
+
+Place experimental patches here with the extension .patch and commit to this repository.
+
+All `*.patch` files inside that directory will then be applied, before Vim is build and the testsuite is then run with that Vim.


### PR DESCRIPTION
This allows to build Vim with additional patches. Place your experimental patch into the patch directory with the extension .patch. All files in that directory will then be applied in an alphanumeric order (?)