### PR TITLE
Update Perl to 5.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ installation and Neocomplete needs a working Lua installation). This means,
 those interpreters have to be installed in addition to Vim. Without it Vim
 won't be able to use that feature! You can find those interperters here:
 
-* [ActivePerl](http://www.activestate.com/activeperl/downloads) 5.22
+* [ActivePerl](http://www.activestate.com/activeperl/downloads) 5.24
 * [ActiveTcl](http://www.activestate.com/activetcl/downloads) 8.6
 * [LuaBinaries](http://luabinaries.sourceforge.net/download.html) 5.3
 * [Python](https://www.python.org/downloads/) 2.7
-* [Python](https://www.python.org/downloads/) 3.4
+* [Python 3](https://www.python.org/downloads/) 3.4
 * [Racket](https://download.racket-lang.org/) 6.4
 * [RubyInstaller](http://rubyinstaller.org/downloads/) 2.2
 

--- a/appveyor.bat
+++ b/appveyor.bat
@@ -19,9 +19,9 @@ set LUA64_URL=http://downloads.sourceforge.net/luabinaries/lua-5.3.2_Win64_dllw4
 set LUA_URL=!LUA%BIT%_URL!
 set LUA_DIR=C:\Lua
 :: Perl
-set PERL_VER=522
-set PERL32_URL=http://downloads.activestate.com/ActivePerl/releases/5.22.1.2201/ActivePerl-5.22.1.2201-MSWin32-x86-64int-299574.zip
-set PERL64_URL=http://downloads.activestate.com/ActivePerl/releases/5.22.1.2201/ActivePerl-5.22.1.2201-MSWin32-x64-299574.zip
+set PERL_VER=524
+set PERL32_URL=http://downloads.activestate.com/ActivePerl/releases/5.24.0.2400/ActivePerl-5.24.0.2400-MSWin32-x86-64int-300558.zip
+set PERL64_URL=http://downloads.activestate.com/ActivePerl/releases/5.24.0.2400/ActivePerl-5.24.0.2400-MSWin32-x64-300558.zip
 set PERL_URL=!PERL%BIT%_URL!
 set PERL_DIR=C:\Perl%PERL_VER%\perl
 :: Python2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,11 +70,11 @@ deploy:
       installation). This means, those interpreters have to be installed in addition to Vim.
       Without it Vim won't be able to use that feature! You can find those interperters here:
 
-      * [ActivePerl](http://www.activestate.com/activeperl/downloads) 5.22
+      * [ActivePerl](http://www.activestate.com/activeperl/downloads) 5.24
       * [ActiveTcl](http://www.activestate.com/activetcl/downloads) 8.6
       * [LuaBinaries](http://luabinaries.sourceforge.net/download.html) 5.3
       * [Python](https://www.python.org/downloads/) 2.7
-      * [Python](https://www.python.org/downloads/) 3.4
+      * [Python3](https://www.python.org/downloads/) 3.4
       * [Racket](https://download.racket-lang.org/) 6.4
       * [RubyInstaller](http://rubyinstaller.org/downloads/) 2.2
 


### PR DESCRIPTION
Perl 5.24 was released, so compile against 5.24

Example build script: https://ci.appveyor.com/project/chrisbra/vim-win32-installer-33v6e/build/53/job/357ohnhh85ie62f5