### PR TITLE
Update racket and fix tcl test

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ installed in addition to Vim. Without it Vim won't be able to use that feature!
 You can find those interperters here:
 
 * [ActivePerl](http://www.activestate.com/activeperl/downloads) 5.24
-* [ActiveTcl](http://www.activestate.com/activetcl/downloads) 8.6
+* [ActiveTcl](http://www.activestate.com/activetcl/downloads) 8.6.6
 * [LuaBinaries](http://luabinaries.sourceforge.net/download.html) 5.3
 * [Python](https://www.python.org/downloads/) 2.7
 * [Python 3](https://www.python.org/downloads/) 3.5

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can find those interperters here:
 * [LuaBinaries](http://luabinaries.sourceforge.net/download.html) 5.3
 * [Python](https://www.python.org/downloads/) 2.7
 * [Python 3](https://www.python.org/downloads/) 3.5
-* [Racket](https://download.racket-lang.org/) 6.6
+* [Racket](https://download.racket-lang.org/) 6.10.1
 * [RubyInstaller2](http://rubyinstaller.org/downloads/) 2.4
 
 Make sure that you install the same architecture (32bit/64bit) for those

--- a/appveyor.bat
+++ b/appveyor.bat
@@ -57,6 +57,7 @@ set TCL32_URL=http://downloads.activestate.com/ActiveTcl/releases/8.6.6.8607/Act
 set TCL64_URL=http://downloads.activestate.com/ActiveTcl/releases/8.6.6.8606/ActiveTcl-8.6.6.8606-MSWin32-x64-401995.exe
 set TCL_URL=!TCL%BIT%_URL!
 set TCL_DIR=C:\Tcl
+set TCL_DLL=tcl%TCL_VER%t.dll
 :: Gettext
 set GETTEXT32_URL=https://github.com/mlocati/gettext-iconv-windows/releases/download/v0.19.8.1-v1.14/gettext0.19.8.1-iconv1.14-shared-32.zip
 set GETTEXT64_URL=https://github.com/mlocati/gettext-iconv-windows/releases/download/v0.19.8.1-v1.14/gettext0.19.8.1-iconv1.14-shared-64.zip

--- a/appveyor.bat
+++ b/appveyor.bat
@@ -58,6 +58,7 @@ set TCL64_URL=http://downloads.activestate.com/ActiveTcl/releases/8.6.6.8606/Act
 set TCL_URL=!TCL%BIT%_URL!
 set TCL_DIR=C:\Tcl
 set TCL_DLL=tcl%TCL_VER%t.dll
+set TCL_LIBRARY=%TCL_DIR%\lib\tcl%TCL_VER_LONG%
 :: Gettext
 set GETTEXT32_URL=https://github.com/mlocati/gettext-iconv-windows/releases/download/v0.19.8.1-v1.14/gettext0.19.8.1-iconv1.14-shared-32.zip
 set GETTEXT64_URL=https://github.com/mlocati/gettext-iconv-windows/releases/download/v0.19.8.1-v1.14/gettext0.19.8.1-iconv1.14-shared-64.zip
@@ -73,7 +74,7 @@ set SUBSYSTEM_VER=!SUBSYSTEM_VER%BIT%!
 :: ----------------------------------------------------------------------
 
 :: Update PATH
-path %PYTHON_DIR%;%PYTHON3_DIR%;%PERL_DIR%\bin;%path%;%LUA_DIR%;%TCL_DIR%\bin;%RUBY_DIR%\bin;%RUBY_DIR%\bin\ruby_builtin_dlls;%RACKET_DIR%;%RACKET_DIR%\lib
+path %PYTHON_DIR%;%PYTHON3_DIR%;%PERL_DIR%\bin;%path%;%LUA_DIR%;%RUBY_DIR%\bin;%RUBY_DIR%\bin\ruby_builtin_dlls;%RACKET_DIR%;%RACKET_DIR%\lib
 
 if /I "%1"=="" (
   set target=build
@@ -116,6 +117,7 @@ call :downloadfile %TCL_URL% downloads\tcl.exe
 mkdir c:\ActiveTclTemp
 start /wait downloads\tcl.exe /extract:c:\ActiveTclTemp /exenoui /exenoupdates /quiet /norestart
 for /d %%i in (c:\ActiveTclTemp\*) do move %%i %TCL_DIR%
+copy %TCL_DIR%\bin\%TCL_DLL% vim\src\
 
 :: Ruby
 :: RubyInstaller is built by MinGW, so we cannot use header files from it.

--- a/appveyor.bat
+++ b/appveyor.bat
@@ -35,9 +35,9 @@ set PYTHON3_32_DIR=C:\python%PYTHON3_VER%
 set PYTHON3_64_DIR=C:\python%PYTHON3_VER%-x64
 set PYTHON3_DIR=!PYTHON3_%BIT%_DIR!
 :: Racket
-set RACKET_VER=3m_a0solc
-set RACKET32_URL=https://mirror.racket-lang.org/releases/6.6/installers/racket-minimal-6.6-i386-win32.exe
-set RACKET64_URL=https://mirror.racket-lang.org/releases/6.6/installers/racket-minimal-6.6-x86_64-win32.exe
+set RACKET_VER=3m_a36fs8
+set RACKET32_URL=https://mirror.racket-lang.org/releases/6.10.1/installers/racket-minimal-6.10.1-i386-win32.exe
+set RACKET64_URL=https://mirror.racket-lang.org/releases/6.10.1/installers/racket-minimal-6.10.1-x86_64-win32.exe
 set RACKET_URL=!RACKET%BIT%_URL!
 set RACKET32_DIR=%PROGRAMFILES(X86)%\Racket
 set RACKET64_DIR=%PROGRAMFILES%\Racket

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -77,7 +77,7 @@ deploy:
       * [LuaBinaries](http://luabinaries.sourceforge.net/download.html) 5.3
       * [Python](https://www.python.org/downloads/) 2.7
       * [Python3](https://www.python.org/downloads/) 3.5
-      * [Racket](https://download.racket-lang.org/) 6.6
+      * [Racket](https://download.racket-lang.org/) 6.10.1
       * [RubyInstaller2](http://rubyinstaller.org/downloads/) 2.4
 
       Make sure that you install the same architecture (32bit/64bit) that matches your Vim installation.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,7 +73,7 @@ deploy:
       Without it Vim won't be able to use that feature! You can find those interperters here:
 
       * [ActivePerl](http://www.activestate.com/activeperl/downloads) 5.24
-      * [ActiveTcl](http://www.activestate.com/activetcl/downloads) 8.6
+      * [ActiveTcl](http://www.activestate.com/activetcl/downloads) 8.6.6
       * [LuaBinaries](http://luabinaries.sourceforge.net/download.html) 5.3
       * [Python](https://www.python.org/downloads/) 2.7
       * [Python3](https://www.python.org/downloads/) 3.5


### PR DESCRIPTION
* Update Racket to 6.10.1.
* Change Tcl DLL name from tcl86.dll to tcl86t.dll.
* Work around for the problem in #32. Copy the dll to the current directory and set $TCL_LIBRARY instead of adding $TCL_DIR/bin to the $PATH.