### PR TITLE
Update Perl installation

### DIFF
--- a/appveyor.bat
+++ b/appveyor.bat
@@ -20,10 +20,10 @@ set LUA_URL=!LUA%BIT%_URL!
 set LUA_DIR=C:\Lua
 :: Perl
 set PERL_VER=524
-set PERL32_URL=http://downloads.activestate.com/ActivePerl/releases/5.24.0.2400/ActivePerl-5.24.0.2400-MSWin32-x86-64int-300560.zip
-set PERL64_URL=http://downloads.activestate.com/ActivePerl/releases/5.24.0.2400/ActivePerl-5.24.0.2400-MSWin32-x64-300558.zip
+set PERL32_URL=http://downloads.activestate.com/ActivePerl/releases/5.24.1.2402/ActivePerl-5.24.1.2402-MSWin32-x86-64int-401627.exe
+set PERL64_URL=http://downloads.activestate.com/ActivePerl/releases/5.24.1.2402/ActivePerl-5.24.1.2402-MSWin32-x64-401627.exe
 set PERL_URL=!PERL%BIT%_URL!
-set PERL_DIR=C:\Perl%PERL_VER%\perl
+set PERL_DIR=C:\ActivePerl
 :: Python2
 set PYTHON_VER=27
 set PYTHON_32_DIR=C:\python%PYTHON_VER%
@@ -99,9 +99,12 @@ call :downloadfile %LUA_URL% downloads\lua.zip
 7z x downloads\lua.zip -o%LUA_DIR% > nul || exit 1
 
 :: Perl
-call :downloadfile %PERL_URL% downloads\perl.zip
-7z x downloads\perl.zip -oC:\ > nul || exit 1
-for /d %%i in (C:\ActivePerl*) do move %%i C:\Perl%PERL_VER%
+call :downloadfile %PERL_URL% downloads\perl.exe
+mkdir c:\ActivePerl
+start /wait downloads\perl.exe /extract:c:\ActivePerl /exenoui /exenoupdates /quiet /norestart
+pushd c:\ActivePerl
+for /d %%i in (*) do for /d %%j in (%%i\*) do move %%j c:\ActivePerl
+popd
 
 :: Tcl
 call :downloadfile %TCL_URL% downloads\tcl.exe
@@ -125,8 +128,6 @@ start /wait downloads\racket.exe /S
 :: Install libintl.dll and iconv.dll
 call :downloadfile %GETTEXT_URL% downloads\gettext.exe
 start /wait downloads\gettext.exe /verysilent /dir=c:\gettext
-:: libwinpthread is needed on Win64 for localizing messages
-::copy c:\gettext\libwinpthread-1.dll ..\runtime
 
 :: Install UPX
 call :downloadfile %UPX_URL% downloads\upx.zip

--- a/appveyor.bat
+++ b/appveyor.bat
@@ -100,11 +100,9 @@ call :downloadfile %LUA_URL% downloads\lua.zip
 
 :: Perl
 call :downloadfile %PERL_URL% downloads\perl.exe
-mkdir c:\ActivePerl
-start /wait downloads\perl.exe /extract:c:\ActivePerl /exenoui /exenoupdates /quiet /norestart
-pushd c:\ActivePerl
-for /d %%i in (*) do for /d %%j in (%%i\*) do move %%j c:\ActivePerl
-popd
+mkdir c:\ActivePerlTemp
+start /wait downloads\perl.exe /extract:c:\ActivePerlTemp /exenoui /exenoupdates /quiet /norestart
+for /d %%i in (c:\ActivePerlTemp\*) do move %%i %PERL_DIR%
 
 :: Tcl
 call :downloadfile %TCL_URL% downloads\tcl.exe


### PR DESCRIPTION
ActivePerl changed their links. The old Perl link isn't even available anymore for downloads. So let's try with a newer release 5.24.1 ping @k-takata for review