### PR TITLE
Update Python3 to 3.5

### DIFF
--- a/appveyor.bat
+++ b/appveyor.bat
@@ -30,7 +30,7 @@ set PYTHON_32_DIR=C:\python%PYTHON_VER%
 set PYTHON_64_DIR=C:\python%PYTHON_VER%-x64
 set PYTHON_DIR=!PYTHON_%BIT%_DIR!
 :: Python3
-set PYTHON3_VER=34
+set PYTHON3_VER=35
 set PYTHON3_32_DIR=C:\python%PYTHON3_VER%
 set PYTHON3_64_DIR=C:\python%PYTHON3_VER%-x64
 set PYTHON3_DIR=!PYTHON3_%BIT%_DIR!
@@ -66,7 +66,7 @@ set UPX_URL=http://upx.sourceforge.net/download/upx391w.zip
 :: ----------------------------------------------------------------------
 
 :: Update PATH
-path %PERL_DIR%\bin;%path%;%LUA_DIR%;%TCL_DIR%\bin;%RUBY_DIR%\bin;%RACKET_DIR%;%RACKET_DIR%\lib
+path %PYTHON_DIR%;%PYTHON3_DIR%;%PERL_DIR%\bin;%path%;%LUA_DIR%;%TCL_DIR%\bin;%RUBY_DIR%\bin;%RACKET_DIR%;%RACKET_DIR%\lib
 
 if /I "%1"=="" (
   set target=build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,7 +74,7 @@ deploy:
       * [ActiveTcl](http://www.activestate.com/activetcl/downloads) 8.6
       * [LuaBinaries](http://luabinaries.sourceforge.net/download.html) 5.3
       * [Python](https://www.python.org/downloads/) 2.7
-      * [Python3](https://www.python.org/downloads/) 3.4
+      * [Python3](https://www.python.org/downloads/) 3.5
       * [Racket](https://download.racket-lang.org/) 6.4
       * [RubyInstaller](http://rubyinstaller.org/downloads/) 2.2
 


### PR DESCRIPTION
The bigvim(64).bat is updated to use Python 3.5 by 7.4.2302. This commit follows it.
Note that python35.dll is not installed in `C:\Windows\System`, which differs from Python 3.4. We need to add `C:\python35(-x64)` to the %PATH%.