### PR TITLE
if_perl: Extract only the "perl" folder

### DIFF
--- a/appveyor.bat
+++ b/appveyor.bat
@@ -109,7 +109,8 @@ call :downloadfile %LUA_URL% downloads\lua.zip
 
 :: Perl
 call :downloadfile %PERL_URL% downloads\perl.zip
-7z x downloads\perl.zip -o%PERL_DIR%\.. > nul || exit 1
+:: Extract only the "perl" folder.
+7z x downloads\perl.zip perl -o%PERL_DIR%\.. > nul || exit 1
 
 :: Tcl
 call :downloadfile %TCL_URL% downloads\tcl.exe


### PR DESCRIPTION
Reduce the unpacking time by extracting only the "perl" folder.

Strawberry Perl has two main folders: "c" and "perl".
The "c" folder contains MinGW compiler which will be used when compiling
some kind of CPAN modules.  It is not needed for compiling Vim or
testing if_perl.