### PR TITLE
Workaround for python 2.7.12 not needed anymore

### DIFF
--- a/appveyor.bat
+++ b/appveyor.bat
@@ -83,9 +83,6 @@ exit 1
 :install_x64
 :: ----------------------------------------------------------------------
 @echo on
-:: Work around for Python 2.7.11
-reg copy HKLM\SOFTWARE\Python\PythonCore\2.7 HKLM\SOFTWARE\Python\PythonCore\2.7-32 /s /reg:32
-reg copy HKLM\SOFTWARE\Python\PythonCore\2.7 HKLM\SOFTWARE\Python\PythonCore\2.7-32 /s /reg:64
 
 :: Get Vim source code
 git submodule update --init


### PR DESCRIPTION
Appveyor seems to have switched to python 2.7.12
so the workaround about changing the registry keys for python should not
be needed anymore.

CC @k-takata for comment