### PR TITLE
mui2: Import new installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,16 @@ This is a project for building Nightly Vim Windows build snapshots
 automatically ([more information](http://vim.wikia.com/wiki/Where_to_download_Vim)).
 
 [Download](https://github.com/vim/vim-win32-installer/releases) and execute the
-most recent `gvim_8.._x86.exe` file to install Vim. The exe file contains the
+most recent `gvim_x.y.pppp_x86.exe` file to install Vim (where `x.y` is the
+release version and `pppp` is the patch number). You can also download the
+`gvim_x.y.pppp_x86-mui2.exe` file. This has a modern interface
+([MUI2](http://nsis.sourceforge.net/Docs/Modern%20UI%202/Readme.html)) but
+it is still in a experimental phase. The exe files contain the
 (32bit) installer while the .zip files contain an archive of the 32bit (`_x86`)
 or 64bit versions (`_x64`). To install it, extract the archive and update your
 PATH variable. The installer will do that automatically and provide some
 additional extensions (e.g. Edit with Vim menu).
+The `gvim...pdb.zip` file only contains the corresponding pdb files for debugging the binaries.
 
 If you need a dynamic interface to Perl, Python2, Python3, Ruby, TCL, Lua or
 Racket/MzScheme, make sure you also install the following. Vim will work

--- a/appveyor.bat
+++ b/appveyor.bat
@@ -290,7 +290,8 @@ copy xxd\xxd.exe xxdw32.exe
 copy install.exe installw32.exe
 copy uninstal.exe uninstalw32.exe
 pushd ..\nsis
-"C:\Program Files (x86)\NSIS\makensis" /DVIMRT=..\runtime /DGETTEXT=c: gvim.nsi "/XOutFile ..\..\gvim_%APPVEYOR_REPO_TAG_NAME:~1%_%ARCH%.exe"
+"%ProgramFiles(x86)%\NSIS\makensis" /DVIMRT=..\runtime /DGETTEXT=c: gvim-orig.nsi "/XOutFile ..\..\gvim_%APPVEYOR_REPO_TAG_NAME:~1%_%ARCH%.exe"
+"%ProgramFiles(x86)%\NSIS\makensis" /DVIMRT=..\runtime /DGETTEXT=c: gvim.nsi "/XOutFile ..\..\gvim_%APPVEYOR_REPO_TAG_NAME:~1%_%ARCH%-mui2.exe"
 popd
 
 @echo off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,8 +43,12 @@ artifacts:
     name: gVim_x64_pdb
   - path: gvim_*_x86.exe
     name: gVim_x86_installer
+  - path: gvim_*_x86-mui2.exe
+    name: gVim_x86_mui2_installer
   - path: gvim_*_x64.exe
     name: gVim_x64_installer
+  - path: gvim_*_x64-mui2.exe
+    name: gVim_x64_mui2_installer
 
 before_deploy:
   - for /f "delims=" %%i in (gitlog.txt) do set GITLOG=%%i

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,8 +58,12 @@ deploy:
 
       $(GITLOG)
 
-      Download and execute the most recent gvim_8.._x86.exe file to install Vim.
-      The exe file contains the (32bit) installer while the .zip files contain an
+      Download and execute the most recent gvim_x.y.pppp_x86.exe file to install Vim
+      (where x.y is the release version and pppp is the patch number).
+      You can also download the gvim_x.y.pppp_x86-mui2.exe file. This has a
+      modern interface (MUI2) but it is still in a experimental phase.
+
+      The exe files contain the (32bit) installer while the .zip files contain an
       archive of the 32bit (_x86) or 64bit versions (_x64). To install it, extract
       the archive and update your PATH variable. The installer will do that
       automatically and provide some additional extensions (e.g. Edit with Vim menu).

--- a/patch/0001-installer-Use-LogicLib.patch
+++ b/patch/0001-installer-Use-LogicLib.patch
@@ -1,0 +1,307 @@
+From e850ab16deadc272e1792c990b83696e226887e4 Mon Sep 17 00:00:00 2001
+From: "K.Takata" <kentkt@csc.jp>
+Date: Mon, 1 Oct 2018 06:47:48 +0900
+Subject: [PATCH 01/22] installer: Use LogicLib
+
+Currently we use low level syntax of NSIS; labels and jump commands.
+LogicLib provides higher level syntax. (E.g. ${If} ... ${EndIf})
+This makes the code much easier.
+
+Also removed codes for Windows 9x.
+---
+ nsis/gvim.nsi | 194 +++++++++++++++++++++++---------------------------
+ 1 file changed, 88 insertions(+), 106 deletions(-)
+
+diff --git a/nsis/gvim.nsi b/nsis/gvim.nsi
+index 55bb4ce00..0a14a1f77 100644
+--- a/nsis/gvim.nsi
++++ b/nsis/gvim.nsi
+@@ -121,9 +121,9 @@ Function .onInit
+   Delete $TEMP\vimini.ini
+ 
+   # If ReadINIStr failed or did not find a path: use the default dir.
+-  StrCmp $INSTDIR "" 0 IniOK
+-  StrCpy $INSTDIR "$PROGRAMFILES\Vim"
+-  IniOK:
++  ${If} $INSTDIR == ""
++    StrCpy $INSTDIR "$PROGRAMFILES\Vim"
++  ${EndIf}
+ 
+   # Should check for the value of $VIM and use it.  Unfortunately I don't know
+   # how to obtain the value of $VIM
+@@ -181,17 +181,18 @@ Function un.GetParent
+   Push $1
+   Push $2
+   StrCpy $1 -1
+-  loop:
++  ${Do}
+     StrCpy $2 $0 1 $1
+-    StrCmp $2 "" exit
+-    StrCmp $2 "\" exit
++    ${If} $2 == ""
++    ${OrIf} $2 == "\"
++      ${ExitDo}
++    ${EndIf}
+     IntOp $1 $1 - 1
+-  Goto loop
+-  exit:
+-    StrCpy $0 $0 $1
+-    Pop $2
+-    Pop $1
+-    Exch $0 ; put $0 on top of stack, restore $0 to original value
++  ${Loop}
++  StrCpy $0 $0 $1
++  Pop $2
++  Pop $1
++  Exch $0 ; put $0 on top of stack, restore $0 to original value
+ FunctionEnd
+ 
+ ##########################################################
+@@ -303,15 +304,7 @@ Section "Vim console program (vim.exe)"
+ 	SectionIn 1 3
+ 
+ 	SetOutPath $0
+-	ReadRegStr $R0 HKLM \
+-	   "SOFTWARE\Microsoft\Windows NT\CurrentVersion" CurrentVersion
+-	IfErrors 0 lbl_winnt
+-	    # Windows 95/98/ME: not supported
+-	    Goto lbl_done
+-	lbl_winnt:
+-	    # Windows NT/2000/XP and later
+-	    File /oname=vim.exe ${VIMSRC}\vimw32.exe
+-	lbl_done:
++	File /oname=vim.exe ${VIMSRC}\vimw32.exe
+ 	StrCpy $2 "$2 vim view vimdiff"
+ SectionEnd
+ 
+@@ -362,25 +355,23 @@ Section "Add an Edit-with-Vim context menu entry"
+ 	  File ${GETTEXT}\gettext64\libiconv-2.dll
+ !endif
+ 
+-	  IfErrors 0 GvimExt64Done
+-
+-	  # Can't copy gvimext.dll, create it under another name and rename it
+-	  # on next reboot.
+-	  GetTempFileName $3 $0\GvimExt64
+-	  File /oname=$3 ${VIMSRC}\GvimExt\gvimext64.dll
+-	  Rename /REBOOTOK $3 $0\GvimExt64\gvimext.dll
++	  ${If} ${Errors}
++	    # Can't copy gvimext.dll, create it under another name and rename it
++	    # on next reboot.
++	    GetTempFileName $3 $0\GvimExt64
++	    File /oname=$3 ${VIMSRC}\GvimExt\gvimext64.dll
++	    Rename /REBOOTOK $3 $0\GvimExt64\gvimext.dll
+ !ifdef HAVE_NLS
+-	  GetTempFileName $3 $0\GvimExt64
+-	  File /oname=$3 ${GETTEXT}\gettext64\libintl-8.dll
+-	  Rename /REBOOTOK $3 $0\GvimExt64\libintl-8.dll
+-	  GetTempFileName $3 $0\GvimExt64
+-	  File /oname=$3 ${GETTEXT}\gettext64\libiconv-2.dll
+-	  Rename /REBOOTOK $3 $0\GvimExt64\libiconv-2.dll
++	    GetTempFileName $3 $0\GvimExt64
++	    File /oname=$3 ${GETTEXT}\gettext64\libintl-8.dll
++	    Rename /REBOOTOK $3 $0\GvimExt64\libintl-8.dll
++	    GetTempFileName $3 $0\GvimExt64
++	    File /oname=$3 ${GETTEXT}\gettext64\libiconv-2.dll
++	    Rename /REBOOTOK $3 $0\GvimExt64\libiconv-2.dll
+ !endif
++	  ${EndIf}
+ 	${EndIf}
+ 
+-	GvimExt64Done:
+-
+ 	# Install 32-bit gvimext.dll into the GvimExt32 directory.
+ 	SetOutPath $0\GvimExt32
+ 	ClearErrors
+@@ -392,26 +383,24 @@ Section "Add an Edit-with-Vim context menu entry"
+ 	File ${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll
+ !endif
+ 
+-	IfErrors 0 GvimExt32Done
+-
+-	# Can't copy gvimext.dll, create it under another name and rename it on
+-	# next reboot.
+-	GetTempFileName $3 $0\GvimExt32
+-	File /oname=$3 ${VIMSRC}\GvimExt\gvimext.dll
+-	Rename /REBOOTOK $3 $0\GvimExt32\gvimext.dll
++	${If} ${Errors}
++	  # Can't copy gvimext.dll, create it under another name and rename it on
++	  # next reboot.
++	  GetTempFileName $3 $0\GvimExt32
++	  File /oname=$3 ${VIMSRC}\GvimExt\gvimext.dll
++	  Rename /REBOOTOK $3 $0\GvimExt32\gvimext.dll
+ !ifdef HAVE_NLS
+-	GetTempFileName $3 $0\GvimExt32
+-	File /oname=$3 ${GETTEXT}\gettext32\libintl-8.dll
+-	Rename /REBOOTOK $3 $0\GvimExt32\libintl-8.dll
+-	GetTempFileName $3 $0\GvimExt32
+-	File /oname=$3 ${GETTEXT}\gettext32\libiconv-2.dll
+-	Rename /REBOOTOK $3 $0\GvimExt32\libiconv-2.dll
+-	GetTempFileName $3 $0\GvimExt32
+-	File /oname=$3 ${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll
+-	Rename /REBOOTOK $3 $0\GvimExt32\libgcc_s_sjlj-1.dll
++	  GetTempFileName $3 $0\GvimExt32
++	  File /oname=$3 ${GETTEXT}\gettext32\libintl-8.dll
++	  Rename /REBOOTOK $3 $0\GvimExt32\libintl-8.dll
++	  GetTempFileName $3 $0\GvimExt32
++	  File /oname=$3 ${GETTEXT}\gettext32\libiconv-2.dll
++	  Rename /REBOOTOK $3 $0\GvimExt32\libiconv-2.dll
++	  GetTempFileName $3 $0\GvimExt32
++	  File /oname=$3 ${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll
++	  Rename /REBOOTOK $3 $0\GvimExt32\libgcc_s_sjlj-1.dll
+ !endif
+-
+-	GvimExt32Done:
++	${EndIf}
+ 	SetOverwrite lastused
+ 
+ 	# We don't have a separate entry for the "Open With..." menu, assume
+@@ -451,20 +440,20 @@ SectionEnd
+ 
+ ##########################################################
+ !ifdef HAVE_NLS
+-	Section "Native Language Support"
+-		SectionIn 1 3
+-
+-		SetOutPath $0\lang
+-		File /r ${VIMRT}\lang\*.*
+-		SetOutPath $0\keymap
+-		File ${VIMRT}\keymap\README.txt
+-		File ${VIMRT}\keymap\*.vim
+-		SetOutPath $0
+-		File ${GETTEXT}\gettext32\libintl-8.dll
+-		File ${GETTEXT}\gettext32\libiconv-2.dll
+-		#File /nonfatal ${VIMRT}\libwinpthread-1.dll
+-		File /nonfatal ${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll
+-	SectionEnd
++Section "Native Language Support"
++	SectionIn 1 3
++
++	SetOutPath $0\lang
++	File /r ${VIMRT}\lang\*.*
++	SetOutPath $0\keymap
++	File ${VIMRT}\keymap\README.txt
++	File ${VIMRT}\keymap\*.vim
++	SetOutPath $0
++	File ${GETTEXT}\gettext32\libintl-8.dll
++	File ${GETTEXT}\gettext32\libiconv-2.dll
++	#File /nonfatal ${VIMRT}\libwinpthread-1.dll
++	File /nonfatal ${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll
++SectionEnd
+ !endif
+ 
+ ##########################################################
+@@ -483,10 +472,9 @@ Function SetCustom
+ 	# Display the InstallOptions dialog
+ 
+ 	# Check if a _vimrc should be created
+-	SectionGetFlags ${sec_vimrc_id} $3
+-	IntOp $3 $3 & 1
+-	StrCmp $3 "1" +2 0
++	${IfNot} ${SectionIsSelected} ${sec_vimrc_id}
+ 	  Abort
++	${EndIf}
+ 
+ 	InstallOptions::dialog "$PLUGINSDIR\vimrc.ini"
+ 	Pop $3
+@@ -494,25 +482,23 @@ FunctionEnd
+ 
+ Function ValidateCustom
+ 	ReadINIStr $3 "$PLUGINSDIR\vimrc.ini" "Field 2" "State"
+-	StrCmp $3 "1" 0 +3
++	${If} $3 == "1"
+ 	  StrCpy $1 "$1 -vimrc-remap no"
+-	  Goto behave
+-
++	${Else}
+ 	  StrCpy $1 "$1 -vimrc-remap win"
++	${EndIf}
+ 
+-	behave:
+ 	ReadINIStr $3 "$PLUGINSDIR\vimrc.ini" "Field 5" "State"
+-	StrCmp $3 "1" 0 +3
++	${If} $3 == "1"
+ 	  StrCpy $1 "$1 -vimrc-behave unix"
+-	  Goto done
+-
+-	ReadINIStr $3 "$PLUGINSDIR\vimrc.ini" "Field 6" "State"
+-	StrCmp $3 "1" 0 +3
+-	  StrCpy $1 "$1 -vimrc-behave mswin"
+-	  Goto done
+-
+-	  StrCpy $1 "$1 -vimrc-behave default"
+-	done:
++	${Else}
++	  ReadINIStr $3 "$PLUGINSDIR\vimrc.ini" "Field 6" "State"
++	  ${If} $3 == "1"
++	    StrCpy $1 "$1 -vimrc-behave mswin"
++	  ${Else}
++	    StrCpy $1 "$1 -vimrc-behave default"
++	  ${EndIf}
++	${EndIf}
+ FunctionEnd
+ 
+ ##########################################################
+@@ -522,11 +508,9 @@ Section Uninstall
+ 	StrCpy $0 "$INSTDIR"
+ 
+ 	# If VisVim was installed, unregister the DLL.
+-	IfFileExists "$0\VisVim.dll" Has_VisVim No_VisVim
+-	Has_VisVim:
+-	   ExecWait "regsvr32.exe /u /s $0\VisVim.dll"
+-
+-	No_VisVim:
++	${If} ${FileExists} "$0\VisVim.dll"
++	  ExecWait "regsvr32.exe /u /s $0\VisVim.dll"
++	${EndIf}
+ 
+ 	# delete the context menu entry and batch files
+ 	ExecWait "$0\uninstal.exe -nsis"
+@@ -568,11 +552,10 @@ Section Uninstall
+ 	Delete $0\*.vim
+ 	Delete $0\*.txt
+ 
+-	IfErrors ErrorMess NoErrorMess
+-	  ErrorMess:
+-	    MessageBox MB_OK|MB_ICONEXCLAMATION \
++	${If} ${Errors}
++	  MessageBox MB_OK|MB_ICONEXCLAMATION \
+ 	      "Some files in $0 have not been deleted!$\nYou must do it manually."
+-	  NoErrorMess:
++	${EndIf}
+ 
+ 	# No error message if the "vim62" directory can't be removed, the
+ 	# gvimext.dll may still be there.
+@@ -587,18 +570,17 @@ Section Uninstall
+ 
+ 	# if a plugin dir was created at installation ask the user to remove it
+ 	# first look in the root of the installation then in HOME
+-	IfFileExists $1\vimfiles AskRemove 0
+-	    ReadEnvStr $1 "HOME"
+-	    StrCmp $1 "" NoRemove 0
+-
+-	    IfFileExists $1\vimfiles 0 NoRemove
+-
+-	  AskRemove:
+-	    MessageBox MB_YESNO|MB_ICONQUESTION \
+-	      "Remove all files in your $1\vimfiles directory?$\n \
+-	      $\nCAREFUL: If you have created something there that you want to keep, click No" IDNO Fin
+-	    RMDir /r $1\vimfiles
+-	  NoRemove:
++	${IfNot} ${FileExists} $1\vimfiles
++	  ReadEnvStr $1 "HOME"
++	${EndIf}
++
++	${If} $1 != ""
++	${AndIf} ${FileExists} $1\vimfiles
++	  MessageBox MB_YESNO|MB_ICONQUESTION \
++	    "Remove all files in your $1\vimfiles directory?$\n \
++	    $\nCAREFUL: If you have created something there that you want to keep, click No" IDNO Fin
++	  RMDir /r $1\vimfiles
++	${EndIf}
+ 
+ 	# ask the user if the Vim root dir must be removed
+ 	MessageBox MB_YESNO|MB_ICONQUESTION \
+-- 
+2.17.0
+

--- a/patch/0002-nsis-Copy-nsis-gvim.nsi-to-nsis-gvim-orig.nsi.patch
+++ b/patch/0002-nsis-Copy-nsis-gvim.nsi-to-nsis-gvim-orig.nsi.patch
@@ -1,0 +1,614 @@
+From a2bd6f21a9b1adeba15a911ba6db7a1db836e906 Mon Sep 17 00:00:00 2001
+From: "K.Takata" <kentkt@csc.jp>
+Date: Wed, 3 Oct 2018 11:24:52 +0900
+Subject: [PATCH 02/22] nsis: Copy nsis/gvim.nsi to nsis/gvim-orig.nsi
+
+---
+ nsis/gvim-orig.nsi | 595 +++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 595 insertions(+)
+ create mode 100644 nsis/gvim-orig.nsi
+
+diff --git a/nsis/gvim-orig.nsi b/nsis/gvim-orig.nsi
+new file mode 100644
+index 000000000..0a14a1f77
+--- /dev/null
++++ b/nsis/gvim-orig.nsi
+@@ -0,0 +1,595 @@
++# NSIS file to create a self-installing exe for Vim.
++# It requires NSIS version 2.0 or later.
++# Last Change:	2014 Nov 5
++
++# WARNING: if you make changes to this script, look out for $0 to be valid,
++# because uninstall deletes most files in $0.
++
++# Location of gvim_ole.exe, vimw32.exe, GvimExt/*, etc.
++!ifndef VIMSRC
++  !define VIMSRC "..\src"
++!endif
++
++# Location of runtime files
++!ifndef VIMRT
++  !define VIMRT ".."
++!endif
++
++# Location of extra tools: diff.exe
++!ifndef VIMTOOLS
++  !define VIMTOOLS ..\..
++!endif
++
++# Location of gettext.
++# It must contain two directories: gettext32 and gettext64.
++# See README.txt for detail.
++!ifndef GETTEXT
++  !define GETTEXT ${VIMRT}
++!endif
++
++# Comment the next line if you don't have UPX.
++# Get it at https://upx.github.io/
++!define HAVE_UPX
++
++# comment the next line if you do not want to add Native Language Support
++!define HAVE_NLS
++
++!include gvim_version.nsh	# for version number
++
++# ----------- No configurable settings below this line -----------
++
++!include UpgradeDLL.nsh		# for VisVim.dll
++!include LogicLib.nsh
++!include x64.nsh
++
++Name "Vim ${VER_MAJOR}.${VER_MINOR}"
++OutFile gvim${VER_MAJOR}${VER_MINOR}.exe
++CRCCheck force
++SetCompressor /SOLID lzma
++SetDatablockOptimize on
++RequestExecutionLevel highest
++XPStyle on
++
++ComponentText "This will install Vim ${VER_MAJOR}.${VER_MINOR} on your computer."
++DirText "Choose a directory to install Vim (should contain 'vim')"
++Icon icons\vim_16c.ico
++# NSIS2 uses a different strategy with six different images in a strip...
++#EnabledBitmap icons\enabled.bmp
++#DisabledBitmap icons\disabled.bmp
++UninstallText "This will uninstall Vim ${VER_MAJOR}.${VER_MINOR} from your system."
++UninstallIcon icons\vim_uninst_16c.ico
++
++# On NSIS 2 using the BGGradient causes trouble on Windows 98, in combination
++# with the BringToFront.
++# BGGradient 004000 008200 FFFFFF
++LicenseText "You should read the following before installing:"
++LicenseData ${VIMRT}\doc\uganda.nsis.txt
++
++!ifdef HAVE_UPX
++  !packhdr temp.dat "upx --best --compress-icons=1 temp.dat"
++!endif
++
++# This adds '\vim' to the user choice automagically.  The actual value is
++# obtained below with ReadINIStr.
++InstallDir "$PROGRAMFILES\Vim"
++
++# Types of installs we can perform:
++InstType Typical
++InstType Minimal
++InstType Full
++
++SilentInstall normal
++
++# These are the pages we use
++Page license
++Page components
++Page custom SetCustom ValidateCustom ": _vimrc setting"
++Page directory "" "" CheckInstallDir
++Page instfiles
++UninstPage uninstConfirm
++UninstPage instfiles
++
++# Reserve files
++# Needed for showing the _vimrc setting page faster.
++ReserveFile /plugin InstallOptions.dll
++ReserveFile vimrc.ini
++
++##########################################################
++# Functions
++
++Function .onInit
++  MessageBox MB_YESNO|MB_ICONQUESTION \
++	"This will install Vim ${VER_MAJOR}.${VER_MINOR} on your computer.$\n Continue?" \
++	/SD IDYES \
++	IDYES NoAbort
++	    Abort ; causes installer to quit.
++	NoAbort:
++
++  # run the install program to check for already installed versions
++  SetOutPath $TEMP
++  File /oname=install.exe ${VIMSRC}\installw32.exe
++  ExecWait "$TEMP\install.exe -uninstall-check"
++  Delete $TEMP\install.exe
++
++  # We may have been put to the background when uninstall did something.
++  BringToFront
++
++  # Install will have created a file for us that contains the directory where
++  # we should install.  This is $VIM if it's set.  This appears to be the only
++  # way to get the value of $VIM here!?
++  ReadINIStr $INSTDIR $TEMP\vimini.ini vimini dir
++  Delete $TEMP\vimini.ini
++
++  # If ReadINIStr failed or did not find a path: use the default dir.
++  ${If} $INSTDIR == ""
++    StrCpy $INSTDIR "$PROGRAMFILES\Vim"
++  ${EndIf}
++
++  # Should check for the value of $VIM and use it.  Unfortunately I don't know
++  # how to obtain the value of $VIM
++  # IfFileExists "$VIM" 0 No_Vim
++  #   StrCpy $INSTDIR "$VIM"
++  # No_Vim:
++
++  # User variables:
++  # $0 - holds the directory the executables are installed to
++  # $1 - holds the parameters to be passed to install.exe.  Starts with OLE
++  #      registration (since a non-OLE gvim will not complain, and we want to
++  #      always register an OLE gvim).
++  # $2 - holds the names to create batch files for
++  StrCpy $0 "$INSTDIR\vim${VER_MAJOR}${VER_MINOR}"
++  StrCpy $1 "-register-OLE"
++  StrCpy $2 "gvim evim gview gvimdiff vimtutor"
++
++  # Extract InstallOptions files
++  # $PLUGINSDIR will automatically be removed when the installer closes
++  InitPluginsDir
++  File /oname=$PLUGINSDIR\vimrc.ini "vimrc.ini"
++FunctionEnd
++
++Function .onUserAbort
++  MessageBox MB_YESNO|MB_ICONQUESTION "Abort install?" IDYES NoCancelAbort
++    Abort ; causes installer to not quit.
++  NoCancelAbort:
++FunctionEnd
++
++# We only accept the directory if it ends in "vim".  Using .onVerifyInstDir has
++# the disadvantage that the browse dialog is difficult to use.
++Function CheckInstallDir
++FunctionEnd
++
++Function .onInstSuccess
++  WriteUninstaller vim${VER_MAJOR}${VER_MINOR}\uninstall-gui.exe
++  MessageBox MB_YESNO|MB_ICONQUESTION \
++	"The installation process has been successful. Happy Vimming! \
++	$\n$\n Do you want to see the README file now?" IDNO NoReadme
++      Exec '$0\gvim.exe -R "$0\README.txt"'
++  NoReadme:
++FunctionEnd
++
++Function .onInstFailed
++  MessageBox MB_OK|MB_ICONEXCLAMATION "Installation failed. Better luck next time."
++FunctionEnd
++
++Function un.onUnInstSuccess
++  MessageBox MB_OK|MB_ICONINFORMATION \
++  "Vim ${VER_MAJOR}.${VER_MINOR} has been (partly) removed from your system"
++FunctionEnd
++
++Function un.GetParent
++  Exch $0 ; old $0 is on top of stack
++  Push $1
++  Push $2
++  StrCpy $1 -1
++  ${Do}
++    StrCpy $2 $0 1 $1
++    ${If} $2 == ""
++    ${OrIf} $2 == "\"
++      ${ExitDo}
++    ${EndIf}
++    IntOp $1 $1 - 1
++  ${Loop}
++  StrCpy $0 $0 $1
++  Pop $2
++  Pop $1
++  Exch $0 ; put $0 on top of stack, restore $0 to original value
++FunctionEnd
++
++##########################################################
++Section "Vim executables and runtime files"
++	SectionIn 1 2 3 RO
++
++	# we need also this here if the user changes the instdir
++	StrCpy $0 "$INSTDIR\vim${VER_MAJOR}${VER_MINOR}"
++
++	SetOutPath $0
++	File /oname=gvim.exe ${VIMSRC}\gvim_ole.exe
++	File /oname=install.exe ${VIMSRC}\installw32.exe
++	File /oname=uninstal.exe ${VIMSRC}\uninstalw32.exe
++	File ${VIMSRC}\vimrun.exe
++	File /oname=tee.exe ${VIMSRC}\teew32.exe
++	File /oname=xxd.exe ${VIMSRC}\xxdw32.exe
++	File ${VIMRT}\vimtutor.bat
++	File ${VIMRT}\README.txt
++	File ..\uninstal.txt
++	File ${VIMRT}\*.vim
++	File ${VIMRT}\rgb.txt
++
++	File ${VIMTOOLS}\diff.exe
++	File ${VIMTOOLS}\winpty32.dll
++	File ${VIMTOOLS}\winpty-agent.exe
++
++	SetOutPath $0\colors
++	File ${VIMRT}\colors\*.*
++
++	SetOutPath $0\compiler
++	File ${VIMRT}\compiler\*.*
++
++	SetOutPath $0\doc
++	File ${VIMRT}\doc\*.txt
++	File ${VIMRT}\doc\tags
++
++	SetOutPath $0\ftplugin
++	File ${VIMRT}\ftplugin\*.*
++
++	SetOutPath $0\indent
++	File ${VIMRT}\indent\*.*
++
++	SetOutPath $0\macros
++	File ${VIMRT}\macros\*.*
++	SetOutPath $0\macros\hanoi
++	File ${VIMRT}\macros\hanoi\*.*
++	SetOutPath $0\macros\life
++	File ${VIMRT}\macros\life\*.*
++	SetOutPath $0\macros\maze
++	File ${VIMRT}\macros\maze\*.*
++	SetOutPath $0\macros\urm
++	File ${VIMRT}\macros\urm\*.*
++
++	SetOutPath $0\pack\dist\opt\dvorak\dvorak
++	File ${VIMRT}\pack\dist\opt\dvorak\dvorak\*.*
++	SetOutPath $0\pack\dist\opt\dvorak\plugin
++	File ${VIMRT}\pack\dist\opt\dvorak\plugin\*.*
++
++	SetOutPath $0\pack\dist\opt\editexisting\plugin
++	File ${VIMRT}\pack\dist\opt\editexisting\plugin\*.*
++
++	SetOutPath $0\pack\dist\opt\justify\plugin
++	File ${VIMRT}\pack\dist\opt\justify\plugin\*.*
++
++	SetOutPath $0\pack\dist\opt\matchit\doc
++	File ${VIMRT}\pack\dist\opt\matchit\doc\*.*
++	SetOutPath $0\pack\dist\opt\matchit\plugin
++	File ${VIMRT}\pack\dist\opt\matchit\plugin\*.*
++
++	SetOutPath $0\pack\dist\opt\shellmenu\plugin
++	File ${VIMRT}\pack\dist\opt\shellmenu\plugin\*.*
++
++	SetOutPath $0\pack\dist\opt\swapmouse\plugin
++	File ${VIMRT}\pack\dist\opt\swapmouse\plugin\*.*
++
++	SetOutPath $0\pack\dist\opt\termdebug\plugin
++	File ${VIMRT}\pack\dist\opt\termdebug\plugin\*.*
++
++	SetOutPath $0\plugin
++	File ${VIMRT}\plugin\*.*
++
++	SetOutPath $0\autoload
++	File ${VIMRT}\autoload\*.*
++
++	SetOutPath $0\autoload\dist
++	File ${VIMRT}\autoload\dist\*.*
++
++	SetOutPath $0\autoload\xml
++	File ${VIMRT}\autoload\xml\*.*
++
++	SetOutPath $0\syntax
++	File ${VIMRT}\syntax\*.*
++
++	SetOutPath $0\spell
++	File ${VIMRT}\spell\*.txt
++	File ${VIMRT}\spell\*.vim
++	File ${VIMRT}\spell\*.spl
++	File ${VIMRT}\spell\*.sug
++
++	SetOutPath $0\tools
++	File ${VIMRT}\tools\*.*
++
++	SetOutPath $0\tutor
++	File ${VIMRT}\tutor\*.*
++SectionEnd
++
++##########################################################
++Section "Vim console program (vim.exe)"
++	SectionIn 1 3
++
++	SetOutPath $0
++	File /oname=vim.exe ${VIMSRC}\vimw32.exe
++	StrCpy $2 "$2 vim view vimdiff"
++SectionEnd
++
++##########################################################
++Section "Create .bat files for command line use"
++	SectionIn 3
++
++	StrCpy $1 "$1 -create-batfiles $2"
++SectionEnd
++
++##########################################################
++Section "Create icons on the Desktop"
++	SectionIn 1 3
++
++	StrCpy $1 "$1 -install-icons"
++SectionEnd
++
++##########################################################
++Section "Add Vim to the Start Menu"
++	SectionIn 1 3
++
++	StrCpy $1 "$1 -add-start-menu"
++SectionEnd
++
++##########################################################
++Section "Add an Edit-with-Vim context menu entry"
++	SectionIn 1 3
++
++	# Be aware of this sequence of events:
++	# - user uninstalls Vim, gvimext.dll can't be removed (it's in use) and
++	#   is scheduled to be removed at next reboot.
++	# - user installs Vim in same directory, gvimext.dll still exists.
++	# If we now skip installing gvimext.dll, it will disappear at the next
++	# reboot.  Thus when copying gvimext.dll fails always schedule it to be
++	# installed at the next reboot.  Can't use UpgradeDLL!
++	# We don't ask the user to reboot, the old dll will keep on working.
++	SetOutPath $0
++	ClearErrors
++	SetOverwrite try
++
++	${If} ${RunningX64}
++	  # Install 64-bit gvimext.dll into the GvimExt64 directory.
++	  SetOutPath $0\GvimExt64
++	  ClearErrors
++	  File /oname=gvimext.dll ${VIMSRC}\GvimExt\gvimext64.dll
++!ifdef HAVE_NLS
++	  File ${GETTEXT}\gettext64\libintl-8.dll
++	  File ${GETTEXT}\gettext64\libiconv-2.dll
++!endif
++
++	  ${If} ${Errors}
++	    # Can't copy gvimext.dll, create it under another name and rename it
++	    # on next reboot.
++	    GetTempFileName $3 $0\GvimExt64
++	    File /oname=$3 ${VIMSRC}\GvimExt\gvimext64.dll
++	    Rename /REBOOTOK $3 $0\GvimExt64\gvimext.dll
++!ifdef HAVE_NLS
++	    GetTempFileName $3 $0\GvimExt64
++	    File /oname=$3 ${GETTEXT}\gettext64\libintl-8.dll
++	    Rename /REBOOTOK $3 $0\GvimExt64\libintl-8.dll
++	    GetTempFileName $3 $0\GvimExt64
++	    File /oname=$3 ${GETTEXT}\gettext64\libiconv-2.dll
++	    Rename /REBOOTOK $3 $0\GvimExt64\libiconv-2.dll
++!endif
++	  ${EndIf}
++	${EndIf}
++
++	# Install 32-bit gvimext.dll into the GvimExt32 directory.
++	SetOutPath $0\GvimExt32
++	ClearErrors
++
++	File /oname=gvimext.dll ${VIMSRC}\GvimExt\gvimext.dll
++!ifdef HAVE_NLS
++	File ${GETTEXT}\gettext32\libintl-8.dll
++	File ${GETTEXT}\gettext32\libiconv-2.dll
++	File ${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll
++!endif
++
++	${If} ${Errors}
++	  # Can't copy gvimext.dll, create it under another name and rename it on
++	  # next reboot.
++	  GetTempFileName $3 $0\GvimExt32
++	  File /oname=$3 ${VIMSRC}\GvimExt\gvimext.dll
++	  Rename /REBOOTOK $3 $0\GvimExt32\gvimext.dll
++!ifdef HAVE_NLS
++	  GetTempFileName $3 $0\GvimExt32
++	  File /oname=$3 ${GETTEXT}\gettext32\libintl-8.dll
++	  Rename /REBOOTOK $3 $0\GvimExt32\libintl-8.dll
++	  GetTempFileName $3 $0\GvimExt32
++	  File /oname=$3 ${GETTEXT}\gettext32\libiconv-2.dll
++	  Rename /REBOOTOK $3 $0\GvimExt32\libiconv-2.dll
++	  GetTempFileName $3 $0\GvimExt32
++	  File /oname=$3 ${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll
++	  Rename /REBOOTOK $3 $0\GvimExt32\libgcc_s_sjlj-1.dll
++!endif
++	${EndIf}
++	SetOverwrite lastused
++
++	# We don't have a separate entry for the "Open With..." menu, assume
++	# the user wants either both or none.
++	StrCpy $1 "$1 -install-popup -install-openwith"
++SectionEnd
++
++##########################################################
++Section "Create a _vimrc if it doesn't exist" sec_vimrc_id
++	SectionIn 1 3
++
++	StrCpy $1 "$1 -create-vimrc"
++SectionEnd
++
++##########################################################
++Section "Create plugin directories in HOME or VIM"
++	SectionIn 1 3
++
++	StrCpy $1 "$1 -create-directories home"
++SectionEnd
++
++##########################################################
++Section "Create plugin directories in VIM"
++	SectionIn 3
++
++	StrCpy $1 "$1 -create-directories vim"
++SectionEnd
++
++##########################################################
++Section "VisVim Extension for MS Visual Studio"
++	SectionIn 3
++
++	SetOutPath $0
++	!insertmacro UpgradeDLL "${VIMSRC}\VisVim\VisVim.dll" "$0\VisVim.dll" "$0"
++	File ${VIMSRC}\VisVim\README_VisVim.txt
++SectionEnd
++
++##########################################################
++!ifdef HAVE_NLS
++Section "Native Language Support"
++	SectionIn 1 3
++
++	SetOutPath $0\lang
++	File /r ${VIMRT}\lang\*.*
++	SetOutPath $0\keymap
++	File ${VIMRT}\keymap\README.txt
++	File ${VIMRT}\keymap\*.vim
++	SetOutPath $0
++	File ${GETTEXT}\gettext32\libintl-8.dll
++	File ${GETTEXT}\gettext32\libiconv-2.dll
++	#File /nonfatal ${VIMRT}\libwinpthread-1.dll
++	File /nonfatal ${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll
++SectionEnd
++!endif
++
++##########################################################
++Section -call_install_exe
++	SetOutPath $0
++	ExecWait "$0\install.exe $1"
++SectionEnd
++
++##########################################################
++Section -post
++	BringToFront
++SectionEnd
++
++##########################################################
++Function SetCustom
++	# Display the InstallOptions dialog
++
++	# Check if a _vimrc should be created
++	${IfNot} ${SectionIsSelected} ${sec_vimrc_id}
++	  Abort
++	${EndIf}
++
++	InstallOptions::dialog "$PLUGINSDIR\vimrc.ini"
++	Pop $3
++FunctionEnd
++
++Function ValidateCustom
++	ReadINIStr $3 "$PLUGINSDIR\vimrc.ini" "Field 2" "State"
++	${If} $3 == "1"
++	  StrCpy $1 "$1 -vimrc-remap no"
++	${Else}
++	  StrCpy $1 "$1 -vimrc-remap win"
++	${EndIf}
++
++	ReadINIStr $3 "$PLUGINSDIR\vimrc.ini" "Field 5" "State"
++	${If} $3 == "1"
++	  StrCpy $1 "$1 -vimrc-behave unix"
++	${Else}
++	  ReadINIStr $3 "$PLUGINSDIR\vimrc.ini" "Field 6" "State"
++	  ${If} $3 == "1"
++	    StrCpy $1 "$1 -vimrc-behave mswin"
++	  ${Else}
++	    StrCpy $1 "$1 -vimrc-behave default"
++	  ${EndIf}
++	${EndIf}
++FunctionEnd
++
++##########################################################
++Section Uninstall
++	# Apparently $INSTDIR is set to the directory where the uninstaller is
++	# created.  Thus the "vim61" directory is included in it.
++	StrCpy $0 "$INSTDIR"
++
++	# If VisVim was installed, unregister the DLL.
++	${If} ${FileExists} "$0\VisVim.dll"
++	  ExecWait "regsvr32.exe /u /s $0\VisVim.dll"
++	${EndIf}
++
++	# delete the context menu entry and batch files
++	ExecWait "$0\uninstal.exe -nsis"
++
++	# We may have been put to the background when uninstall did something.
++	BringToFront
++
++	# ask the user if the Vim version dir must be removed
++	MessageBox MB_YESNO|MB_ICONQUESTION \
++	  "Would you like to delete $0?$\n \
++	   $\nIt contains the Vim executables and runtime files." IDNO NoRemoveExes
++
++	Delete /REBOOTOK $0\*.dll
++	Delete /REBOOTOK $0\GvimExt32\*.dll
++	${If} ${RunningX64}
++	  Delete /REBOOTOK $0\GvimExt64\*.dll
++	${EndIf}
++
++	ClearErrors
++	# Remove everything but *.dll files.  Avoids that
++	# a lot remains when gvimext.dll cannot be deleted.
++	RMDir /r $0\autoload
++	RMDir /r $0\colors
++	RMDir /r $0\compiler
++	RMDir /r $0\doc
++	RMDir /r $0\ftplugin
++	RMDir /r $0\indent
++	RMDir /r $0\macros
++	RMDir /r $0\plugin
++	RMDir /r $0\spell
++	RMDir /r $0\syntax
++	RMDir /r $0\tools
++	RMDir /r $0\tutor
++	RMDir /r $0\VisVim
++	RMDir /r $0\lang
++	RMDir /r $0\keymap
++	Delete $0\*.exe
++	Delete $0\*.bat
++	Delete $0\*.vim
++	Delete $0\*.txt
++
++	${If} ${Errors}
++	  MessageBox MB_OK|MB_ICONEXCLAMATION \
++	      "Some files in $0 have not been deleted!$\nYou must do it manually."
++	${EndIf}
++
++	# No error message if the "vim62" directory can't be removed, the
++	# gvimext.dll may still be there.
++	RMDir $0
++
++	NoRemoveExes:
++	# get the parent dir of the installation
++	Push $INSTDIR
++	Call un.GetParent
++	Pop $0
++	StrCpy $1 $0
++
++	# if a plugin dir was created at installation ask the user to remove it
++	# first look in the root of the installation then in HOME
++	${IfNot} ${FileExists} $1\vimfiles
++	  ReadEnvStr $1 "HOME"
++	${EndIf}
++
++	${If} $1 != ""
++	${AndIf} ${FileExists} $1\vimfiles
++	  MessageBox MB_YESNO|MB_ICONQUESTION \
++	    "Remove all files in your $1\vimfiles directory?$\n \
++	    $\nCAREFUL: If you have created something there that you want to keep, click No" IDNO Fin
++	  RMDir /r $1\vimfiles
++	${EndIf}
++
++	# ask the user if the Vim root dir must be removed
++	MessageBox MB_YESNO|MB_ICONQUESTION \
++	  "Would you like to remove $0?$\n \
++	   $\nIt contains your Vim configuration files!" IDNO NoDelete
++	   RMDir /r $0 ; skipped if no
++	NoDelete:
++
++	Fin:
++	Call un.onUnInstSuccess
++
++SectionEnd
+-- 
+2.17.0
+

--- a/patch/0003-nsis-Skip-if-libgcc_s_sjlj-1.dll-doesn-t-exist.patch
+++ b/patch/0003-nsis-Skip-if-libgcc_s_sjlj-1.dll-doesn-t-exist.patch
@@ -1,0 +1,54 @@
+From d0a2fd64404f1b4b3e41d77f75cf8220da8bd479 Mon Sep 17 00:00:00 2001
+From: "K.Takata" <kentkt@csc.jp>
+Date: Mon, 1 Oct 2018 06:51:20 +0900
+Subject: [PATCH 03/22] nsis: Skip if libgcc_s_sjlj-1.dll doesn't exist
+
+Next release of mlocati/gettext-iconv-windows might remove the
+dependency on the DLL.
+---
+ nsis/gvim.nsi | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/nsis/gvim.nsi b/nsis/gvim.nsi
+index 0a14a1f77..d8b54b613 100644
+--- a/nsis/gvim.nsi
++++ b/nsis/gvim.nsi
+@@ -380,7 +380,10 @@ Section "Add an Edit-with-Vim context menu entry"
+ !ifdef HAVE_NLS
+ 	File ${GETTEXT}\gettext32\libintl-8.dll
+ 	File ${GETTEXT}\gettext32\libiconv-2.dll
++  !if /FileExists "${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll"
++	# Install libgcc_s_sjlj-1.dll only if it is needed.
+ 	File ${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll
++  !endif
+ !endif
+ 
+ 	${If} ${Errors}
+@@ -396,9 +399,12 @@ Section "Add an Edit-with-Vim context menu entry"
+ 	  GetTempFileName $3 $0\GvimExt32
+ 	  File /oname=$3 ${GETTEXT}\gettext32\libiconv-2.dll
+ 	  Rename /REBOOTOK $3 $0\GvimExt32\libiconv-2.dll
++  !if /FileExists "${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll"
++	  # Install libgcc_s_sjlj-1.dll only if it is needed.
+ 	  GetTempFileName $3 $0\GvimExt32
+ 	  File /oname=$3 ${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll
+ 	  Rename /REBOOTOK $3 $0\GvimExt32\libgcc_s_sjlj-1.dll
++  !endif
+ !endif
+ 	${EndIf}
+ 	SetOverwrite lastused
+@@ -452,7 +458,10 @@ Section "Native Language Support"
+ 	File ${GETTEXT}\gettext32\libintl-8.dll
+ 	File ${GETTEXT}\gettext32\libiconv-2.dll
+ 	#File /nonfatal ${VIMRT}\libwinpthread-1.dll
+-	File /nonfatal ${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll
++  !if /FileExists "${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll"
++	# Install libgcc_s_sjlj-1.dll only if it is needed.
++	File ${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll
++  !endif
+ SectionEnd
+ !endif
+ 
+-- 
+2.17.0
+

--- a/patch/0004-nsis-Respect-NLS-setting-for-GvimExt.patch
+++ b/patch/0004-nsis-Respect-NLS-setting-for-GvimExt.patch
@@ -1,0 +1,150 @@
+From 58328665f06251aade9df43c7e3a3515c225d8d6 Mon Sep 17 00:00:00 2001
+From: "K.Takata" <kentkt@csc.jp>
+Date: Mon, 1 Oct 2018 06:55:27 +0900
+Subject: [PATCH 04/22] nsis: Respect NLS setting for GvimExt
+
+Don't install gettext and iconv for GvimExt if NLS setting is off.
+---
+ nsis/gvim.nsi | 93 ++++++++++++++++++++++++++++++---------------------
+ 1 file changed, 55 insertions(+), 38 deletions(-)
+
+diff --git a/nsis/gvim.nsi b/nsis/gvim.nsi
+index d8b54b613..6f6246d5e 100644
+--- a/nsis/gvim.nsi
++++ b/nsis/gvim.nsi
+@@ -330,7 +330,7 @@ Section "Add Vim to the Start Menu"
+ SectionEnd
+ 
+ ##########################################################
+-Section "Add an Edit-with-Vim context menu entry"
++Section "Add an Edit-with-Vim context menu entry" sec_gvimext_id
+ 	SectionIn 1 3
+ 
+ 	# Be aware of this sequence of events:
+@@ -350,10 +350,6 @@ Section "Add an Edit-with-Vim context menu entry"
+ 	  SetOutPath $0\GvimExt64
+ 	  ClearErrors
+ 	  File /oname=gvimext.dll ${VIMSRC}\GvimExt\gvimext64.dll
+-!ifdef HAVE_NLS
+-	  File ${GETTEXT}\gettext64\libintl-8.dll
+-	  File ${GETTEXT}\gettext64\libiconv-2.dll
+-!endif
+ 
+ 	  ${If} ${Errors}
+ 	    # Can't copy gvimext.dll, create it under another name and rename it
+@@ -361,51 +357,20 @@ Section "Add an Edit-with-Vim context menu entry"
+ 	    GetTempFileName $3 $0\GvimExt64
+ 	    File /oname=$3 ${VIMSRC}\GvimExt\gvimext64.dll
+ 	    Rename /REBOOTOK $3 $0\GvimExt64\gvimext.dll
+-!ifdef HAVE_NLS
+-	    GetTempFileName $3 $0\GvimExt64
+-	    File /oname=$3 ${GETTEXT}\gettext64\libintl-8.dll
+-	    Rename /REBOOTOK $3 $0\GvimExt64\libintl-8.dll
+-	    GetTempFileName $3 $0\GvimExt64
+-	    File /oname=$3 ${GETTEXT}\gettext64\libiconv-2.dll
+-	    Rename /REBOOTOK $3 $0\GvimExt64\libiconv-2.dll
+-!endif
+ 	  ${EndIf}
+ 	${EndIf}
+ 
+ 	# Install 32-bit gvimext.dll into the GvimExt32 directory.
+ 	SetOutPath $0\GvimExt32
+ 	ClearErrors
+-
+ 	File /oname=gvimext.dll ${VIMSRC}\GvimExt\gvimext.dll
+-!ifdef HAVE_NLS
+-	File ${GETTEXT}\gettext32\libintl-8.dll
+-	File ${GETTEXT}\gettext32\libiconv-2.dll
+-  !if /FileExists "${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll"
+-	# Install libgcc_s_sjlj-1.dll only if it is needed.
+-	File ${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll
+-  !endif
+-!endif
+ 
+ 	${If} ${Errors}
+-	  # Can't copy gvimext.dll, create it under another name and rename it on
+-	  # next reboot.
++	  # Can't copy gvimext.dll, create it under another name and rename it
++	  # on next reboot.
+ 	  GetTempFileName $3 $0\GvimExt32
+ 	  File /oname=$3 ${VIMSRC}\GvimExt\gvimext.dll
+ 	  Rename /REBOOTOK $3 $0\GvimExt32\gvimext.dll
+-!ifdef HAVE_NLS
+-	  GetTempFileName $3 $0\GvimExt32
+-	  File /oname=$3 ${GETTEXT}\gettext32\libintl-8.dll
+-	  Rename /REBOOTOK $3 $0\GvimExt32\libintl-8.dll
+-	  GetTempFileName $3 $0\GvimExt32
+-	  File /oname=$3 ${GETTEXT}\gettext32\libiconv-2.dll
+-	  Rename /REBOOTOK $3 $0\GvimExt32\libiconv-2.dll
+-  !if /FileExists "${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll"
+-	  # Install libgcc_s_sjlj-1.dll only if it is needed.
+-	  GetTempFileName $3 $0\GvimExt32
+-	  File /oname=$3 ${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll
+-	  Rename /REBOOTOK $3 $0\GvimExt32\libgcc_s_sjlj-1.dll
+-  !endif
+-!endif
+ 	${EndIf}
+ 	SetOverwrite lastused
+ 
+@@ -462,6 +427,58 @@ Section "Native Language Support"
+ 	# Install libgcc_s_sjlj-1.dll only if it is needed.
+ 	File ${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll
+   !endif
++
++	${If} ${SectionIsSelected} ${sec_gvimext_id}
++	  SetOverwrite try
++
++	  ${If} ${RunningX64}
++	    # Install DLLs for 64-bit gvimext.dll into the GvimExt64 directory.
++	    SetOutPath $0\GvimExt64
++	    ClearErrors
++	    File ${GETTEXT}\gettext64\libintl-8.dll
++	    File ${GETTEXT}\gettext64\libiconv-2.dll
++
++	    ${If} ${Errors}
++	      # Can't copy the DLLs, create it under another name and rename it
++	      # on next reboot.
++	      GetTempFileName $3 $0\GvimExt64
++	      File /oname=$3 ${GETTEXT}\gettext64\libintl-8.dll
++	      Rename /REBOOTOK $3 $0\GvimExt64\libintl-8.dll
++	      GetTempFileName $3 $0\GvimExt64
++	      File /oname=$3 ${GETTEXT}\gettext64\libiconv-2.dll
++	      Rename /REBOOTOK $3 $0\GvimExt64\libiconv-2.dll
++	    ${EndIf}
++	  ${EndIf}
++
++	  # Install DLLs for 32-bit gvimext.dll into the GvimExt32 directory.
++	  SetOutPath $0\GvimExt32
++	  ClearErrors
++	  File ${GETTEXT}\gettext32\libintl-8.dll
++	  File ${GETTEXT}\gettext32\libiconv-2.dll
++  !if /FileExists "${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll"
++	  # Install libgcc_s_sjlj-1.dll only if it is needed.
++	  File ${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll
++  !endif
++
++	  ${If} ${Errors}
++	    # Can't copy the DLLs, create it under another name and rename it
++	    # on next reboot.
++	    GetTempFileName $3 $0\GvimExt32
++	    File /oname=$3 ${GETTEXT}\gettext32\libintl-8.dll
++	    Rename /REBOOTOK $3 $0\GvimExt32\libintl-8.dll
++	    GetTempFileName $3 $0\GvimExt32
++	    File /oname=$3 ${GETTEXT}\gettext32\libiconv-2.dll
++	    Rename /REBOOTOK $3 $0\GvimExt32\libiconv-2.dll
++  !if /FileExists "${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll"
++	    # Install libgcc_s_sjlj-1.dll only if it is needed.
++	    GetTempFileName $3 $0\GvimExt32
++	    File /oname=$3 ${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll
++	    Rename /REBOOTOK $3 $0\GvimExt32\libgcc_s_sjlj-1.dll
++  !endif
++	  ${EndIf}
++
++	  SetOverwrite lastused
++	${EndIf}
+ SectionEnd
+ !endif
+ 
+-- 
+2.17.0
+

--- a/patch/0005-nsis-Register-EstimatedSize.patch
+++ b/patch/0005-nsis-Register-EstimatedSize.patch
@@ -1,0 +1,102 @@
+From 73fec6bf3ae04c73346f6aef75ca2e11fb600176 Mon Sep 17 00:00:00 2001
+From: "K.Takata" <kentkt@csc.jp>
+Date: Mon, 1 Oct 2018 06:58:49 +0900
+Subject: [PATCH 05/22] nsis: Register "EstimatedSize"
+
+Show the estimated size in the control panel.
+---
+ nsis/gvim.nsi | 43 ++++++++++++++++++++++++++++++++++++++-----
+ 1 file changed, 38 insertions(+), 5 deletions(-)
+
+diff --git a/nsis/gvim.nsi b/nsis/gvim.nsi
+index 6f6246d5e..69e2ab3e3 100644
+--- a/nsis/gvim.nsi
++++ b/nsis/gvim.nsi
+@@ -42,7 +42,10 @@
+ !include LogicLib.nsh
+ !include x64.nsh
+ 
+-Name "Vim ${VER_MAJOR}.${VER_MINOR}"
++!define PRODUCT		"Vim ${VER_MAJOR}.${VER_MINOR}"
++!define UNINST_REG_KEY	"Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}"
++
++Name "${PRODUCT}"
+ OutFile gvim${VER_MAJOR}${VER_MINOR}.exe
+ CRCCheck force
+ SetCompressor /SOLID lzma
+@@ -196,7 +199,7 @@ Function un.GetParent
+ FunctionEnd
+ 
+ ##########################################################
+-Section "Vim executables and runtime files"
++Section "Vim executables and runtime files" sec_main_id
+ 	SectionIn 1 2 3 RO
+ 
+ 	# we need also this here if the user changes the instdir
+@@ -300,7 +303,7 @@ Section "Vim executables and runtime files"
+ SectionEnd
+ 
+ ##########################################################
+-Section "Vim console program (vim.exe)"
++Section "Vim console program (vim.exe)" sec_cons_id
+ 	SectionIn 1 3
+ 
+ 	SetOutPath $0
+@@ -401,7 +404,7 @@ Section "Create plugin directories in VIM"
+ SectionEnd
+ 
+ ##########################################################
+-Section "VisVim Extension for MS Visual Studio"
++Section "VisVim Extension for MS Visual Studio" sec_visvim_id
+ 	SectionIn 3
+ 
+ 	SetOutPath $0
+@@ -411,7 +414,7 @@ SectionEnd
+ 
+ ##########################################################
+ !ifdef HAVE_NLS
+-Section "Native Language Support"
++Section "Native Language Support" sec_nls_id
+ 	SectionIn 1 3
+ 
+ 	SetOutPath $0\lang
+@@ -490,6 +493,36 @@ SectionEnd
+ 
+ ##########################################################
+ Section -post
++
++	# Get estimated install size
++	SectionGetSize ${sec_main_id} $3
++	${If} ${SectionIsSelected} ${sec_cons_id}
++	  SectionGetSize ${sec_cons_id} $4
++	  IntOp $3 $3 + $4
++	${EndIf}
++	${If} ${SectionIsSelected} ${sec_gvimext_id}
++	  SectionGetSize ${sec_gvimext_id} $4
++	  IntOp $3 $3 + $4
++	${EndIf}
++	${If} ${SectionIsSelected} ${sec_visvim_id}
++	  SectionGetSize ${sec_visvim_id} $4
++	  IntOp $3 $3 + $4
++	${EndIf}
++	${If} ${SectionIsSelected} ${sec_nls_id}
++	  SectionGetSize ${sec_nls_id} $4
++	  IntOp $3 $3 + $4
++	${EndIf}
++
++	# Register EstimatedSize.
++	# Other information will be set by the install.exe.
++	${If} ${RunningX64}
++	  SetRegView 64
++	${EndIf}
++	WriteRegDWORD HKLM "${UNINST_REG_KEY}" "EstimatedSize" $3
++	${If} ${RunningX64}
++	  SetRegView lastused
++	${EndIf}
++
+ 	BringToFront
+ SectionEnd
+ 
+-- 
+2.17.0
+

--- a/patch/0006-nsis-Adjust-some-settings.patch
+++ b/patch/0006-nsis-Adjust-some-settings.patch
@@ -1,0 +1,27 @@
+From 2c0212b81c4384ac79234d00ea4d2dedc091878a Mon Sep 17 00:00:00 2001
+From: "K.Takata" <kentkt@csc.jp>
+Date: Mon, 1 Oct 2018 07:00:18 +0900
+Subject: [PATCH 06/22] nsis: Adjust some settings
+
+* Use 64 MB dictionary for better compression.
+* Support HiDPI.
+---
+ nsis/gvim.nsi | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/nsis/gvim.nsi b/nsis/gvim.nsi
+index 69e2ab3e3..759411989 100644
+--- a/nsis/gvim.nsi
++++ b/nsis/gvim.nsi
+@@ -49,6 +49,8 @@ Name "${PRODUCT}"
+ OutFile gvim${VER_MAJOR}${VER_MINOR}.exe
+ CRCCheck force
+ SetCompressor /SOLID lzma
++SetCompressorDictSize 64
++ManifestDPIAware true
+ SetDatablockOptimize on
+ RequestExecutionLevel highest
+ XPStyle on
+-- 
+2.17.0
+

--- a/patch/0007-dosinst-Register-some-more-information-in-installer.patch
+++ b/patch/0007-dosinst-Register-some-more-information-in-installer.patch
@@ -1,0 +1,77 @@
+From 2950ac125888507113faaff13d97c7d32c08f11b Mon Sep 17 00:00:00 2001
+From: "K.Takata" <kentkt@csc.jp>
+Date: Mon, 1 Oct 2018 07:01:56 +0900
+Subject: [PATCH 07/22] dosinst: Register some more information in installer
+
+Register the following items:
+* DisplayIcon
+* DisplayVersion
+* Publisher
+
+EstimatedSize will be registered in the NSIS script, because it is
+easier than registering in dosinst.c.
+---
+ src/dosinst.c | 22 ++++++++++++++++++++--
+ 1 file changed, 20 insertions(+), 2 deletions(-)
+
+diff --git a/src/dosinst.c b/src/dosinst.c
+index 182546e88..1c96305a9 100644
+--- a/src/dosinst.c
++++ b/src/dosinst.c
+@@ -1491,7 +1491,10 @@ register_uninstall(
+     HKEY hRootKey,
+     const char *appname,
+     const char *display_name,
+-    const char *uninstall_string)
++    const char *uninstall_string,
++    const char *display_icon,
++    const char *display_version,
++    const char *publisher)
+ {
+     LONG lRet = reg_create_key_and_value(hRootKey, appname,
+ 			     "DisplayName", display_name, KEY_WOW64_64KEY);
+@@ -1499,6 +1502,15 @@ register_uninstall(
+     if (ERROR_SUCCESS == lRet)
+ 	lRet = reg_create_key_and_value(hRootKey, appname,
+ 		     "UninstallString", uninstall_string, KEY_WOW64_64KEY);
++    if (ERROR_SUCCESS == lRet)
++	lRet = reg_create_key_and_value(hRootKey, appname,
++		     "DisplayIcon", display_icon, KEY_WOW64_64KEY);
++    if (ERROR_SUCCESS == lRet)
++	lRet = reg_create_key_and_value(hRootKey, appname,
++		     "DisplayVersion", display_version, KEY_WOW64_64KEY);
++    if (ERROR_SUCCESS == lRet)
++	lRet = reg_create_key_and_value(hRootKey, appname,
++		     "Publisher", publisher, KEY_WOW64_64KEY);
+     return lRet;
+ }
+ 
+@@ -1519,6 +1531,7 @@ install_registry(void)
+     char	vim_exe_path[BUFSIZE];
+     char	display_name[BUFSIZE];
+     char	uninstall_string[BUFSIZE];
++    char	icon_string[BUFSIZE];
+     int		i;
+     int		loop_count = is_64bit_os() ? 2 : 1;
+     DWORD	flag;
+@@ -1583,11 +1596,16 @@ install_registry(void)
+     else
+ 	sprintf(uninstall_string, "%s\\uninstall-gui.exe", installdir);
+ 
++    sprintf(icon_string, "%s\\gvim.exe,0", installdir);
++
+     lRet = register_uninstall(
+ 	HKEY_LOCAL_MACHINE,
+ 	"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\Vim " VIM_VERSION_SHORT,
+ 	display_name,
+-	uninstall_string);
++	uninstall_string,
++	icon_string,
++	VIM_VERSION_SHORT,
++	"Bram Moolenaar et al.");
+     if (ERROR_SUCCESS != lRet)
+ 	return FAIL;
+ 
+-- 
+2.17.0
+

--- a/patch/0008-dosinst-Adjust-the-default-_vimrc.patch
+++ b/patch/0008-dosinst-Adjust-the-default-_vimrc.patch
@@ -1,0 +1,29 @@
+From 15f3140e3b5abc9f7cc14d008c02130ee281a23d Mon Sep 17 00:00:00 2001
+From: "K.Takata" <kentkt@csc.jp>
+Date: Mon, 1 Oct 2018 07:05:35 +0900
+Subject: [PATCH 08/22] dosinst: Adjust the default _vimrc
+
+Don't set 'diffexpr' if the internal diff is supported.
+---
+ src/dosinst.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/dosinst.c b/src/dosinst.c
+index 1c96305a9..344d62be3 100644
+--- a/src/dosinst.c
++++ b/src/dosinst.c
+@@ -1191,8 +1191,9 @@ install_vimrc(int idx)
+     {
+ 	/* Use the diff.exe that comes with the self-extracting gvim.exe. */
+ 	fclose(tfd);
+-	fprintf(fd, "\n");
+-	fprintf(fd, "set diffexpr=MyDiff()\n");
++	fprintf(fd, "if &diffopt !~# 'internal'\n");
++	fprintf(fd, "  set diffexpr=MyDiff()\n");
++	fprintf(fd, "endif\n");
+ 	fprintf(fd, "function MyDiff()\n");
+ 	fprintf(fd, "  let opt = '-a --binary '\n");
+ 	fprintf(fd, "  if &diffopt =~ 'icase' | let opt = opt . '-i ' | endif\n");
+-- 
+2.17.0
+

--- a/patch/0009-nsis-Use-nsExec-Exec-instead-of-ExecWait.patch
+++ b/patch/0009-nsis-Use-nsExec-Exec-instead-of-ExecWait.patch
@@ -1,0 +1,53 @@
+From 50b334a228175eb761798bc44dca0fe62e7e1940 Mon Sep 17 00:00:00 2001
+From: "K.Takata" <kentkt@csc.jp>
+Date: Mon, 1 Oct 2018 07:06:40 +0900
+Subject: [PATCH 09/22] nsis: Use nsExec::Exec instead of ExecWait
+
+It doesn't show a noisy command prompt.
+---
+ nsis/gvim.nsi | 12 ++++++++----
+ 1 file changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/nsis/gvim.nsi b/nsis/gvim.nsi
+index 759411989..be40a4003 100644
+--- a/nsis/gvim.nsi
++++ b/nsis/gvim.nsi
+@@ -113,7 +113,8 @@ Function .onInit
+   # run the install program to check for already installed versions
+   SetOutPath $TEMP
+   File /oname=install.exe ${VIMSRC}\installw32.exe
+-  ExecWait "$TEMP\install.exe -uninstall-check"
++  nsExec::Exec "$TEMP\install.exe -uninstall-check"
++  Pop $3
+   Delete $TEMP\install.exe
+ 
+   # We may have been put to the background when uninstall did something.
+@@ -490,7 +491,8 @@ SectionEnd
+ ##########################################################
+ Section -call_install_exe
+ 	SetOutPath $0
+-	ExecWait "$0\install.exe $1"
++	nsExec::Exec "$0\install.exe $1"
++	Pop $3
+ SectionEnd
+ 
+ ##########################################################
+@@ -570,11 +572,13 @@ Section Uninstall
+ 
+ 	# If VisVim was installed, unregister the DLL.
+ 	${If} ${FileExists} "$0\VisVim.dll"
+-	  ExecWait "regsvr32.exe /u /s $0\VisVim.dll"
++	  nsExec::Exec "regsvr32.exe /u /s $0\VisVim.dll"
++	  Pop $3
+ 	${EndIf}
+ 
+ 	# delete the context menu entry and batch files
+-	ExecWait "$0\uninstal.exe -nsis"
++	nsExec::Exec "$0\uninstal.exe -nsis"
++	Pop $3
+ 
+ 	# We may have been put to the background when uninstall did something.
+ 	BringToFront
+-- 
+2.17.0
+

--- a/patch/0010-nsis-Use-MUI2.patch
+++ b/patch/0010-nsis-Use-MUI2.patch
@@ -1,0 +1,3916 @@
+From 7677964a9636faecfdcb008b74d95fba50ba5d05 Mon Sep 17 00:00:00 2001
+From: "K.Takata" <kentkt@csc.jp>
+Date: Mon, 1 Oct 2018 07:08:08 +0900
+Subject: [PATCH 10/22] nsis: Use MUI2
+
+Mostly based on the @gpwen's work in vim-installer-mui2.
+
+However, this still relies on dosinst.c, because of the discussion in
+ #3485.  We don't want to maintain duplicated codes in dosinst.c and
+nsis script.
+
+Enable the unicode flag for translation.
+---
+ nsis/gvim.nsi                 | 436 +++++++++++++++++++++++++++-------
+ nsis/icons/header.bmp         | Bin 0 -> 102654 bytes
+ nsis/icons/header.svg         | 265 +++++++++++++++++++++
+ nsis/icons/un_header.bmp      | Bin 0 -> 102654 bytes
+ nsis/icons/uninstall.bmp      | Bin 0 -> 618006 bytes
+ nsis/icons/vim_16c.ico        | Bin 766 -> 766 bytes
+ nsis/icons/vim_uninst_16c.ico | Bin 766 -> 766 bytes
+ nsis/icons/welcome.bmp        | Bin 0 -> 618006 bytes
+ nsis/icons/welcome.svg        | 268 +++++++++++++++++++++
+ nsis/lang/english.nsi         | 235 ++++++++++++++++++
+ src/dosinst.c                 |   2 +-
+ 11 files changed, 1115 insertions(+), 91 deletions(-)
+ create mode 100644 nsis/icons/header.bmp
+ create mode 100644 nsis/icons/header.svg
+ create mode 100644 nsis/icons/un_header.bmp
+ create mode 100644 nsis/icons/uninstall.bmp
+ create mode 100644 nsis/icons/welcome.bmp
+ create mode 100644 nsis/icons/welcome.svg
+ create mode 100644 nsis/lang/english.nsi
+
+diff --git a/nsis/gvim.nsi b/nsis/gvim.nsi
+index be40a4003..d09b9eb4e 100644
+--- a/nsis/gvim.nsi
++++ b/nsis/gvim.nsi
+@@ -1,7 +1,9 @@
+-# NSIS file to create a self-installing exe for Vim.
+-# It requires NSIS version 2.0 or later.
++﻿# NSIS file to create a self-installing exe for Vim.
++# It requires NSIS version 3.0 or later.
+ # Last Change:	2014 Nov 5
+ 
++Unicode true
++
+ # WARNING: if you make changes to this script, look out for $0 to be valid,
+ # because uninstall deletes most files in $0.
+ 
+@@ -38,12 +40,17 @@
+ 
+ # ----------- No configurable settings below this line -----------
+ 
+-!include UpgradeDLL.nsh		# for VisVim.dll
+-!include LogicLib.nsh
+-!include x64.nsh
++!include "Library.nsh"		# For DLL install
++!include "UpgradeDLL.nsh"	# for VisVim.dll
++!include "LogicLib.nsh"
++!include "MUI2.nsh"
++!include "nsDialogs.nsh"
++!include "Sections.nsh"
++!include "x64.nsh"
+ 
+ !define PRODUCT		"Vim ${VER_MAJOR}.${VER_MINOR}"
+-!define UNINST_REG_KEY	"Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT}"
++!define UNINST_REG_KEY	"Software\Microsoft\Windows\CurrentVersion\Uninstall"
++!define UNINST_REG_KEY_VIM  "${UNINST_REG_KEY}\${PRODUCT}"
+ 
+ Name "${PRODUCT}"
+ OutFile gvim${VER_MAJOR}${VER_MINOR}.exe
+@@ -55,70 +62,217 @@ SetDatablockOptimize on
+ RequestExecutionLevel highest
+ XPStyle on
+ 
+-ComponentText "This will install Vim ${VER_MAJOR}.${VER_MINOR} on your computer."
+-DirText "Choose a directory to install Vim (should contain 'vim')"
+-Icon icons\vim_16c.ico
++#ComponentText "This will install Vim ${VER_MAJOR}.${VER_MINOR} on your computer."
++#DirText "Choose a directory to install Vim (should contain 'vim')"
++#Icon icons\vim_16c.ico
+ # NSIS2 uses a different strategy with six different images in a strip...
+ #EnabledBitmap icons\enabled.bmp
+ #DisabledBitmap icons\disabled.bmp
+-UninstallText "This will uninstall Vim ${VER_MAJOR}.${VER_MINOR} from your system."
+-UninstallIcon icons\vim_uninst_16c.ico
++#UninstallText "This will uninstall Vim ${VER_MAJOR}.${VER_MINOR} from your system."
++#UninstallIcon icons\vim_uninst_16c.ico
+ 
+ # On NSIS 2 using the BGGradient causes trouble on Windows 98, in combination
+ # with the BringToFront.
+ # BGGradient 004000 008200 FFFFFF
+-LicenseText "You should read the following before installing:"
+-LicenseData ${VIMRT}\doc\uganda.nsis.txt
++#LicenseText "You should read the following before installing:"
++#LicenseData ${VIMRT}\doc\uganda.nsis.txt
+ 
+ !ifdef HAVE_UPX
+   !packhdr temp.dat "upx --best --compress-icons=1 temp.dat"
+ !endif
+ 
++
++##########################################################
++# MUI2 settings
++
++!define MUI_ICON   "icons\vim_16c.ico"
++!define MUI_UNICON "icons\vim_uninst_16c.ico"
++
++# Show all languages, despite user's codepage:
++#!define MUI_LANGDLL_ALLLANGUAGES
++
++!define MUI_WELCOMEFINISHPAGE_BITMAP       "icons\welcome.bmp"
++!define MUI_UNWELCOMEFINISHPAGE_BITMAP     "icons\uninstall.bmp"
++!define MUI_HEADERIMAGE
++!define MUI_HEADERIMAGE_BITMAP             "icons\header.bmp"
++!define MUI_HEADERIMAGE_UNBITMAP           "icons\un_header.bmp"
++
++!define MUI_COMPONENTSPAGE_SMALLDESC
++!define MUI_LICENSEPAGE_CHECKBOX
++!define MUI_FINISHPAGE_RUN                 "$0\gvim.exe"
++!define MUI_FINISHPAGE_RUN_TEXT            $(str_show_readme)
++!define MUI_FINISHPAGE_RUN_PARAMETERS      "-R $\"$0\README.txt$\""
++
+ # This adds '\vim' to the user choice automagically.  The actual value is
+ # obtained below with ReadINIStr.
+ InstallDir "$PROGRAMFILES\Vim"
+ 
+ # Types of installs we can perform:
+-InstType Typical
+-InstType Minimal
+-InstType Full
++InstType $(str_type_typical)
++InstType $(str_type_minimal)
++InstType $(str_type_full)
+ 
+ SilentInstall normal
+ 
+ # These are the pages we use
+-Page license
+-Page components
+-Page custom SetCustom ValidateCustom ": _vimrc setting"
+-Page directory "" "" CheckInstallDir
+-Page instfiles
+-UninstPage uninstConfirm
+-UninstPage instfiles
++#Page license
++#Page components
++#Page custom SetCustom ValidateCustom ": _vimrc setting"
++#Page directory "" "" CheckInstallDir
++#Page instfiles
++#UninstPage uninstConfirm
++#UninstPage instfiles
++
++# General custom functions for MUI2:
++#!define MUI_CUSTOMFUNCTION_ABORT   VimOnUserAbort
++#!define MUI_CUSTOMFUNCTION_UNABORT un.VimOnUserAbort
++
++# Installer pages
++!insertmacro MUI_PAGE_WELCOME
++!insertmacro MUI_PAGE_LICENSE "${VIMRT}\doc\uganda.nsis.txt"
++!insertmacro MUI_PAGE_COMPONENTS
++Page custom SetCustom ValidateCustom
++#!define MUI_PAGE_CUSTOMFUNCTION_LEAVE VimFinalCheck
++!insertmacro MUI_PAGE_DIRECTORY
++!insertmacro MUI_PAGE_INSTFILES
++!define MUI_FINISHPAGE_NOREBOOTSUPPORT
++!insertmacro MUI_PAGE_FINISH
++
++# Uninstaller pages:
++!insertmacro MUI_UNPAGE_CONFIRM
++#!define MUI_PAGE_CUSTOMFUNCTION_LEAVE un.VimCheckRunning
++!insertmacro MUI_UNPAGE_COMPONENTS
++!insertmacro MUI_UNPAGE_INSTFILES
++!define MUI_FINISHPAGE_NOREBOOTSUPPORT
++!insertmacro MUI_UNPAGE_FINISH
++
++##########################################################
++# Languages Files
++
++!insertmacro MUI_RESERVEFILE_LANGDLL
++!include "lang\english.nsi"
++
++# Include support for other languages:
++!ifdef HAVE_MULTI_LANG
++    !include "lang\dutch.nsi"
++    !include "lang\german.nsi"
++    !include "lang\italian.nsi"
++    !include "lang\simpchinese.nsi"
++    !include "lang\tradchinese.nsi"
++!endif
++
++
++# Global variables
++Var vim_dialog
++Var vim_nsd_keymap_1
++Var vim_nsd_keymap_2
++Var vim_nsd_mouse_1
++Var vim_nsd_mouse_2
++Var vim_nsd_mouse_3
++Var vim_keymap_stat
++Var vim_mouse_stat
++
+ 
+ # Reserve files
+ # Needed for showing the _vimrc setting page faster.
+-ReserveFile /plugin InstallOptions.dll
+-ReserveFile vimrc.ini
++#ReserveFile /plugin InstallOptions.dll
++#ReserveFile vimrc.ini
++ReserveFile ${VIMSRC}\installw32.exe
+ 
+ ##########################################################
+ # Functions
+ 
++Function CheckOldVim
++  Push $0
++  Push $R0
++  Push $R1
++  Push $R2
++
++  ${If} ${RunningX64}
++    SetRegView 64
++  ${EndIf}
++
++  ClearErrors
++  StrCpy $0 0	  # Found flag
++  StrCpy $R0 0    # Sub-key index
++  StrCpy $R1 ""   # Sub-key
++  ${Do}
++    # Eumerate the sub-key:
++    EnumRegKey $R1 HKLM ${UNINST_REG_KEY} $R0
++
++    # Stop if no more sub-key:
++    ${If} ${Errors}
++    ${OrIf} $R1 == ""
++      ${ExitDo}
++    ${EndIf}
++
++    # Move to the next sub-key:
++    IntOp $R0 $R0 + 1
++
++    # Check if the key is Vim uninstall key or not:
++    StrCpy $R2 $R1 4
++    ${If} $R2 S!= "Vim "
++      ${Continue}
++    ${EndIf}
++
++    # Verifies required sub-keys:
++    ReadRegStr $R2 HKLM "${UNINST_REG_KEY}\$R1" "DisplayName"
++    ${If} ${Errors}
++    ${OrIf} $R2 == ""
++      ${Continue}
++    ${EndIf}
++
++    ReadRegStr $R2 HKLM "${UNINST_REG_KEY}\$R1" "UninstallString"
++    ${If} ${Errors}
++    ${OrIf} $R2 == ""
++      ${Continue}
++    ${EndIf}
++
++    StrCpy $0 1	  # Found
++    ${ExitDo}
++
++  ${Loop}
++
++  ${If} ${RunningX64}
++    SetRegView lastused
++  ${EndIf}
++
++  Pop $R2
++  Pop $R1
++  Pop $R0
++  Exch $0 ; put $0 on top of stack, restore $0 to original value
++FunctionEnd
++
++Section "Uninstall old version of Vim" sec_old_vim_id
++	SectionIn 1 2 3 RO
++
++	# run the install program to check for already installed versions
++	SetOutPath $TEMP
++	File /oname=install.exe ${VIMSRC}\installw32.exe
++	nsExec::Exec "$TEMP\install.exe -uninstall-check"
++	Pop $3
++	Delete $TEMP\install.exe
++
++	# We may have been put to the background when uninstall did something.
++	BringToFront
++SectionEnd
++
+ Function .onInit
+-  MessageBox MB_YESNO|MB_ICONQUESTION \
+-	"This will install Vim ${VER_MAJOR}.${VER_MINOR} on your computer.$\n Continue?" \
+-	/SD IDYES \
+-	IDYES NoAbort
+-	    Abort ; causes installer to quit.
+-	NoAbort:
+-
+-  # run the install program to check for already installed versions
+-  SetOutPath $TEMP
+-  File /oname=install.exe ${VIMSRC}\installw32.exe
+-  nsExec::Exec "$TEMP\install.exe -uninstall-check"
++#  MessageBox MB_YESNO|MB_ICONQUESTION \
++#	"This will install Vim ${VER_MAJOR}.${VER_MINOR} on your computer.$\n Continue?" \
++#	/SD IDYES \
++#	IDYES NoAbort
++#	    Abort ; causes installer to quit.
++#	NoAbort:
++
++  call CheckOldVim
+   Pop $3
+-  Delete $TEMP\install.exe
+-
+-  # We may have been put to the background when uninstall did something.
+-  BringToFront
++  ${If} $3 == 0
++    # No old versions of Vim found. Unselect and hide the section.
++    !insertmacro UnselectSection ${sec_old_vim_id}
++    SectionSetInstTypes ${sec_old_vim_id} 0
++    SectionSetText ${sec_old_vim_id} ""
++  ${EndIf}
+ 
+   # Install will have created a file for us that contains the directory where
+   # we should install.  This is $VIM if it's set.  This appears to be the only
+@@ -147,17 +301,17 @@ Function .onInit
+   StrCpy $1 "-register-OLE"
+   StrCpy $2 "gvim evim gview gvimdiff vimtutor"
+ 
+-  # Extract InstallOptions files
+-  # $PLUGINSDIR will automatically be removed when the installer closes
+-  InitPluginsDir
+-  File /oname=$PLUGINSDIR\vimrc.ini "vimrc.ini"
++#  # Extract InstallOptions files
++#  # $PLUGINSDIR will automatically be removed when the installer closes
++#  InitPluginsDir
++#  File /oname=$PLUGINSDIR\vimrc.ini "vimrc.ini"
+ FunctionEnd
+ 
+-Function .onUserAbort
+-  MessageBox MB_YESNO|MB_ICONQUESTION "Abort install?" IDYES NoCancelAbort
+-    Abort ; causes installer to not quit.
+-  NoCancelAbort:
+-FunctionEnd
++#Function .onUserAbort
++#  MessageBox MB_YESNO|MB_ICONQUESTION "Abort install?" IDYES NoCancelAbort
++#    Abort ; causes installer to not quit.
++#  NoCancelAbort:
++#FunctionEnd
+ 
+ # We only accept the directory if it ends in "vim".  Using .onVerifyInstDir has
+ # the disadvantage that the browse dialog is difficult to use.
+@@ -166,21 +320,21 @@ FunctionEnd
+ 
+ Function .onInstSuccess
+   WriteUninstaller vim${VER_MAJOR}${VER_MINOR}\uninstall-gui.exe
+-  MessageBox MB_YESNO|MB_ICONQUESTION \
+-	"The installation process has been successful. Happy Vimming! \
+-	$\n$\n Do you want to see the README file now?" IDNO NoReadme
+-      Exec '$0\gvim.exe -R "$0\README.txt"'
+-  NoReadme:
++  #MessageBox MB_YESNO|MB_ICONQUESTION \
++  #     "The installation process has been successful. Happy Vimming! \
++  #     $\n$\n Do you want to see the README file now?" IDNO NoReadme
++  #    Exec '$0\gvim.exe -R "$0\README.txt"'
++  #NoReadme:
+ FunctionEnd
+ 
+ Function .onInstFailed
+   MessageBox MB_OK|MB_ICONEXCLAMATION "Installation failed. Better luck next time."
+ FunctionEnd
+ 
+-Function un.onUnInstSuccess
+-  MessageBox MB_OK|MB_ICONINFORMATION \
+-  "Vim ${VER_MAJOR}.${VER_MINOR} has been (partly) removed from your system"
+-FunctionEnd
++#Function un.onUnInstSuccess
++#  MessageBox MB_OK|MB_ICONINFORMATION \
++#  "Vim ${VER_MAJOR}.${VER_MINOR} has been (partly) removed from your system"
++#FunctionEnd
+ 
+ Function un.GetParent
+   Exch $0 ; old $0 is on top of stack
+@@ -390,6 +544,30 @@ Section "Create a _vimrc if it doesn't exist" sec_vimrc_id
+ 	SectionIn 1 3
+ 
+ 	StrCpy $1 "$1 -create-vimrc"
++
++	${If} ${RunningX64}
++	  SetRegView 64
++	${EndIf}
++	WriteRegStr HKLM "${UNINST_REG_KEY_VIM}" "keyremap" "$vim_keymap_stat"
++	WriteRegStr HKLM "${UNINST_REG_KEY_VIM}" "mouse" "$vim_mouse_stat"
++	${If} ${RunningX64}
++	  SetRegView lastused
++	${EndIf}
++
++	${If} $vim_keymap_stat == "default"
++	  StrCpy $1 "$1 -vimrc-remap no"
++	${Else}
++	  StrCpy $1 "$1 -vimrc-remap win"
++	${EndIf}
++
++	${If} $vim_mouse_stat == "default"
++	  StrCpy $1 "$1 -vimrc-behave default"
++	${ElseIf} $vim_mouse_stat == "windows"
++	  StrCpy $1 "$1 -vimrc-behave mswin"
++	${Else}
++	  StrCpy $1 "$1 -vimrc-behave unix"
++	${EndIf}
++
+ SectionEnd
+ 
+ ##########################################################
+@@ -522,7 +700,7 @@ Section -post
+ 	${If} ${RunningX64}
+ 	  SetRegView 64
+ 	${EndIf}
+-	WriteRegDWORD HKLM "${UNINST_REG_KEY}" "EstimatedSize" $3
++	WriteRegDWORD HKLM "${UNINST_REG_KEY_VIM}" "EstimatedSize" $3
+ 	${If} ${RunningX64}
+ 	  SetRegView lastused
+ 	${EndIf}
+@@ -539,33 +717,103 @@ Function SetCustom
+ 	  Abort
+ 	${EndIf}
+ 
+-	InstallOptions::dialog "$PLUGINSDIR\vimrc.ini"
++	!insertmacro MUI_HEADER_TEXT \
++	    $(str_vimrc_page_title) $(str_vimrc_page_subtitle)
++
++	nsDialogs::Create 1018
++	Pop $vim_dialog
++
++	${If} $vim_dialog == error
++	  Abort
++	${EndIf}
++
++	${If} ${RunningX64}
++	  SetRegView 64
++	${EndIf}
++
++	GetFunctionAddress $3 ValidateCustom
++	nsDialogs::OnBack $3
++
++	# 1st group - Key remapping
++	${NSD_CreateGroupBox} 0 0 100% 38% $(str_msg_keymap_title)
++	Pop $3
++
++	${NSD_CreateRadioButton} 5% 8% 90% 8% $(str_msg_keymap_default)
++	Pop $vim_nsd_keymap_1
++	${NSD_AddStyle} $vim_nsd_keymap_1 ${WS_GROUP}
++
++	${NSD_CreateRadioButton} 5% 18% 90% 16% $(str_msg_keymap_windows)
++	Pop $vim_nsd_keymap_2
++
++	${If} $vim_keymap_stat == ""
++	  ReadRegStr $3 HKLM "${UNINST_REG_KEY_VIM}" "keyremap"
++	${Else}
++	  StrCpy $3 $vim_keymap_stat
++	${EndIf}
++	${If} $3 == "windows"
++	  ${NSD_SetState} $vim_nsd_keymap_2 ${BST_CHECKED}
++	${Else} # default
++	  ${NSD_SetState} $vim_nsd_keymap_1 ${BST_CHECKED}
++	${EndIf}
++
++
++	# 2nd group - Mouse behavior
++	${NSD_CreateGroupBox} 0 42% 100% 58% $(str_msg_mouse_title)
+ 	Pop $3
++
++	${NSD_CreateRadioButton} 5% 48% 90% 16% $(str_msg_mouse_default)
++	Pop $vim_nsd_mouse_1
++	${NSD_AddStyle} $vim_nsd_mouse_1 ${WS_GROUP}
++
++	${NSD_CreateRadioButton} 5% 65% 90% 16% $(str_msg_mouse_windows)
++	Pop $vim_nsd_mouse_2
++
++	${NSD_CreateRadioButton} 5% 81% 90% 16% $(str_msg_mouse_unix)
++	Pop $vim_nsd_mouse_3
++
++	${If} $vim_mouse_stat == ""
++	  ReadRegStr $3 HKLM "${UNINST_REG_KEY_VIM}" "mouse"
++	${Else}
++	  StrCpy $3 $vim_mouse_stat
++	${EndIf}
++	${If} $3 == "xterm"
++	  ${NSD_SetState} $vim_nsd_mouse_3 ${BST_CHECKED}
++	${ElseIf} $3 == "windows"
++	  ${NSD_SetState} $vim_nsd_mouse_2 ${BST_CHECKED}
++	${Else} # defualt
++	  ${NSD_SetState} $vim_nsd_mouse_1 ${BST_CHECKED}
++	${EndIf}
++
++	${If} ${RunningX64}
++	  SetRegView lastused
++	${EndIf}
++
++	nsDialogs::Show
+ FunctionEnd
+ 
+ Function ValidateCustom
+-	ReadINIStr $3 "$PLUGINSDIR\vimrc.ini" "Field 2" "State"
+-	${If} $3 == "1"
+-	  StrCpy $1 "$1 -vimrc-remap no"
++	${NSD_GetState} $vim_nsd_keymap_1 $3
++	${If} $3 == ${BST_CHECKED}
++	  StrCpy $vim_keymap_stat "default"
+ 	${Else}
+-	  StrCpy $1 "$1 -vimrc-remap win"
++	  StrCpy $vim_keymap_stat "windows"
+ 	${EndIf}
+ 
+-	ReadINIStr $3 "$PLUGINSDIR\vimrc.ini" "Field 5" "State"
+-	${If} $3 == "1"
+-	  StrCpy $1 "$1 -vimrc-behave unix"
++	${NSD_GetState} $vim_nsd_mouse_1 $3
++	${If} $3 == ${BST_CHECKED}
++	  StrCpy $vim_mouse_stat "default"
+ 	${Else}
+-	  ReadINIStr $3 "$PLUGINSDIR\vimrc.ini" "Field 6" "State"
+-	  ${If} $3 == "1"
+-	    StrCpy $1 "$1 -vimrc-behave mswin"
++	  ${NSD_GetState} $vim_nsd_mouse_2 $3
++	  ${If} $3 == ${BST_CHECKED}
++	    StrCpy $vim_mouse_stat "windows"
+ 	  ${Else}
+-	    StrCpy $1 "$1 -vimrc-behave default"
++	    StrCpy $vim_mouse_stat "xterm"
+ 	  ${EndIf}
+ 	${EndIf}
+ FunctionEnd
+ 
+ ##########################################################
+-Section Uninstall
++Section "un.$(str_unsection_register)"
+ 	# Apparently $INSTDIR is set to the directory where the uninstaller is
+ 	# created.  Thus the "vim61" directory is included in it.
+ 	StrCpy $0 "$INSTDIR"
+@@ -582,11 +830,11 @@ Section Uninstall
+ 
+ 	# We may have been put to the background when uninstall did something.
+ 	BringToFront
++SectionEnd
+ 
+-	# ask the user if the Vim version dir must be removed
+-	MessageBox MB_YESNO|MB_ICONQUESTION \
+-	  "Would you like to delete $0?$\n \
+-	   $\nIt contains the Vim executables and runtime files." IDNO NoRemoveExes
++Section "un.$(str_unsection_exe)"
++
++	StrCpy $0 "$INSTDIR"
+ 
+ 	Delete /REBOOTOK $0\*.dll
+ 	Delete /REBOOTOK $0\GvimExt32\*.dll
+@@ -625,13 +873,13 @@ Section Uninstall
+ 	# No error message if the "vim62" directory can't be removed, the
+ 	# gvimext.dll may still be there.
+ 	RMDir $0
++SectionEnd
+ 
+-	NoRemoveExes:
++Section "un.Remove vimfiles directory"
+ 	# get the parent dir of the installation
+ 	Push $INSTDIR
+ 	Call un.GetParent
+-	Pop $0
+-	StrCpy $1 $0
++	Pop $1
+ 
+ 	# if a plugin dir was created at installation ask the user to remove it
+ 	# first look in the root of the installation then in HOME
+@@ -641,20 +889,28 @@ Section Uninstall
+ 
+ 	${If} $1 != ""
+ 	${AndIf} ${FileExists} $1\vimfiles
+-	  MessageBox MB_YESNO|MB_ICONQUESTION \
+-	    "Remove all files in your $1\vimfiles directory?$\n \
+-	    $\nCAREFUL: If you have created something there that you want to keep, click No" IDNO Fin
++	  #MessageBox MB_YESNO|MB_ICONQUESTION \
++	  #  "Remove all files in your $1\vimfiles directory?$\n \
++	  #  $\nCAREFUL: If you have created something there that you want to keep, click No" IDNO Fin
+ 	  RMDir /r $1\vimfiles
+ 	${EndIf}
++SectionEnd
++
++Section "un.Remove the Vim root directory (may contain your _vimrc)"
++	# get the parent dir of the installation
++	Push $INSTDIR
++	Call un.GetParent
++	Pop $0
+ 
+ 	# ask the user if the Vim root dir must be removed
+-	MessageBox MB_YESNO|MB_ICONQUESTION \
+-	  "Would you like to remove $0?$\n \
+-	   $\nIt contains your Vim configuration files!" IDNO NoDelete
+-	   RMDir /r $0 ; skipped if no
+-	NoDelete:
+-
+-	Fin:
+-	Call un.onUnInstSuccess
++	#MessageBox MB_YESNO|MB_ICONQUESTION \
++	#  "Would you like to remove $0?$\n \
++	#   $\nIt contains your Vim configuration files!" IDNO NoDelete
++	#   RMDir /r $0 ; skipped if no
++	#NoDelete:
++	RMDir /r $0
++
++	#Fin:
++	#Call un.onUnInstSuccess
+ 
+ SectionEnd
+diff --git a/nsis/icons/header.bmp b/nsis/icons/header.bmp
+new file mode 100644
+index 0000000000000000000000000000000000000000..c2f426953cc286fe381e8f0761222dbb1cf51525
+GIT binary patch
+literal 102654
+zcmeI*2fSrfeJ}8H?-XDtLlKY}ItUC+upuA_2qwlZ3IZZ3iijYns3@_-USh>qqG;+%
+z^QG69Vw#ERJsQ!c#>5geYK$?@Sl)Nv-<|&~_Br>=ojdp5X=i<g%i4RdzW%>|TmQY!
+z1rPo9o2CX`x{v=(@ZZTUpXL8kgS+}W7<|z45A8je`ETZiKi}C7(ziFJZ++`q|MNfp
+z^NnwO<Lh7l`q#epwg3Fj|NM`cB;(Rej}%aBV~uZb2g9EXVX^`{_6ii50>J<N@Baoj
+z$ouzy|M$;-{`3DflfLkUFSvBmBLyZf+_ATOGWzXl1qy)Q{N^{wIQSy+zVxLpeeQFg
+z``3T{*H3)n6aRN6$+!eZj}%Z$;fXZdo_2CFmK|~hdH|$qe)X$g{o)tD_~}o7`r{w}
+z_=i9I;lKO4zx(T%B;(Rej}%ZWdg%m)JLJYs2E7C;P-seKK0Q>GNI;mPYSKB$yN`bK
+zqksFifBUC@`lo;J2Y>MXnIz-VO^*~%OyLO(=d;d}GCS)E6oTfN>8(T6BFN%_2>?I!
+zsZV|6BOm#zzxt~`{KG%|jo<i<U;M>i{NFQ4#-*DcDey1<@-Gt@_Lg*Vx$CSz!AAyy
+zHk;b=S*5z8ZV!O}^iTiv7k}{=zxR8;_shTh%Rlu~KlQ^u{KL1;BpH{#@+-gMkphZA
+z>jZ|o4%JO&I*c9gp+n{z0gj~qw=w0?Ur(igv~X9Mo(c+60U+Iz)cf%t|M4IE!5@6f
+zTi)`9nIz-#$A0X`e&H8>L4gSjCp5VWu0XI8KtUFWaZa+x{_DT~D+hVpm6hC)JdFcW
+zd5BZD8W{sXDErYL{n59-{q5iX{ontJSG?k-GfC#PuYK*AXP$Zg```cPfBxs^f??ZB
+zfqg48yWn0=ro0`lKo2{R1$vy5U-`;c9NTeJQVX5sRdVV6m%sewoan`QQb-Jh-7Fih
+zBp`eN;1B%34?x`aec$)pdh4yX%%m5*;033jetN<R#=}tKb4lK<1f%NP;nqxsv@5JY
+z4}h=(ea`71?lYhH3?1^5pZug#1Lt@j``E|)m3N%yzH<b}eC^qK)Kp6AcmTfUHLrQe
+zOJ4H)=Rg1En{R&RGoN|WO*fr<^2q?W=DvgJlR6*{!_Z(b1e`(RQG?0E&8DC=e}@aV
+zPh0%%3Y$Ke<My)xJpdx|2ru{oG%m`2_=kV^o4@%R?n*XV(qI1NU%K=6fB*MR^gt3A
+zArWRFmx3DI6<(mGwE;^40^o~Z{Nm?5?|IL9*0Y}RjAvYb{q-9*Y=FBx?>9K;IfGS?
+zA5724!-C<T|M{Qm=%4@jpPk^7y!2rJC#g4@r<?hIv4!Dsc~po7$wK1xvq6)Q?DQ*8
+z7(|K@UcnCZIj#G%Kl?N11+25*`mNvk&ENdZ|1*<he&=_7=l6gA_doc-55ne$KJ=lS
+zt*Z!$U_vrNCDaV7panqU?}i(0xbC{^PB@_pd<DRRUpP4M<_?3ap1ui&KlgJ#r!T|M
+z3!XqOQ-h-egM8Vi^1W1#+Duy}_ro-T=+dRLCOiGsPbRpXtN?n$|B)X$M3yK#!i%tT
+zZk{8&_r33Z4i5g;#`Kdv`IA5MGe1MF{pzp&Du6&Du?Vw3M|yttv!6{68q~lJ{0>XN
+z0Ptx~ds+*?gKr(IyJWEL(!r|h?gYc1{n?+z0rVo4#tD9UfpL&;6DjFtl6?E9^6pp4
+zO{Ols(OR`s))I)@$sSFHv2(9LFh~f}AyFd`-Eqeq09Z$OKlDRC<kaA8Z+qKY-}=_u
+zZoAE29+h{z;~kFm93?nl|Mg%0buy8fN^6BgF!2{&#JxZ$0RG62{D>+&2{;mf_k8ET
+zzhM|+0y)9g3muqv)k`c>B3NRmCb^$XJtaM*Ua^#M6QXep$c<G?6R;E$81CFOzg^8P
+zN*9u2D@6z*SMZ^KIzuP-pzqCZe)H>I_qtcU@|7=t`O9DSvX}Ym9O2cke)a2L|9W_Y
+z#Gm+ypK#vy+rRzWfAmLx#CC&U;_m|=_yCoaCh72fJ^);QX@|c0*Ms3X=bS_M{?ae~
+z5`joMlZn8nqr{rZNbcx8DNo%@f&8U5S1|=7_Y<cIuyX~-ZCCp>8O+YN0<9uSAEQQ+
+zBghzhe)^|>`d#mOm-BOo<3e$Ez>S%61ex#s-tXnu1WX0UM8^#TBGnW|$UfCYywF$4
+zP&nPJ1ndEDq%=JH?6b9IRE`&QqzkCmmn7qosY+HR$yWi&aFUXSSH%=?hXntVKlu~7
+zH0hrJIW{A;JSQO5XXo4W$&9wE6(|hS!8kg|0!AEhMhH?M#jXG#xIOo|&wci@pMCY!
+zS6{L*J@&DWz5MdaAOHBryUDM@z5`6EDU8q?{gnq{Es&V;g3e_Fjs)OH7&^g+_xHZ{
+zy&7kq!nnTDolD}F;1+)4ue>{kfio~CiDQ|ROfh8$R(C2+l}yBcsNxiIYB`N`{#K!7
+z9GT|1*IQF}o?Xnp*zjQHS+`elp0y^$tXmv1sE$Fz8^hWn8W8Qf-~DcJEQFmy1n_y-
+z!ydL~&6@7$ZtisMx#!YdLGPXKd?)coSq0%2zVL-<ffsbx23&v1CjGM%(KgdlO7DH|
+zdy~8x2Syzw>C`2S*ZrhetnO2lVU_^(SKb}*Ii5-~s#BF=nMsTDn7fluUMXrh<(!Hh
+zx|)kldQ_Li9KJbMBXgBpy8H8=$XsLSwJ=w)-u+%Jm%Re>xg2g}=eT3;!5|ks402F7
+zkD$2`5U836BLqo6=GclAD}Zme-FDk&j<j;+N(I0Wa>c+<QxgV5hV~`k+1)V&FX(0g
+zI8qwk;~w__ZC&UH9wiy-?yFw)D)*D*74V2L3zZP(ue>|%o0kIqs^~s=l9Ci!79vqd
+zA$PbrMjdSl#_CDXN_XugH>DJ4tF-w%RcvJ4s-9wPQ|%r3uBV~YmT5a}Nw@B&aN1}G
+z<4(0xg?pK*JF;T0aC=!T%k+ldK5DD9gWoywW@obWE*Rvc=a69;v65(U!~`5M0~5gl
+zU#FgW>QkQb6pH1@bm^s+u3o)bvHRWcelL2_iv*z&fAA{?#wq+J2^avrV7>qx3B%J)
+zJ53kjO!<f;U^gTJSEmLn$&=vl2%81fc$U;k;k4i;moE*Ljmgy`7=SuTEvKBLD2ro>
+z+PyA%@JInmM`8l3@(E7Jful>weFYQ?C0E@nyPIuw<+U(VZ?>-LQbG%qlv*Oso%EiP
+z!+$-kTA546kQpWKzLdFWAp<ay3?^-+k=`uYinR#s_^Wp%dvmWIwLI4ps=BeYEwtOQ
+z6XZh-)&b?v!C;VCL?SSz$PP68oaa0z67Yc!e4vvxLJfI`&fC91<;53Y9BIgZ67&g!
+zdHU0zJ{JIwf6n088#eRrv^Ng!c2ieo|8oZ`A3Rw3kipb3fIc|tsH51XfS)AfM(>Z>
+zm>&J;N4p=3^@&e>BBNE30n*DZyG%s|9`l&TuxgpK*IaXr>L3Y^q(A->ld!hFHoAy5
+z6pP-h8(&t!5-eaPN`*$qQ)(?@M#&-LmTuilb;T4`1sn8Na;Z)ClXSsT)S^3GYuuxa
+zrM{v{Qr+=X85J{t9*DC0=7QQasHBR+BS|9)R3qAv+KS5PI)l&nHRWb?oyDx_r$<lC
+zOR)@i{)4X_*$FZuG01tyU(v%LOUitOcXENw9sq3oAIz3yeE7p39?YI~)>*_Kcg?le
+zUORgbKO_MUJhwyB_;l#SgSDrQFVa1I(1RXy@WBUfwj3Dlwbx$bi_y0oSRfCm3H!}P
+zw*W+qC>G5)=ub#(jv$?JNRAy{GOmf#I(aN=)NIg)@L)C}4Xl8);4hohrRw~&ykt_^
+z(O1C}Qq;v2RrgdGg;hzCm)tZqWz^D_0igU~VR$YY)V`*)U<^q{;?m7@4J_d&+A#&F
+zgrHQ+A}F7VIdwHQgVeRP3V!vT>1XvkwLZP^XXI{X@c7d3;CBM()fBcAgKvD}8#f~F
+zPXFiUCr5(B2S511)6>&aQ&XhjQ=j_Oxd2GXJof1w8eo=C8%~EFdZ?#+A3r$!@~#*~
+zceso@cfD)(RY$$t_rCX)*>lf5M;1Hipo2UWgG!H;*>~T4M;6;}zx_O=0Q4|eM2m#b
+z9;!f=h#camuP{r0U`}RH>g17=nSqHQgT%-(EhA>+hs;o{cm}>8CV;ccBu%+wm}}M}
+zNjr+^E3_S=MerZ{*vEt`{Nq3VqcRGs(pGfeQ)My$V9BJ2u#!jSlEI*SC3Td!7>VOl
+zBXMbh9s#3SXheAk@>d?f-S@N>K`qHJ3`y_Uk<kW;de<Eks|#5*eVx|$Yt~~1pS>s=
+z-qACQg+a9EV6I^JUElRxFepVf?Kva?W98lB?Ss_^3>0%-a3@I5ToA`(*3^o@3C|m>
+z*u8THIWZY7=9B^C_t;|(x+VA=c;JD5{KtPhT#Q4;({=0CrPzrlo;X~_9S5L_oqzuM
+zEe2ZvA|c`rhX)_TgI0AXrYMJxc#)JtQaAZp;SqtM(vTv$C6y2}Tp&?I?sPH{xoLq?
+zAtP-()qKBp6i^IpqfB6gYjrj2j{6_@zz4Xpl~2XgO)VC#5vpahI>kDmfG~<CNj8B4
+zW&+NcivedY8HP5sT#aA?*pBir1%2}7B{<3)EkZj66^&U%6V$TatysjdF{rMtSpay#
+zInrsypH5Rfg9qex@U3#PqXW?R7ZHO9m|KIj7-{%`2Rr~VOS>IA;{~0=33K56yE4RO
+z4-rtwmvYJ}r+B*l5rcj2-W6kG_KG=KQ0&MfkM#7Si!O?=<M8Yiqeydyl5z0<<R?EF
+zw83^*sdk!)jjUR=3f@r;jSH=2iR?SljRZtaXb-DLc*w@A9Wpx2aS+MBD#?h@6V>C$
+z14SW4>>bIGHT0`UPY4prhxYI;@eEo}Mbb_+#XBu&P*{Ru3ag^uh$?v@L-3vf=+q$#
+zW7c0)G^JS#K^Yh!rwA-42yZbLvy%r0+yIVX*<60@*M6-=qEl1QxTpqQE1=(qbxpyA
+zHZcJlKt(fEICWK&(YrBc`YKwn;1`6kBXD-p0vbQoYRYDs17CU7_3P2d!A~&QBk$g&
+z)pMK?7*hN|gCJY`usOY;QAdZR5^txvNqZeLIO1_#mbTgJj>~Aa&|q-famP75bm=Iw
+zSL|_*o2frjl#Giy%E#L)cHxB=R%?JvOqALt6RCkAqaW-Yc_2IlgY0pPHnFA?A>b)e
+zM56ElbO;#f3djM;mi$0w25sFRt*OgTi@m((J@0W!>o0bpjP6JWf`fE0axyC%Krea}
+zQ<3tHLDi)mXbpKQg9$(xtU+9vX5lB`K%^QTg12`WfHBDEQOmHbk#GQA1CH{Nj7!)w
+zDxhnppl($MOnd-Nt(fTpuO5wrG&c*?HEzBcypcP}O#p_j!LSBTQfKfzBYh$Vdo-L&
+zyH+rCPJyby@aU(EK8r7P6wS1)q42%;_RapmzNZfkIBRh7%Q|(GNodR3Vko>j5SjV@
+z|Ni^$PtPRjhSgCq1DaCOtNQ1icOIvx%VFU2n!10$0S9oFlAEQrMRTKtk|XE``5B(B
+z(JF#LKQJQWD2Jo<UiZ4!-R^d`!wx$PPtYB;oLiVC3<z{WDFPH_qWO?+sGUoe^Oi5`
+z_~Va1;)o+K3c3WTElysdU|<W{A=3#a1WYgm0tj9ZFPAm%u9G0AvGV5P$VQbnz3EL_
+zhDyZ<qhK&Xuuh}211!W4ESr?SoN3?lJ>PTBd*1V?qmH`!-S1AvxbemtVcg;yKR}rd
+zfLMgcUyVol3(Vl0KI4otjydKSuZ7~n{9ra03{{L6jTIaW>eo|8NQNy@bp%}D;bvqD
+z%(n)QceMt>PJq5lVR3cQLWdne1CfTd17T0^HaO;KqhT0z)B!<NPsYBhc-Y23nteN0
+z$_RBd?N1%qJ>{91OC62A>Y#*#b*d6|6mZ&3aeG=Qs1j18wgI4oXqis5P$B^N(b;fs
+zOdIP)nPv(&-3aDRTE>xhn^k9Rp*^dF>@j>&?}7_1z&%FR=03_C+ou=^4U_x=x7~N&
+zy?rz$&;5l<m<yQ>jBGlfAkHuZ2#V|mWL#*jMl3G|1$vZBe{qipO`?z^3+otJ(bVWL
+z3S&XEh<KAI2G-dk%*UavS>^+;J1u&mi?&2NCU0v>8WIiGkRUtu86#jAbrjF+wH9@B
+zpAEBB=2Ay-&TfN_pMCB3E_b<$%VBlYS)u#Fc%0qCU@XmHbu`pYf-qYmG60bNLkM!G
+zP^GAm$PYP*uEC;3GF)}lRXG*a{(O>H9a>hX7v+<2V`zR%gG3vnm5>@!X5=H<VD##+
+z6hJT@Sg>UlXD(LIHpTgD*tmx(*a!eV^q~)J3yjR;6&5z4kUBxGF(;#Yj4VI$CS{)B
+zkS21lhnJC;Or(NgOt2Mu4DR;KJ`CqlNBP;Pqf;vfr@XSOa`)HIs-xI%+Z~OL7iF-=
+zVAWG+VQBA$)ltDP?qlPIB!DM0bJ9sCwN1&>xD+FT(I>%29R)xs?h6E<3=4?l0zf_-
+z+GCGsv1`sBVi$WS`-TaLYD!%X^^&1f=(dd34F1?-k45M0{a&7fmo&i>%%wMgUdi4i
+z{gx<!LH<c#B$(KkmJ|l19Q34$RW%DyQimLJNX~rQrr6HP6P=JKI--3fuP!Cl3iQV2
+z64&CJidBe*fdBZJwk=cCBLpWH?9uI*OUhng$ln;zvvSSgxSRVhj5<0jm7<Ow`k2}B
+zY(r_-J9?k{bUy{R;-XD&-@EL2M`>J#AAY#|;$*ZSfM=vSimreN_Bs6sKH`t&CXtCG
+zBOXqZq(;(00Z`bRGZAejX`ikeuL2{HoRY{3jw6PuFjtYbyhg08D1Q3lAlg`aK!P)i
+zbRn^o=&M4?tw4|dp`IXiJ`yKCdS)1M4l|?JQv&1Ziq$6Njr|DeMuKmkd1AdV$Wcil
+zWZOnDHu9=SE#b!D24OS$%M(Rk<-U%pub4@ZfH;Yrty(g6nOJ1;QQECJbQ@JpT~kct
+zKP{RXjLXqWi9#(4-?em7aV_kT-fr;as9}beB09m~7|;zrva^99uY#Sm5v%qdoN&vX
+zU>J3jN!6=Pby0qkI(lWdjnu_nF^&lL_c&tqBN$VMbj60%QKpdl{0z#YRlDqR*bdEo
+z5MvTX9VIm!uOl1YJl;rB3}J8=)cK2c=!6I+(4(gEXS$S>#E1wB#wI5Q_hZZ`5(LCb
+zOfdR5I#4^xByG7be)o5OS4Zj^s`e}KFV$H;7(xe63#x|Mh*u-8!d70HNOR~TL?o2#
+zPE>1z%^?$yD6Ul%iPr?EPzEH8C?B7&4K+c|F&LDxT&Z})6<1g#vmoZeNw5o$!~sb5
+zYFq%7GD;HVbbB+kK4!|bRWgx*jJ+tPYr9~;c7Z~&^T7~5u_>i%VP7Z#o#53YW7X!0
+zlj(t?cZnbaL&`sIp}knOcCg_En_w7q)P20Vty}8o$*<@N-~9~(+AN<*PaQ>jEV7k*
+z4i34vgW*b0n;M~xdPPDPcrvQSa)r0KL_%$k@&t|hBo_ie?Y2I05X~@QSWhUHWP!oh
+zo(kjM*o8aj-(MD=&{Mo!;@or73ee06K19nBlweR4pSnqkIXXn-IlPV>R18_dH63hY
+z!2w){CaK5h6J}964BE9|Fw;zVLP}x#TLA2BH!*}Wq$0m=^}?G<?!(;-1iNTeeOVCN
+zFZGp^GbUu)7bh@GStZFV@T=ksW{u%c1JXYGHyA{3xJ~S9(**6pAon#X3Cl`m7$!n3
+zu^l@Z3=4xMXtFr4O|hE@#`5wH3lNPiWb0YM3&SA7#=Q%Myw>(&_5OnsU$_Z|n^8wE
+zo-MiGJ-TfiR!2!U_m6tg?6+v9W<p1Y)lo+ViV=}8$S$LE(mZ>>C%Keia3OEB7Y=NF
+z&?Je&6^R3YhNVz!0SUT^23j0Nv8r2hB!?yeifkfn5xHGJmgEj4uu2Al00<oc1r3vi
+z%t{TkTU>D1qT3?c2tj15uGwKJrb9r(h((}US1))7xG7`S^Z_WK{gRBpMaiW7szsyb
+zm8~kckoDngfkd+);6T-=6w^MKfA@EPcNK<EjYophMR6p{jz|iF=bUqnb<mF1befSE
+zMs}oTv=b<$rhr4@lc6zWfCF0-M>e*SXL7MH2!^~O)KOHya>+@7K(&)zG7GM#qoia{
+zDn%U?HJb3YBW7%!VRbYL+ukR1r}_KdYcPFex7)+&sFx|+Kl<pSv01hlpt&55(#h};
+zM&ux(Mad`-Jw#7{Ad;)=W6RT(S6&HU@Dgh`4RDNTnNYC)0Eof~P3VI-GPDgva0h}&
+zr62;1RH4q1&ISy&EYKR1)y6}LVoL~u6^JngX&Nfh14(vFvMSno@=oK}GMx|v;2j<b
+zYq-!O>8T<UzN(OPrl3vO$t*AyWlTh(yW)FQm=S6KxCgxgPcs0%8Y5>dri`-;Yl0YH
+zSuvQ!pduEtDK)7b+Cd6{lDUL2QiLq8St9^kkp^WWNSsBHgFzNOjdp}Em>UsEyB#<<
+z>17?hsH3}erwRkx(ZX<(I{NaiSf`Gz>D+ETbriE5J|GzOj<&W^(ZjGh8q1NO#F{J)
+z9)*$#0yKaguy;<3h|6kZ{u!%^fVI%N6LCCtndFhfM?}kp;(B$TbRasbeV4=m02&NA
+zg6z>MP-6?0PHN}aVz3p0*=s%%$Ni8C<{;1_9iKE!1+WF~DM-|vTEGYkfEF3&l&1#9
+z$~Jz3fiLPMDgr>P##{(NjQx?1d}I~YCWarg*WTd(W=gdv46?6nF%)YPPLV{!BAHl6
+zw`PQZcU%n4;BWRNdIW~AVsTM3Y$)ZNML;=mV!MbKw36Z|0z(pZ{rdGbW%s)dPM$e^
+zIPkn~i$sRB7?hv&j&4pJrP^Vhy#y(3YluqZMz4%ZQ*Mhz&xB1XA7c=kib)uC9ofg#
+zPzDZ#_8|{>$i|l!ABET+F_YZ!t|GxFa;BTxOhS-UN7U8QJd~kWz>H~T{b3E7a4q^n
+zwD(j8Ov3<&U;%x?5i-U$!4?J)^K4Ip!7v8xH3$=JIhD|<T5Nw)j%zD*<*@>O9++a*
+zDXhDm#R?rQBjWfqe!!75%gxfszxTaQhDHjKWj^DL20*mg4%oy!v}4#vt}tjATwWd#
+zpz2z13NY*&262ox+L0X^g8`tw6j5_QY4|GLfIHfnTR?mXSnMFj^5S9;sng=LECF~9
+zr1n@hIQ7-DuQJW4jvhCwjvjecM<&DSXbYmP%-e2s!f8n@v_4iT+5%2R5X9SnDq6p&
+z^D-!?M43lF;r{^D1=P)?wQJW>Hqa6nvI@JC&6#A8EsH9=VQ_>d2_^uPT5+i?3?jl3
+zg7gFo1gWdVN>yFOwCOKRo*XZSOq_4_n$;GEBsrxoy)Xc|E2|>C5q6*nuK;rbi_F!j
+zuDM*03U+Og>A*R1N=2%v2BjJB%|@F8pkl2M)R7j5Le?k-qA)%{l{K{%gW42$1Dgm^
+zF_dW-q^AK;M|Wrp764-%uyjIN7MU84^|7EaVP{ng1ZUQZjzN3JTM`)Jx2WA}uikfX
+z$b-9(HVG}YAi{4+96_g|Mi0MiaEMpwr$?xxZI!LhdkfM?#En278kP{SwIW2y>4$9U
+za6w@PCR##Kh!DO&15TaXmAFiUrOrWmt7Ixh^QRfYZ!AI3;JhVdRjkxv5KW>?L=G?T
+zD?vT}S%qORJj7m0=7QhS<$^&A8$FP~HO}@B1WYt#3Up%_qz58?BaeRu5(7gbvOUp2
+zDmaEI7!Tm64#ET(O{0dyhfI;EHMB$uSTx*&F<U;FDi4*2&>X`Ga2Sh*IoJ*}Ld-jy
+zF4_Yi&4ht(NlVE$I}orb!v7cr_GKwBND0w?VCcBKw3Mv8(}5m{qK>YA)L{Sa#faHN
+zo9z`_#7kD2Zp5}h-wgeBA03JuL5Cy)aYmFR1a9Mqx<d+8oRYI8kxG0!^;D22H4?|e
+z$+>r!mIOrnLRE&=3jPk-&OZC>kuhvANRZJ*;YbTs5|s2PR@Nb-lNX}4S~H8H)nG8X
+zC<v%a%A<cc733gXr<Fmlpef0H!>~b;m_sB%2E`?-5l$O?pckm7BzDB6Fbge<g{bk!
+zaJ*y%kQ}|s_>ml?U0jXsTAtR{(x%w&9BjGIp=}p-L=27uAgaLA>_`*?yp-pSW&$8Q
+z&-md|U=Ubz=j<aer1@m0gql$BylT`#Q@o>l-EDB>6T6+U1&TRe>lMo->xOvcgB|%a
+zHz|I~-~)4&A<=YXR0zhpWxK&Jsyk^21#m<qYh_tCxH%GWkK|Mj-?Qv!nC<}uBe6C|
+zGlTeKP#~$qRie#=;f*X0gJfR@Zx+T+H3cF}AU<$n4tPh_o$Dr}&lFf>83QQcML8Rq
+zt4iHRP6j|0Tfpc877#D30+sO<1-Prr;S3%adftKL;1~c}2kgjpL^EL;+dCYOz2+U3
+z=t6*LvMl$xh;{+@X%{*Q3>^^YNHm3!3^zqybn58zV8g8gXYtG^+Rkt>cc{?y9s&2}
+z$TFNEnG~*Tg2QEKi98JU9eLD7%OK`R!{CTKLP$86v-mb>tw%8W5{-lG)s<peqG5FC
+zCL~%12i(0{b;;k`+FUuCAc;VLlLQQ@zE!xF!R2(<ZoSJAg)A~=X&V60t3L7)^VCRq
+z5e9{s1Wi<?tm?>GWHcRBMJX^;H-@c{hT$qSA6D~|p7f-MfL;MM!j3Bhjhu2)thls#
+zYB~KM^QS7HD3&1dqa~6xS=gn(AmZoZ=6wwe`5`U!6Q1w{5^6Xl*lGPEXVp<}w+)x!
+z6MzLEb(FvROvD;@Wv>_^n{ADj1%_Ogy)tSUiElX)8HGVCD0ypGgaiwqgbu^cML4(G
+zl;}!S1ks=unhB6q&n`eBQiNq-WL@&vmiNXWsj1GjIVC`;h)^-LSf<7XhS7?NelJDF
+z-wRXpVcH;7fsaVng+UpY;G+d&CdV0i3^%*1ZYvPwbA&2pOglVIK%p2RXd;q!Od)8h
+zMPMG{Z@jo!VPmG83z0PiL(L+n+nYX(0(D`SI;wQbEw`v*kTh-Qyopn_wwM(gQzMzw
+z4krXNeE_t5X2(B_a;#eb$bDxknb^(_XraiG=76e0R7-?GFm#+m)dWN6C`y|vLmd?i
+zGbXLvdvM&dIuGipuNka4e00I7y$91X`j-uD-xO#|Bc73aovjZMqNV7T5JA5}*b+3+
+z4_Qg111eRf2&TnC_M*txjzqs@Vd<Ae5KjgF4Do?0*4Uio=??MRNBGrUG*T-`s1Z`S
+zrl;xMQ^g8{;UVeQeZWEdlwsuwV!Oc7tX@!p>ZX&vY9j4i<b%ZFMR1l%iW!)WtU%CL
+z(@(`9F%vPDB$r9K%)<KX(#l{~ZBsia08P-snoAC70zghYei+M6k%I*X=!wARSlBQV
+zWo>Jg4ugn?stJa$4-|q}!bMl_*NMFS@3ZOOe)k%zJ!NppYX<wDvFT=8!2RQ%J$r-!
+zhNrx`dk6nc1@6;@cCWl-(;F5H8DUYR#seStK+X_{jQj&kJiG|uwFF!{-qKP?I^?8$
+zl1r(j7FEVnS1bF1^HWVRMo@x85{jNl>*lm9bZ~nrTvhPWIA?6-W-(YWR2^YMeZ(ld
+zKq4BbUTinASF9$|qOVp!#(imK#+`6a%4Jr-)3$u&XX<q*PT{KJPVZ(tYMZL{+#xbq
+zDD#RE5(NfVsTilZ0LYKmZOV*md`U3~hOE(Oq!Eb3ke>HgKUnv$!Mcaf{^J+*$zR~w
+z%74Azu%Njibu`ZuWg^kf5jMeu)a`!ldvC9cma@E|sQTMJ?N!WWTR<%x=`ON~w*(?+
+z>CUhD<o#_iD1y{JDv#RZ+yGlgmK-BsXc?VraPmX0y4tkw>8tIxB?d+%rL<>PLVD(2
+z({CH88TDpS)9=+%tg5ubXseIRr@`K%UQ;{7r74(;EyMaK7_<}`h%*|;yVQGUyBur$
+zgzVf_0tSF<&gi}dBP}%s!4R<(42h)Hu<AxIllDAvkas8+7lsTmL`x?}#^@PU<5U!e
+zP<v6-$nEY?NP9W5eD7w;XM=Kh7fjh8(vW^$uk2+7*zC44k|MCBjslTki)LYY&90OH
+zq}_K{a(M8ehoIgZW6x@YZ@kvrv13(KzBlIK%XZdnez;`sPFr}h`Ci=}=+a`=f=6{>
+zurL7}p<<Y<04EUu$O`5N<=vu!&I0hv!9mYoJ`94PsH8-)B|3{cDEc84QF4TYz=V}j
+zGPe?gs`sQJ7X;l8UqbwN6i&sc!L>$`@#5}2+N(W^sSbvuq2Q1LRArd$0I0mb#uib?
+zvSVC8B9Bd#gu%!%?Y9FCsi#Lw#vCD0zy69oQr(O5T28UH;v~P|707B+?;`{m?1_7)
+zfZcxk?T#B95D2~%q`?u|0?@A`9rU~|C`DQZIS7Li&fsV-Un%5{%gy|yXywSD-mKqB
+zB=%s)Ds*0qJK<4`Ec^;tMxC>UJxX5ib_`c+L7_WvAcZ5{hK~*z4jD{=2n_A4DqQ^#
+z+F~#zheuvLMxH_(F!~FR*q{NV!0=EfcNVq+HX_SQ>%d@{JiO(M1wv5d4?hf==Ta6C
+z<ghFU1Z&Qm{dux=j~@7<%W`56+-S&`U3QsHhhs;v3-|Zl7(2R^7#x;{eB+|^@ThVv
+z;$0)9$-?$xu380(Xe^OU%tIO`OF;~S#7#|0VYH^Ozk#96HAqOrG3;!W#8k&Xscl3%
+zmFoUnL!I1TzzSGi+Z0=a#zO7K>M?wlAoIc7(>V>azmB(1cmdEa<evW4ZGb^AWSu$H
+zH5e|4Rupofi^WRp=+*-;E%c<JFM?Vh&Pn_V*J{<#1uXvjtAzM%R>>wZG0FD9W>nC^
+z$Z&bZl8R}h%v@vWHPv3uRb_I2VJi>}qNS39oY>@`vnM>36P_G&BA;N47Jx`}TVW9H
+zoWjGPBl{ME@-X5)AL(LYP&+*s3V@`J;#U+rybEDl!}0XIu&wFUDir8W0=lGJ*3+t0
+zcT%AJTaT*nn9LRx9@Ea`(OfHFYcR&v9_0O_aS2v;;44zd*<9?b9ssv32IJxrLCRIq
+z!cg!43_7e|L<|nYP}qq>ish7pwS9$%F_{z|Q=lGIvs;;|2HVV5wz=z64+d#9@wxGy
+zIg@q##QPCZc;=aBqUucmeC#IjUMxAt_H1!9pFGceM6=jkflMsKq(ruehdKQ%o5r~)
+zc<f0-??k}h^4NntYHaCzne**PMs|&yM&5U`tvkuLD`0V~8-<EG%HPiG&f&lVFA`6L
+z3@^l;0C?G*2z#+GDEPz+V)KDsTZXXqeR#tgPItNAoyNH+7#x;{zM*Z=D1;%rc2$=&
+zUqr6oN*guPZZMUqWSgm{y-bzq-LK0kP?<c^HC1XjWo4A9@-j=hGCOGFmc=SrK%$WA
+zjE$31U>d2IG~|8YDf?Xb@)P|#{&D;Ch<ULvNRWx&5C+*oY(9DJ5#CyXWZpz`dL=~;
+zIx#uo%H@Ee*VZguXl!{1Abr`gP(J4A;9%A}v+;j9O7O_o0+Zodso0iOI6#*1bhtoa
+zDs9#PbW0z=j#$S@^6t2w_Itxvo`u?hda2#9P!=s3Y2KLN$`%hlH8ptXOYZs3?_Bei
+zuRh_V8}?{nxL6qU`hfR$_=3EoKOg7~mvQ=Bzatat)uG9ePg)Wf?sNH?>6ahj-_*(7
+zXSBUbvTPXaZ5BGmHXTwp0c?{y_7NNufPxlWF5UDf6_u1p$&Co^0M!<#rW627tw}O2
+zVNG>iQ_F=JJ2Op^$IPi!+HZ#eyvw#$I}ip9wRYCRT7T=7&k^LD!uu&;_=s2B8w}t0
+z<tLojz;F>U=-kR_7dw<MXc%Jix#RU!$0&(s^I{QnOs^Uoea#}n@Zf9qnEu8CroVI1
+z)N{ID5%N+$abN+LVaI#h1R5ycPB9+@SJPg&Y9$$$Vq?Go3ScBi4EkKU>5&2|N-3!+
+zP_p#_R22{}s(@Y;C_n|IE&<I`JqlXzx~}M*q>q36<L(%Y_ER^*0Nx1<N0Lf5*I(q+
+z!Z0ECa3NrFYI^EXuRWuK;TNtv@fo{E8ZIIRVMiE%;dx8K%fj;k-EbL)DS@GowuBQ*
+zub%T))mni*&-_8xteO7ig&hEI>HtV~hoVNV>f+uk03ze!lZYR+JFFB7>RrDiE;Y>a
+zjyvuE3J4;Sf*tZm2Dl(pEgVlgh9u)Mcmb$jN?k2f0mxE7a895Kr<#Q?6rz~kg^>$g
+zV87TDf92gV5@XZ2aq3s^Mm~YzT!b+OhE`aN?%8LbJ-uS;F>g2%3}5%T$8C7VZs>M#
+zF^Ht?lo5)Kb_zcXvH9Hbts4iL5bbYXJMDf|?fR{jhVK|0_|zEye*2=S>$}f!6Wq%N
+zKx>i>!X$|^GQ~p0Uf?}rGT0!zOSGP)<4nUg1<ZgX_gd&5Y9jtX3FrWXW7!vDl$6m3
+z*ouP%y?|N)EiktgU?cdxx&od?!h$yRX~*jrs_R|9UM&$<pCs>&kO_4)4vESWh-5bn
+zHkyMO%|(s7?EPUF+PK6eI+C`tUZ$R2IsMq%&H}^Ne&&h|H}1B$7z7-j$jJKJN?zId
+zfNr>qGtGo{vk>#?&hA&$ZrTbMb^zRS`r8*xf9t}jYYzoLBD<Drc?c%mMF`p#GAQnA
+z^lz=i?@=D8@e=kW%n2URKS=~r3KLsk3qe&&<fmfZ1(p$uZW$FO_^@13EX}5XfDOA3
+zk{-dS1~sCvJ1Pnt*ND$7=vR!fWF+#oPjyd~AsN9CHy}otkR=M2XX$pVUb4~Hdz4bk
+zWxFXSmL12l*S?*#V%7BJZ@(WHzUot#9e@3*MTr;XlL0`<p&L5MqM?o6`TH>3=DOpR
+zx-<yXUi*a_zp8fp(66e^O9chM>-MI9b^yG(`|Pl&p=Ac31<|8@2?kLzdPdby0Bcss
+z0jsx`-ZPVgZSydr|Geb^FP4-Hl88>?3^uJTu&5=0j7##4up>H&E#l8!!;u3cXT)&r
+zusBcxJq$Tz2s_yK)Vus?s{X3zrbm#dafl{ZQIRna;_RK}R3UaO3}&yh-GLz^!j9WS
+zYCnRv-99tEa`p6;?>ZL@U;5!kFUtFag+agg;FN)?lXbK8c<fw28-HJvU0~>~tNaS{
+z%Do0BJa5aSp>OQp<@$X(0DkkrsjJp`flh1755U@&l7p6rDoDP-AQ|L^2!^n;B=48`
+z(g-!c^nHNz_S<g<B2Xm+3xiZp2n7@8LEa2aVLH5*Ux+REf=99skm1_*6KM55Swp*E
+zZmXp=n1U?e)i}uO-Cwc0)B}!mam7B{C^5<DPWF^S0@1hue$FbSPEXX)@th$v7OqQs
+zkM%*H$0RXB%kKTbmAkFD>b>W^_3Kx!T-Ck2w3Y8JwHVZzjk8%9Bn%>$@o*dY6sZU}
+z4-Apzp@()l<f?t{^s8#)<sbm=f5X}ifZw=q>WV`E5H)6T#xLMfJWany*N(8N0E%^H
+zN8rUAhd+L6vTdT1i-5vQNl$VRbMt0szMtF{llOHjnkR_CAbwcy?N%|-^4@48M&S;|
+zlLYVez7$&JE3<z6dWX4?I57$5Lm>sjxJjAwwS5rbohCcAYLAtVf6sX<S9dScFD?c(
+zC_s)WnxSH$e%)Xs(8k~7F2KM8LkgsqPqplm-R-Zc%>~1IymheuP5X8L{C^itU3#$h
+zg~iQoD*#%Dc1PF<c7!NI&uq83f`y9slcA_uQU)FAN!4tBF|AjUOe9{F@7=FUuTFcd
+z#-^hLc=YqE^=Pvh!f}GZ`Cza%o$_PF=nn*w9Vc99Dc0Y&yeJ#1*Q{h7TJ}Z9pf-78
+zar=xG*VXTM#EpE)XIL<#s`(9cE$?=~;KUb?Q%V7Fzh~{&0r2Y=Og;J_Uy&kGw;=$t
+z2pIrTNS9+HB%+CZ=PL*GwZOR`;8Tq>8CCpcnsHj%L?1&QE^k{Ih7=yQ-pFtBl8ipB
+zK>P`tr=Zr?t*a?-=wo;Ee-bmFzN|+wzSnIS=xUp<=RAS1ZHrl@ScTM4aBxV3g)$ka
+zqk=<NM(bvNq0hoDE(ZM$uLA|?oO8}$$Yc?O(BR%9fj0go^QXQQ%wWm)nd?{8hUMVt
+zw+;5a`G5|9U%O!H5eNB*E~9CCAefAyYy^zarf_tC42_*V=tBo4SlXkn4G14%^Z^vi
+zI-4UsIdix-of?3cU1JQ^*YD{zcpZc)VA1HSaEgN^?x@?3!GM{`?n3}nSrRaxTFoQ<
+zG6pecpDm@PvL$t`usc4#;HNR@!xrCS=9F-ISki5aule+DmFzfmG$x_#ruhH@_ZJ>$
+zcc}N-@x{g9o<|Lixpo$YK5K?;X0#jv3xgq}slFBLWn@AD+4xnpQ)Yfut%c!fZyD@+
+z%UwDEe)WQ>haBjW-F{&z)Z*`a7Hx^jWDK?gSB!FEQ>+YEXY6#C!lt+)OD2kh2Ri7Z
+z$w(-lmzzyNbXpKL1&fdOvc91TvrZ40jWEbHO8?iIGI>=qK;sLAO(^4^@r{N0XgPU@
+z1HfINM~?-6kxTx%1KN~Z-X1orF;6f!e<CRi+DGyzEY~i;Aa|LcW2n!<FFFR{LYP^8
+zXvz1K_+~R~yKeyF1>eZ0{0s#{tRt`C`#PduRVxgh_U6I9w;t31@GBQgJ?H=*wPqP1
+z`_TXV*KN^D7673SOAMfRW`aS71ss(yh1B^fTMSw^P(|~SO$-Jd0>(88U$!#(IfyxU
+zvc(KWpiYA@2-htJL5Wd74zdKr=>?envfup(g5{EAoDD%J2}o|zSCI#><DYC9y&K6y
+z7o8`O^e~8tVPzmd9u)?&<4b|T4u($|2sV?%tYYaIHa*8%OCy0c{w5=c=@b`@n4J9R
+z*qXxzr@pR(;c0IgtbNhJ9RR;{-qc0=`-CZ3k5slf23r6^9|DFxXaYdGDErQt9mo(*
+zFvx$^Vi4y9Lxm}>sX`Zx93(dZ&|($_>6|2B4&SYnb0{DMLmrsI8nqSy044#~VzUa&
+zCxehC7~D}X2pUIS-GyFDzM_VTGIE9nA{mdkkx#MWf}x+^iaXs`Nl$v|V4s)WwFBT6
+z&zm~G10aK!`;pM0`vnF5&U4)sw^%qKq6I+cgDKDx`ob>?P>gip6YRUl!4`vl>{kKB
+z6y{P>%U`-HpusGNG508qbwc6fmkZ0u1)U*?&N+K)^mz(~>H;suI3L6fmocPT)x}+_
+zov*d*K01spy8Lo5TB28w0z>Z!BEqaQ;#n9BoqQ#djX?DFUw&3^<>9NRzj*%iznwRA
+z?tW|>-Ubv)c2MC=zeM5k!%&YBiUq(}<qSF-L1W~mmZ)}&bg1E$>FJ`rdy_H=FoQmc
+zwn@^#k&}IvT6;?9)WG6M;7q3lKnf2~`%#s`5&sW;k|-n}VZ83oKSS*D>t;!JKFBQk
+zjO@O(+U6L9#3P?D`vEt<G=vm0Q=hv*dn4uD_?yVJVCeTT<5-wFYwgs1){=mns0bUm
+zQsjnVxaf;KzQJq(AxJ2bfaDrj0TH7>A_4s+yqIZZQ_m+uhvej(Dfri_IGqPZ@lI}9
+zHz>o$*c5RT1CbDSD3;(0`e>?jQESy=jSOXe^4PEndAACBKCsLMl;nr4Rgq+z-TTIf
+zceKk}OP?tXfBf7hPp!cAgF!Gn;;LB~GDFDaY!J^IHEcZMMm`nCSTGc%3VO(iCFPS)
+z#A{-VISIj#<RuM@Y^=$$(T2XHutA*12|LXbf+&P$O`n8?<OweV3vdXpvIl))j{lR$
+zQ&=%zgdoNsxoM8DcKgg3UwtUpA_#Q@JxNml2-i&Syai@`9Mf16QW&Cnb@Wxp;=kgA
+z;W4YE5m+Wt;T;$Yt<F#;is<}Fs0d)&>Y~v|I~ZO$`)Pd~o?OU8IOrAzLqsd~EG`-`
+zjrnOmHW6tO7z)TN7*Yk7ABHm!oK-~G!n9BVI#Q1qlIWAXj!tYjSRjIZ2Lgpb-vaW8
+zWv3)TX;NHgAdD%wgu$L11QVF@t5R0L;*fv<s8|6_ydPQ2s0<9@nouinF|Pe0No29=
+zhNO30x8|g?NXF?z5nTWVV~H>&m;-D9EH3AR&L*<sOXL?V^i}5YD`sKHNFkmw7lXm@
+zN6NeLH?ewbIWVL(;qxd;a0ork>v-e^7*hYd_(K{lKMY$8atmV!1Q3P;Rz}D%6)jq<
+z8p`J+fhnml=u8I|2qT4|HBm8QabYJ0ofaq(<&!Bi3GAe7_;5GY)W*_qCgaAq0g22X
+zOQb?siP2Q|wMkm2LwU9~CJ+UqTIT5r08MTFbhs;*v{2NByfn&3K@mch?HRow%w@(P
+zFdlyS?2la7Yq-b;IhI-&3>|e93^kbP_%;;kr9`zb#E6y|hJ``gh5$nL3_#3*B8?4}
+zIp)WOg`+qu;9!v|JPbC8MZ!^G-rxYiQ-|+#SFq)ip^gq?uprZB9OW=Y5re@nlWFPk
+z%F;IH*@DRYi59v=`~(4DSrjmYXU!{K)b`m~G|zY8Hw%^@gB=VXI}1ZjfP$e{br>n*
+z1>eZ0BuFWx6sORzXjP;h81iGFH|KH748tA<xrtzqN{K%}*2NcJTo@4mCUAv5AQc9k
+zn-h!Rsjy#6uEKB%ICNL<97%OPSOT<4R)(HQ<Ux=Wk{}R?W}KOZj8pmANfjQ>5RSyL
+zx|z`y(cvyzIBOMeKs<7mx?X#+aR^@6$+p5E7#?=%EDVt%&uw<fnF2*?B+$m+q?MI4
+z<a&(-gswOxz>o$GhE`yiVOSW%XAnF-Ko{j>$?<xNLH-bSF(;=~7^HT>psA7d)X0K{
+zGLfX1k4F`&CQgQkq<^;RC4|B+1F&?+aAs>xAYw{6`X?5tyMBQ#ae(Q|GSVo7$|zIS
+zcUeqr(ZmaYI9?PF?9MJEF40okS*`%;4L900k%KW054(gDq1)|CF1e&&D7<rFFr>>B
+z3}?RR*fq`PfZ&lmry@<PU`Qof1{Y0jgzl&!ycyV_7qXZGL?N(*)cv&`Hicp-6$Z~b
+z>#QiE{3^opsxYI>Ch~j&An}w}x;*u^ASl5L<JU}0nFVTL$*)3ChU9M{5r04=#3DRO
+z>WVle8F4LRwn}aFEuzC+ws7rxR1T|(`QyNL-{Gv?=f|MTV7&A<p8RcyK}bB5IyM7C
+zhfoHbUGruQLLD#oMm{A<3Wk1dFhnchpNEhqgh$c&8Xz#ukX(o}%e6$*QhT8<8v!8U
+zgpMRQRh(=VtndoH;-uD%>6o5uax`$-X{S|TS}Vo^n37Dr{6cO*4M2gs9>Zi>^wl&o
+zFn>LbcB-%{m0SjTBdb?Clg!8!$nsi1>xt6Po5&)xhbz*`=r9a<il~<+e5!?8VB2C4
+z4E@AXVCb07j%QL>#KK@mMwD&HrxChE$qXpxaWnzWVWu%*fmTDMS+S9ex%D?g=Q`4z
+zPIYYnj`^HmUVH7e1*<K}h;0Dj?rdWwl^kS0>czgdl55QD@+g0;d@r?6w|*UVofc|6
+zv*~fg*mSg)w_Rv2garzB!0ljy`+A#W5DeFenVOM?exDsBWWSgp3xlDs|AHaW5b}0%
+zfnW(B^v^#@BoR#HMUm?g5lQU`XfVuKh0X;yXZWa}IrB>dTZFz8wux4TSIyyjDXt#T
+zT{EMC&wM6Tg@-fqsXi&wTY)Siy0RC9pmQ<X?HGuK#U09%#%N-2@x~B>Xn>WGO<cC~
+z!B~RBf7fjcY4kfR1w${t)1ODGo#SuPW($Tq6(QX#uDF8uAb?mpbOUf`MPY9x7xA(-
+z1q}6wF;Y%20b8&D0IEWnVObP=sYbYhOR_KG_$N(m(F)jZ1Z*SfJc1U=z7|%I@Io?z
+z7Fs_~PaWD$FbI{0JY<%doDQ2vChjH2g~8CfZxzgT`st@@nw{m1IT|VFWJF=CLMs-S
+zY|&D0QQ_=MZ4D%bL-Ltml4FtrZ22U4!=}|RX{F)s$<V!*VJ=%V@m;NO2q_y~5yFHZ
+z1x#QD51X?mlu1D3=jnZDn#X(l!C(i&jW4<ZOAEvCQg5!OxJ|(@zXJ}2OkkoAYhs!a
+zNthM2VHq%3yQ4cyQX&@HM0Kgu-mko;Mr&tj(MHbKO(2T0u#fpIduIMpPh?la)RxY-
+zcG<3l&0?D@L9Q5{a87SpsPhOhfwWM&MiF&#v|VAagW-c_r6K-cMp*<(>0Ce?f8Tr)
+z$p(xYHf+!|`<EI(m!poBXJ&awH@(z0;g(yP3cSH1NXpo5_cgUVv)EFy+@;Fb=Gqjj
+z5}%~EaEA)q&3Obb2iHB$34lIlx8F<(#V@Ws=o1z`_Oj;i!3no)`q0F%4LI`7aW~Jt
+zdT(H&7PEs03=bI(w~<fjv1J&Vd%htitkhCa@RrRaZ0WE?;sWvoTk=%OWwq0GG|4aj
+z3KRzM#$d1w5EWcOnh*hm;PCe(7Z-!Gl5Eg@3-p8+Yyk{Uc<#VYOSFlim6ha>ABnQf
+z-sD28UpACE=9pu&?<EWVVZM>&amy?UF%;0|$}CDRlSZ~?1%@#ghfIRBgF(JHAK6BP
+zEF<T_T!l%_i^&C{Vw)xDkp=2I+k|Wy6#7EUcGSM#V8gBRf}!u&2Y^QCw0h&vuJFwY
+z%d%h$8Za1|c$88ZU*I$_?<}y9cOVRI4Q)*7F3$=S23uV;FDp5f!1gI%j>!VR`bJqO
+z(_c7ZG>wGVW^Wb-t2G(+W?;DX<auFm_jTPFA$8FUN4*AJZVd*FpJU4RR5Lsl@nMH`
+zKY!-$1cS>%oV!RbEe82y5*d}3Wdt>$VLllzc%nUrxz>cCB&wv|o0buLxLLT3ECAr-
+zY$ef;ygdkBfQs(+*|2#G9)07AsZ;k-SUkD0!LNYic5IGUMs_{_n@%O5FE9jZeTni4
+z2D5a#2%Su(xpXVgVvq-0n5YvaVIf`!5~)S+f)VjxXwM4;hOw2BWjyhF83(m{p>IAI
+zJnF_3D?f7P;Ec5j3q>|I036@`!k&s64Ggh}V32E(Q*na9r6bE-t!1>tQHH3ncaC=_
+zxn34<9F{YBk)q-M!60ldjFRV5i-esg29La9#mbMK<+Fr?W7ZS~MOn|Mmj#r8aRVz1
+z@?Y^TPB6HuA!X_28(KnCag9<(9T5_RV%74#3^yY>4+isPk_C|Qe5!agV?G!>;)azg
+zKY2C)PQClYLHFY`vvSZ2r}OD$0cGghEe6@nxR!NWx=oq1yi2V>FxZO11nP^<0z=Y}
+zCbm2nbey+Y3?BaUl`B4VP6xoZZy2ne&X+=?i!L1o#q6~htkdmXicThzUD6c*Ll}%G
+z<e6~<Mk94tPZ|mw<qj<jx-W!g0itBHRp8xOBvQ|-;(HysV)!`z@atBs`0V{V0N!@O
+zU{&|Nw$Edh9Q4-h!d{x#?AT(c^7-hCPbNZeA_te0CU>>QTT#g2;IJMHNkf6bjtjX)
+z(Vp)Wy#M|0w=!O=a1gM#NrWnEj-m@h`E=ff3)i1?&E72x4+Fr@&j9cZ#}8Ic`GA;s
+zo>Naf)!2Lxj5o>HSh9;dFs)$@4r>_5IivCYv56wOs{v$r=G%iIX~;hVZjeY6=8LaB
+z&Kwvn(U8F3_nKg8YI^F*cb)sTZ#?;=YxW8Z4}IF|6<?YG;A@W?teEoo7jKt~-V{%s
+zZ-jc=2)kIKfeGQ$qk&0&VmoWKM14(~-IZ6Mg(3e8H)(?H$wX1yfuTSVAGND=(8lB|
+zK$UziXk_y4b|o5JC6XmcV~9Kf;pbg<(mTF=&23-5dc!qq)?d5Z^naY+si3bsb}&8V
+z01+s>1%OK!o8yw%pK;l9&l=d`X7X!I#^!rg69DeY7+LDMhr0ZYZOHQgiDVNn5{qoZ
+z`u=$*50)kgjrR6XJ_vTfjVHhJJJ-DQj!UOMeQpQ9mmULvtVQVKnasePX&RdkqyXL0
+zjA&D<f@UWGTxuemv~LB5kqC@vUh>^7U$<D?BoIY%4$jp>(RKbv#`$zZKAdvVvrm2H
+zCoZ4<()m*_JldBld{qoXz#@uE)Yy2C7HeR}kR(=3Vh>9EHWL6&0J3Z=P%xAU!4LoC
+zL|s^_rmA{yR01~&Fg-Icy#KW)PTh0_X(U`nnaz%^n%&Y&4Xn+y-N`T87EC&ttbi5h
+zk>Ao?hUP&gV2lC`Zc=@F!53pZUAi%hZ+SuwlNH!bR$x4#ZvE31j1U)8dJ9RCPx~X6
+zV(Yu^wJ@@m$<4_M?8Gb3gFwKTn^7s{cjD<!rZ!oD?PLXdNUY24WO$QdOjcmB0+SV(
+ztiWUiCMz&mfyoL?R$#IMlNFe(z+?p`D==As$qGzXV6p;}6_~8RWCbQGu;3N=|Ji`@
+AWB>pF
+
+literal 0
+HcmV?d00001
+
+diff --git a/nsis/icons/header.svg b/nsis/icons/header.svg
+new file mode 100644
+index 000000000..21e60fbc4
+--- /dev/null
++++ b/nsis/icons/header.svg
+@@ -0,0 +1,265 @@
++<?xml version="1.0" encoding="UTF-8" standalone="no"?>
++<!-- Created with Inkscape (http://www.inkscape.org/) -->
++
++<svg
++   xmlns:dc="http://purl.org/dc/elements/1.1/"
++   xmlns:cc="http://creativecommons.org/ns#"
++   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
++   xmlns:svg="http://www.w3.org/2000/svg"
++   xmlns="http://www.w3.org/2000/svg"
++   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
++   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
++   width="300"
++   height="114"
++   id="svg2"
++   version="1.1"
++   inkscape:version="0.47 r22583"
++   sodipodi:docname="header.svg"
++   inkscape:export-filename="header.png"
++   inkscape:export-xdpi="90"
++   inkscape:export-ydpi="90">
++  <defs
++     id="defs4">
++    <filter
++       id="filter2840"
++       inkscape:label="Drop shadow"
++       width="1.5"
++       height="1.5"
++       x="-.25"
++       y="-.25">
++      <feGaussianBlur
++         id="feGaussianBlur2842"
++         in="SourceAlpha"
++         stdDeviation="3.000000"
++         result="blur" />
++      <feColorMatrix
++         id="feColorMatrix2844"
++         result="bluralpha"
++         type="matrix"
++         values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0.600000 0 " />
++      <feOffset
++         id="feOffset2846"
++         in="bluralpha"
++         dx="-5.000000"
++         dy="5.000000"
++         result="offsetBlur" />
++      <feMerge
++         id="feMerge2848">
++        <feMergeNode
++           id="feMergeNode2850"
++           in="offsetBlur" />
++        <feMergeNode
++           id="feMergeNode2852"
++           in="SourceGraphic" />
++      </feMerge>
++    </filter>
++    <filter
++       id="filter2910"
++       inkscape:label="Drop shadow"
++       width="1.5"
++       height="1.5"
++       x="-.25"
++       y="-.25">
++      <feGaussianBlur
++         id="feGaussianBlur2912"
++         in="SourceAlpha"
++         stdDeviation="2.500000"
++         result="blur" />
++      <feColorMatrix
++         id="feColorMatrix2914"
++         result="bluralpha"
++         type="matrix"
++         values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0.600000 0 " />
++      <feOffset
++         id="feOffset2916"
++         in="bluralpha"
++         dx="-3.000000"
++         dy="3.000000"
++         result="offsetBlur" />
++      <feMerge
++         id="feMerge2918">
++        <feMergeNode
++           id="feMergeNode2920"
++           in="offsetBlur" />
++        <feMergeNode
++           id="feMergeNode2922"
++           in="SourceGraphic" />
++      </feMerge>
++    </filter>
++  </defs>
++  <sodipodi:namedview
++     id="base"
++     pagecolor="#ffffff"
++     bordercolor="#666666"
++     borderopacity="1.0"
++     inkscape:pageopacity="1"
++     inkscape:pageshadow="2"
++     inkscape:zoom="2.1369427"
++     inkscape:cx="130.27686"
++     inkscape:cy="77.09629"
++     inkscape:document-units="px"
++     inkscape:current-layer="header"
++     showgrid="false"
++     inkscape:window-width="1280"
++     inkscape:window-height="942"
++     inkscape:window-x="0"
++     inkscape:window-y="27"
++     inkscape:window-maximized="1"
++     inkscape:snap-global="true"
++     inkscape:showpageshadow="false" />
++  <metadata
++     id="metadata7">
++    <rdf:RDF>
++      <cc:Work
++         rdf:about="">
++        <dc:format>image/svg+xml</dc:format>
++        <dc:type
++           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
++        <dc:title></dc:title>
++      </cc:Work>
++    </rdf:RDF>
++  </metadata>
++  <g
++     inkscape:label="Layer 1"
++     inkscape:groupmode="layer"
++     id="header"
++     transform="translate(0,-938.36218)">
++    <text
++       xml:space="preserve"
++       style="font-size:40px;font-style:normal;font-weight:normal;fill:#000000;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans"
++       id="text3026"
++       x="4.0525044"
++       y="-8.7699928">The editor</text>
++    <text
++       xml:space="preserve"
++       style="font-size:40px;font-style:normal;font-weight:normal;line-height:100%;fill:#000000;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans;filter:url(#filter2910)"
++       x="178.45901"
++       y="988.47156"
++       id="text3198"
++       sodipodi:linespacing="100%"><tspan
++         sodipodi:role="line"
++         id="tspan3200"
++         x="178.45901"
++         y="988.47156"
++         style="font-size:36px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:center;line-height:100%;writing-mode:lr-tb;text-anchor:middle;font-family:Courier New;-inkscape-font-specification:Courier New Bold">The</tspan><tspan
++         sodipodi:role="line"
++         x="178.45901"
++         y="1024.4716"
++         id="tspan3202"
++         style="font-size:36px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:center;line-height:100%;writing-mode:lr-tb;text-anchor:middle;font-family:Courier New;-inkscape-font-specification:Courier New Bold">editor</tspan></text>
++    <g
++       id="g2916"
++       style="filter:url(#filter2840)">
++      <path
++         inkscape:connector-curvature="0"
++         id="path2999"
++         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.07548681;stroke-miterlimit:2.6099999;stroke-opacity:1;stroke-dasharray:none"
++         d="M 107.53604,994.85892 57.991535,946.32092 9.4535173,995.84025 57.991535,1044.4034 107.53604,994.85892" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3003"
++         style="fill:#006b05;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.07548681;stroke-miterlimit:2.6099999;stroke-opacity:1;stroke-dasharray:none"
++         d="m 102.57907,994.85892 2.96915,0 -47.556685,47.55668 0,-2.9691 44.587535,-44.58758" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3007"
++         style="fill:#007d17;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.07548681;stroke-miterlimit:2.6099999;stroke-opacity:1;stroke-dasharray:none"
++         d="m 11.441335,995.84025 2.969148,0 43.581052,43.60625 0,2.9691 -46.5502,-46.57535" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3011"
++         style="fill:#66ff99;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.07548681;stroke-miterlimit:2.6099999;stroke-opacity:1;stroke-dasharray:none"
++         d="m 57.991535,951.25272 0,-2.94398 -46.5502,47.53151 2.969148,0 43.581052,-44.58753" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3015"
++         style="fill:#45ff02;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.07548681;stroke-miterlimit:2.6099999;stroke-opacity:1;stroke-dasharray:none"
++         d="m 57.991535,948.30873 0,2.94399 44.587535,43.6062 2.96915,0 -47.556685,-46.55019" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3019"
++         style="fill:#009933;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.07548681;stroke-miterlimit:2.6099999;stroke-opacity:1;stroke-dasharray:none"
++         d="m 57.991535,1039.4465 44.587535,-44.58758 -44.587535,-43.6062 -43.581052,44.58753 43.581052,43.60625" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3023"
++         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.07548681;stroke-miterlimit:2.6099999;stroke-opacity:1;stroke-dasharray:none"
++         d="m 67.25125,961.16664 2.969146,2.99431 0,0 -20.482085,20.78405 0,-20.78405 1.987817,0 2.969148,-2.99431 0,-7.90094 -2.969148,-2.99431 -33.012896,0 -2.969149,2.99431 0,7.90094 2.969149,2.99431 2.314928,0 0,67.35935 3.623367,2.9692 10.241043,0 70.98276,-73.32286 0,-7.90094 -2.96915,-2.99431 -32.358674,0 -3.296256,2.99431 0,7.90094" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3027"
++         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.07548681;stroke-miterlimit:2.6099999;stroke-opacity:1;stroke-dasharray:none"
++         d="m 19.694561,962.17314 -1.987821,-1.98782 0,-5.9383 1.987821,-1.98782 31.05024,-0.0252 1.962656,2.01298 -1.962656,0.95617 -1.00649,-0.95617 -30.04375,4.9318 0,2.99432" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3031"
++         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.07548681;stroke-miterlimit:2.6099999;stroke-opacity:1;stroke-dasharray:none"
++         d="m 25.632856,1032.5017 -2.314928,-1.9878 0,-68.36592 2.314928,-1.96266 0,72.31638" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3035"
++         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.07548681;stroke-miterlimit:2.6099999;stroke-opacity:1;stroke-dasharray:none"
++         d="m 75.177364,962.17314 1.987819,-1.98782 0,3.97563 -33.038059,33.66712 3.64853,-7.9261 27.40171,-27.72883" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3039"
++         style="fill:#7f7f7f;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.07548681;stroke-miterlimit:2.6099999;stroke-opacity:1;stroke-dasharray:none"
++         d="m 26.312236,959.20399 -0.67938,0.98133 -2.314928,1.98782 -3.623367,0 0,-3.97563 6.617675,1.00648" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3043"
++         style="fill:#7f7f7f;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.07548681;stroke-miterlimit:2.6099999;stroke-opacity:1;stroke-dasharray:none"
++         d="m 47.775654,962.17314 0,27.72883 -3.64853,7.90094 0,-37.64275 5.611187,0 1.00649,-0.98133 -1.00649,-4.93181 2.969146,0 0,5.9383 -1.962656,1.98782 -2.969147,0" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3047"
++         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.07548681;stroke-miterlimit:2.6099999;stroke-opacity:1;stroke-dasharray:none"
++         d="m 71.201725,962.17314 -1.962656,-1.98782 0,-5.9383 2.289766,-1.98782 30.068915,0 2.31493,1.98782 -3.32142,2.96915 -29.389535,1.96265 0,2.99432" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3051"
++         style="fill:#7f7f7f;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.07548681;stroke-miterlimit:2.6099999;stroke-opacity:1;stroke-dasharray:none"
++         d="m 103.91268,960.18532 -69.699491,72.31638 -8.580333,0 0,-2.9692 6.290568,0 69.674326,-71.33499 -1.00649,-3.95049 3.32142,0 0,5.9383" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3055"
++         style="fill:#7f7f7f;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.07548681;stroke-miterlimit:2.6099999;stroke-opacity:1;stroke-dasharray:none"
++         d="m 77.819404,959.20399 -0.679382,0.98133 -1.962658,1.98782 -3.975639,0 0,-3.97563 6.617679,1.00648" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3059"
++         style="fill:#cccccc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.07548681;stroke-miterlimit:2.6099999;stroke-opacity:1;stroke-dasharray:none"
++         d="m 44.127124,997.80291 0,-37.64275 5.611187,0 1.00649,-0.98134 0,-3.97563 -1.00649,-0.98133 -29.062421,0 -0.981329,0.98133 0,3.97563 0.981329,0.98134 4.956966,0 0,69.37234 1.283276,0.9814 5.661511,0 69.347217,-72.31639 0,-2.84335 -1.00649,-1.1323 -28.710153,0 -1.006492,0.98133 0,4.0008 1.006492,0.98133 4.956966,0 0,3.97563 -33.038059,33.64196" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3063"
++         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.07548681;stroke-miterlimit:2.6099999;stroke-opacity:1;stroke-dasharray:none"
++         d="m 62.143307,997.85323 2.31493,-1.98781 5.938295,0 1.660709,1.98781 -1.987817,5.93827 -2.289767,1.9879 -5.938295,0 -1.685872,-1.9879 1.987817,-5.93827" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3067"
++         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.07548681;stroke-miterlimit:2.6099999;stroke-opacity:1;stroke-dasharray:none"
++         d="m 64.131127,1030.539 5.963458,-17.8149 -1.987818,0 1.987818,-5.9634 8.882281,0 1.987818,1.9878 1.333602,0 1.962657,-1.9878 6.617676,0 1.98782,1.9878 1.308439,0 1.987818,-1.9878 7.246734,0 2.64204,3.9756 -4.32791,14.0909 1.96265,0 -1.91233,5.7118 -11.901751,0 4.655019,-13.8644 -2.969147,0 -2.742688,8.1023 1.962658,0 -1.862008,5.7621 -11.901753,0 4.629856,-13.8644 -2.969146,0 -2.767852,8.1526 1.987821,0 -1.862008,5.7118 -11.901754,0" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3071"
++         style="fill:#cccccc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.07548681;stroke-miterlimit:2.6099999;stroke-opacity:1;stroke-dasharray:none"
++         d="m 102.50359,1008.7485 1.53489,2.1891 -4.881475,15.6509 1.962655,0 -0.65422,1.9627 -7.92611,0 4.629858,-13.8644 -6.944788,0 -3.950475,11.9017 1.962657,0 -0.654219,1.9627 -7.926114,0 4.629855,-13.8644 -6.944785,0 -3.950476,11.9017 1.987818,0 -0.67938,1.9627 -7.926116,0 5.963458,-17.8149 -1.987818,0 0.654217,-1.9878 7.271898,0 1.987818,1.9878 1.962657,0 1.987819,-1.9878 5.938295,0 1.987821,1.9878 1.987818,0 1.987821,-1.9878 5.988621,0" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3075"
++         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.07548681;stroke-miterlimit:2.6099999;stroke-opacity:1;stroke-dasharray:none"
++         d="m 69.088095,1006.7607 -6.064107,18.0413 2.063305,0 -1.962657,5.737 -11.876589,0 5.938295,-17.8149 -1.98782,0 13.889573,-5.9634 z m -13.889573,5.9634 1.98782,-5.9634 11.901753,0" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3079"
++         style="fill:#cccccc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.07548681;stroke-miterlimit:2.6099999;stroke-opacity:1;stroke-dasharray:none"
++         d="m 61.816199,1028.5512 0.654219,-1.9627 -1.987819,0 5.963458,-17.84 -8.253225,0 -0.67938,1.9878 2.314928,0 -5.938297,17.8149 7.926116,0" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3083"
++         style="fill:#cccccc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.07548681;stroke-miterlimit:2.6099999;stroke-opacity:1;stroke-dasharray:none"
++         d="m 68.408713,1002.8102 1.333602,-3.97563 -0.65422,-0.98134 -3.975639,0 -1.308438,0.98134 -1.333601,3.97563 0.679382,0.9813 3.975639,0 1.283275,-0.9813" />
++    </g>
++  </g>
++</svg>
+diff --git a/nsis/icons/un_header.bmp b/nsis/icons/un_header.bmp
+new file mode 100644
+index 0000000000000000000000000000000000000000..4b6516951f44a16a8398341992000b4343204405
+GIT binary patch
+literal 102654
+zcmeI*1(+;XnFin+To(@-ELb3f1c!@DaM(o_LU0Z4?u*;vPJ%C%#dVQj!QCNbgUjNJ
+zF1GvL`7-|=s=9l6X1e>1)OnuU_f*yK^MAjds=3m2{`T}ecI-+Q_wRiE?d$U1{@-KA
+z8T{_p@o~?;cJdud|CVm}`QHtY{<fU{`q#hy`Okm;)1UtIhd=z`cfb4HZ-4vS|6WQm
+zF5UD<0mYVU{A~jae;C5B0-JjU3QYmvAOHAAaD%*G{Nfis{pnBtYbpKgXFqf4rbh}4
+zFx=c*K8$`Ntv~_rFMs(983$iP-Y<Xo%b)z@CqMYX55E2FZ~x~~l5q)+9x0%h!h<y2
+zNIN-<WmB#|2Y^(~-~8q`KmYm9fB3^69&^kwU;p~ozx1UqeSRs)xOCGa1r&>3I>2yK
+zZu~IlIjlgTDVb?{s49_wFh$j*bCP%8`qsC;_{A@N@{^zZ@P|Kq#8Q%R>83{tD5mfL
+z!)exeD6>^ppb#`=rn3%Jiy(^!CII~2_rCYdZ+`Q0pZnZLKJt-wzx&;9dCOb=eJRPf
+zbkidRzW@F24>0U3>2SGyR-oV`13@dMwtQBp?x@=V;5WYUjn91MGavlm2jBL#x4rhY
+zuYK9eUUukGl5zR=x4+#Z1r&qU0fyU$>V}#2u>(GI$ixxgNcx}UluN&!N&#u%t}-1J
+z6s7_|x+kgks#m@0g)e;JGoSg)e_cv4E?@b|SHAhpZ&qM{;Xsqya0P;$01C1|jB}Dj
+z_WR%eK7l;$%1Z7?p2mTxJjAJ6jZ6R_l)d5=uXx_`p7)feJms;EeeAz1C7CBZ=}DKm
+z)TJ(e`OClQO>Y_p!?u?K`#Lk*aIc3cZ@?AkU<a~5k8|?Zzy7tb9Y-a#P%N*KOZR{E
+zt6wFe7w1VKF%WjMY`~I$@CAU+dCqen?op3=)I%QfkOwZM2S5112OMxfjulLXp~lBa
+z-gSae^$oZ+!;rSa3UmMnJJ2Ui2XR08(U0hm-}%mWL=D98jz0Qmzw*L)?u#P`^R=<{
+zsHv3J$pC!f6QB6VM?UgF4|>pj?|a{S-RoZWyyrdl-FIIA+-IMC&UUu5$@F1pFc<>P
+zpz)}|Wa5e`Xw7fGaQn2y?{?VqVU8PT1v&sk<Pl!*1!!E9U-`;czVL-Fa96U?l0N&{
+z&${#FFMnA?4<vyR5@8l{DX7t1;RR}18?YoG06yXok9fcX9&qn_-}~-&zx!S9dRNec
+zJ21S_jc#<6t6XL8z4vZm_~}o7T1Vgg?srA-NnZLefRohA=IILm7hC9;%cDXxNEQ+|
+z&IS!5+43t;7(|K@UcnCZiPnAUQ=bwqV4c19z3+X`d*1UOOG)Pa?|=V?KJ=lFfBfUH
+z`L(ZoEwObKArVYSMyQ0Ez6x3ZB>wJpx4Yf>&UZfF`IZj8?z`{72OoUH8{QBGuXCO2
+z6b#?^#y9HAF!X{akjvEI=)fRf_Nja))uT4kmdX7vjUc*o>8#0?-}+&K8)OC08~%^{
+z&>^x!;SpYhow#{Ic!wW;xWK``EvMJK<~6T>{p-oKcf8{r00N1`BFq9E>G|Uy|2T)x
+zpayo}w=V$$z&qXPPAvd$defUyL9cLyD_r~9*KT3>hBv$c2hfYNG$Q!v1;#<XO{Aoo
+zN%HNZ%DZ1FH<`NlMr+klSxX>pkUbiPv9(tq7$gMgkf;%ejymcn0IU$+OJDj@QG@3`
+z_qor0_OqY$tY`V<QF;FJpD(N@lpw(Vu6MnQOr)mLS|Jfk{KAWKFAxfVFMs*VRq05;
+zkpP5EsSiU;AQ61M(1D3py~Hvlf+dD(lKaWjQ_@rF6iXR5AsWYk+*q|V0ZTE!aBI{2
+zhMHZJE+ofRiV#Gu;6wiuLnrs3?-|c{#*?4?<i|bkagTY-V;=qJNBb2=c)}B&@YJV1
+z6&@k+)vtcFc;EZp_r8yQ^rLJy_$B_1Jn~2?D@{`HeHsA5T>zNh4h%1Q*~=2XZ++`q
+z2}IJFOaw+9<*ccU<c{8x^3=@~$S<|IiYXwupL41JJMMtohT5-TFk5d0T1AvTMvWv#
+zkTLkY?sczw(TiRrehzV5C}IcPn296EJoKRt<=6yF1;|9<1_F_43L|8n>Q21SSIJN~
+zT~Pvd05}qcJ9qBXno$Wa>PQz*uP;f)B~z8GOp>nxl;I>L4X=tR;0_7?iBEijE=~I9
+zfE=5VTAm1q_1SuxKFnxCtw3Rr4#v?z7BJ$7GeVF8>Ff#sg4_M?fB*a3=RUW+?QQ>g
+zIo;$YH(|cr;ug1XlV1gD0F!D8BlJeU@*u1Q5;I;<WjJB_D(FZ6j)b8IKD@u=B`?u9
+z`xM6YmF`>;#{{?IH-6>aF$|o6IY}JLq-2UIL$JD2=Tyl={D&$|A*YtpNT;_7E#t^E
+z<zBC+?v!0jU#vfvDeHDBPFZUxX5HeDL3Iow-Wb*v(ST@Q{Nfio$3oZ%B0$7-uY28-
+zoa7`z1{2cdE_XS)E9kx81ur1}D61g+u!lV?EsO*pCrscr?zf|qUhHBQBY8Crj5<ov
+zsY@EK`$@4_-KQ$UECK3Q-W}(2Je6crrz*oTlNRSOcaczDDQY?8oQfX08b>D`s>@>b
+zZ;oqZT*>*}pME0a#?WbDT(QpmPA!+60@Gaf8`&Cn%sm+7qK82a3h@Y<8v%i;i7-Nt
+z1Z0jK_qfM}z7wACg#R!m9q)L@QveJh*BKaUYL3B>q43oL@B$aOfG|Y7pyQy|-tWNh
+z!WX_UXzM~p@F>YpcOU=w$Ge{-uYgC4S*V0Kzw++5Z(a)cRndL$Bqb@dEJUJ^LN2&D
+zK^<)g#_CDXN_XufH>DJ4tF-w%RcvJ4s-9wPQ|%r3T|M<uTc+)_CEdE8!fB%&j62m%
+z74BrJ?#POr!tG_XEYlf&`>3tb4t{Io&CX=$T`<T?&mqGyVkObyhzU4i2Id3{eC@a2
+zez(8<?J1Tc(~WO@;}e|V1d3heGM9Py!yoPt8u16e&cKMmmkJsH9(2$_D@wo#Fx-Ft
+z{dM7-DIbvp?1n_(>ePTGc@i8RVY8qb&yrdxoEF^V@}<GDF}Zpi2B3~o%PHq5%Hmj}
+zcCU*bJW{~Yk(dChd=4ih;OJ6vUjfBJ$yGPY?q*wEc`Yo}JGQRsQjQiVDYZnNJLx?o
+z`@f!6t;{83$c&PAU&>sxkO3G;29q|^NM{yp#ae`R{MEaXow-+!S{^rrs%~s;3+;An
+zfqaO;I-ndn7z{FtNCd_d*@1@dcfb2Z0v>qafg)>!8uAXEx4%K<4Q_CQNJIXUpwBUw
+zyWHh2;{eFG{HK)?V^gzA;Q$xE_{A@AiA$XEjAw-ObDZNGssnzKBR7g&e>sWuyB~}7
+z*0;Vjqg9dtQt($%0cUbpwM^PO+~E$YgCsnX{`gN!!rJ=U=px!sEPAtUd|5e`U;!&p
+zDl|f#Qfm=2N)8#fbn9lSE2gk2*q~p@r8eD9(gjaZi|%x-agUZu{aTfzy5p%bDrNv3
+z5M}qx1+{BXNfrAeNh1nWBifPLipuCZgU|Ri<z{uA#jNS4M^DX5u?%?n!Pky#fy_t@
+zavt(mbTG)0GGE6#xj>H%04)Cpvn3g?cfIQcvzNZ~rHMZXI^>W;5{U0hK(K<Q$%z_#
+z&U2n~av4vragA%7{`99`u^1Sh>|`gKT#UXgV1YcKChRvG-2xCbqF6K|(4Ql<2|<c+
+zNWzXT8P`N=MIMV9H5>FHJebXq239~?@XIE3sX9L`FPW5f^i}YL6m@Y$)jd^4VO5gk
+zB{z*t8MX9f04P6L=+8xi+Sim8j3LQLT)LUAfhGJzJEj1Y5R{5p1m#mPQCDL#NL^d2
+z;8*XNepb&@>(d#3M($<?k1zEHzXhOIQ&=qqpZ2t;EhF#m{^#c>M}ov_UF%xMInHtR
+z*kcdU@Q!!9<2V3PH31eJV3ttpr?Z^pES~PQ*Irk?@|9&My8SZloZ$?+zUru#OJ4Gl
+zGABLhNk<mjbI(0Jr2x}oWlnj@Q;sZls#BfHQwl%_gGIDR2<@Q?WQoWjj`|9-^ati-
+z7NsJOoXiYN1Q{eomT4I=BR^z@Vx4E;3t|F@T_$PDCBs~^9!c6!Okbhx5G{f~`skw_
+zSNQ5zzp9MFs<ai|_f(k-09Z09BCO<*xnwXXUr8NhE=D4pY9uaA&?8_p3ymlbL4M@{
+z+<i}L5!8|l!;tij9T{zqsCV5#vAU2|)7NQ@zh*sQ@Y#!^;mw|z6$a6sz+A!bYFE1&
+z3`&treF+#_kEzJPqnLQX-$8omf;c9#z?sGffW(uCNxzsVgEA*R@rmh{;B&guo$g~F
+z`&hpihm5CZI@6g_?EL3Hf4_`70-%ar@rqY$G1vkS2@!udJoq3Uw5mI2iV}Rpi=+fe
+z-Q;V9M+AmSLyG8@R6@*ffkY9x=wwdhrUgocjI<opJVHAPD2BFCCNRRax|(&z{UeV&
+zk}F&JR7~B}V&NL0T1Kl=tOE)NqiB+36F6Wd;GDS_aORR>Xj9A82qu8-C=XN6CvRR3
+zN13BVXvd(UF{@~TTGqQ2i#Rq0)zvi%0MBubbei#}(^Svk0l6J~tDJ0h02==cF^GV<
+zHCT(0h7n#NdtT6SPM8Z_=t9a6mmNevC11(~FL*&u$<rL+W@C1Wi7Y5~_OqW|v8!J7
+zsu6Y^o}FS8Y3@)m4&HBfyW0iYeWhA76B{}H@sAJhD2K*{R<lI*9qC2_A}6$m)gwG)
+zW7dL<qB#PQ{Hv0T6M9bd2zj6=q=>yEIkJX+73m2<&hnu>yvun8EvO=Cr<&rOmNe*C
+zf?^7*qTh%rc}IreJp<6GAPZyGuPU0-EQX*AjF3|V78HcHn2XuTg9B~=N3d)z?|kPw
+zYa}`~1&uq^plb#68?mk_xX>mhfCH##rV6L7iZXgP=1gBjD;E5MFm?paZdyR&$68I<
+zOcU^xS6#mzjU4=d!47$MF0Gz$Mqo(s0}VndZ^yTO&dNs}?Mo%zPIZ$AFE3Nb(>6QZ
+zaTzU_+Hs!qoJaJ~rBG(4*v)Qsvnoc$MIGhi?G#HdDGA8LM5%2uks25>`oZ3j2f{-z
+z$R5XN6Kgsr1UyBGNEBXx4gn)w2Xa8NB|nf^Lfft%t*OgTi@h9n*kPiyez6N>bVoW6
+z9HfJhlUd;adeNgZ6)7(asxI|FYsgy}OaRJY4dTi)3qJt|BGvE^yuHf+j6p_^T83qf
+zgaharaFmy1T*9VN0bM%<b*nmH;sbDM#Y`V~^=Krdxml>Lar4dKja(!*2QYLEhBbJS
+zI)m>R>4O~X&~Ps8TES490!f1*Be8JTW=b7JGi_@q{NyM1&Hf$dI@h_VvV1AjQOTCI
+z#Zb7Lq??kbKJ}^Tneu&g)R_SVl=P~;Xd|bn%RcaVP2E4uX->mgN^X|g7R`+oN{*l(
+z<Y#!gMym)0{lJKfP!6^Eq8GjBxzBxWW-OkdJ8C(%FijW`=!8-PD9S|hA>B|rmn`Qk
+zU)FigdtNUxV-$1=QrkIsiGqPGXopNEm=G|*6bK-Ahj_WHd3UX+<&`%VAsbbm{`9A7
+z87dVcjDo=k!HPy{2Uv(9ST-rYoN3p*<~1*Jk&CdJ=_+)Ld)(t5FmCaUAD~PJKrBM!
+zuf`+&9n9dI=Dw!7cr6qkws$rc3{{L6jTIaW>eo{tq)-J_$AK$6+>C62`PSg^uGT=<
+z0_e*WW~+-9I_wA<h%~ev2%CaOJhkYneAH0^f~ua3eOD1=QgWO+n)YLO^304=N29L_
+zl#sBZDp5xPr|lHCr-gzlAysM{07{6K=|l@90+1h_4fn>hv2K)UrhsF#6Oxv3B;ID#
+zSzBn&Dj|CepVYh3m97*{(r<zLD06HdVIVY2@(bKfbfOcrk0#`~zi<h2A=818O$QXj
+z8HNBsk==ld3yo{U@?ub+N6GYydqijwg&bM=2138CsnKB+#)4=O@g`9Wtg}U!#-XiE
+zoSfD~iym~*mS`vBZB0o-qQM%XZDGEGUS*<=;+dV+qK=;RtY=Nhaq1|}sc}x!fb_Jd
+zJ*~^WIx1G^zGFOM_b?bsv#*YZ+DQ;*OGE|$(tij+?i8vNH4^zDC#P$$XeSwNdCOZS
+zDyscylCwIrtWYn?C*vm2{DcOHHb!eW*o0#JN3_A{)nO@sU_7v3%Ph_~R?xP?`E1y@
+zhbq_z0D9lEEif{VS6JAHLh1y$#+;1qF|z!~o0NHiLmK2@2QMQpnMei0m|$dqNP3|!
+znQ`hUKO1!v>!zV8Db5JR68776N24QT-KRSRhW4(njyeqEJ~nPh4)BC#Xt`}u@-!~R
+zh+y<d@KHwrP>TBk0Vu-)BDnyN569R#M2lT>{t&y^yZQDBiE2t+5A~9vROq&h)(oBo
+zj?UZroje<vG{F<hr89s|$<8JHmMDQi{z+gYnAn(>6b7XPdQ!!znuSwR4n^37PCHnl
+z@<b;j+SATcbt$n{pffg?xE9}3tU^2l{3p+}ZJDATAvj>LL$?zyDSLq-e`7=svUE(P
+z1H&-$zEp}j%BDzplxau$-cjdg+;@(&-oAI)@s85Ch*bA^Xtm$~&q#F?T>%m7bNUf{
+z#2?K~A`?kQJe(#;jiiMFpkr@hBHB#SK3z9n1x6w{C6N~#M+{ZN6Nuq8Vr@n7(-#NP
+za_t=?II~C>5?hJB>PWd2=+HmZ6U5>paq^>Qh9T!LGs-GCmrGZyHt87bM@Tmkd;`rB
+z>xDs%N(v#{Hj1&4S4C<GHx4%lo6#>%6n&NZI;y^6CPf0`BzCrH$=GFLk;O-8x8~4o
+zREfH#n3MmsXlgJnM=vD`we0w=rIU(lVUP57gD*!7GrSbh0fQ4j*MDSZ14CW~J8L8C
+z0wA<7j5^As>Qtw?C|~MmAW2>96eCF$!*%l!j7XNgI?5DMjGsYyv}%`K_U+Kz2QemL
+z)KOAHcpcgB=J7_7VhDq~pyDsu!A1~Fphr#R&vYp%i4hSNj7?4q?#Gx>BnXI=m|*mA
+zbf9*WN!oH>eBc8g(2=@^s{Km*OBL$}L+IdXLDeuD@oMB%*vcytX%2mah=h{eiE53o
+zIb`Ay#kHy;@tOlFlmSU2%Eu>cLrsu#3<jkvS1JlZStYX|=E6y^3y{PC!aq~Y0V-vb
+zB+BXbW@>%RlxwSGA_EzFQB2o%!GP@og=Fi&5I?agrE6hdC;^?|)g#ZUjXNjP0Y&E$
+zK?a7Df8IhHVW}Bt1;ePL?&H;M-BL$ybDP^JOpC)O`|2p#W05g89BczaauaR$)lsiV
+z=mJkh)mX0MZ7z{e+oL=|<37oS08qQFj~qlZOc>S^iX~ZKFt(?{MulCtgZ}-p_#8dO
+z+a=CDH?088oZv&WEI|ndY1ir|DJFD?$P>Jd98?Th!ZjUix!?}C4oy;z(I?EJb{Mp4
+z!C<DD@`RMa_O}4o*=}M8XGleU-RgxmmE4EBB?#_1t*S2zLi?q@a&pFmZ2RH_hAFEg
+znFW4ToWZOy9BM$?Xa5F+=nc1teQlbcT^QtxBPC&3$qd6ps3o>zi@~rkXo4n-1KSk4
+ziC`=*|F8q1(S>Y1D|l@fMA*1@!7x@EeNWh~U^rPF1+J9j_P39Hb(C~-|LRx2y1fI#
+zC_jC5RLDRvA`%86+8Ah_9pIB($}qT)H`)sawmxW*#Nmo0$UwtVD7J<K-9!T|F48|O
+zSaT$YCIO0UB5e`5T|k!P4kfTU3I+iXIsytBCJmXD8fdq;;IKuvMYIuu$XH#o!%|F#
+zfQAu^K((%3@DOlQ#;oZBP(b@78G(zEN&8icM$Ic*Rd6Be!`T9fW<kJ#s!=JXeK5B>
+zRTx4w9tlnt#gQyKA}I{oaqFNRt?4u)F^ud;&1efKrKW&G;*+5<WPk%(6CoR0$ul`C
+z41yuA2z3-yuv`);z!*6d1FjGxDcO-qQAc4X#m1?lQP^m$d<7bbySuNBdYJ+lI0O!=
+zY%xG{**~R|;USF3K}3s^Q6PGVo&Z54S5efeGB>~Z&EX4PGMCil7|}AJVEq9Qg%g_4
+z2XSO*dlbPP2qKk&2sl!OI!8JiFxav{YdlsP4=IW*AqZ9=#u%h&s7Mba*)hqgXzR&4
+zjbqDnLJ)v=cqFXhLXV`UicI*bLeiOnHen~Tz*v+q5sB`K?^R(&r~%*}^a?!90QhQ*
+zoSl*~Vj0#1F~G87FpEJ&EM`+`Qk&XA3V@QigfUWtEU#H309=s<Wg|$OnaIH)i=IY1
+zLKw`Ah$ME97%qHKM^ABzQ&@l7(ZX<~I?C;4<Jw}FZ9hQJS4Uf0spz4vj>d8%D6uAs
+zgGZrcf&dMm2ke~_BjU0enLcAx5wI3ocOs6*E|WYGd_=TtD6UucNe7~{+ILAD0HDE;
+zBgh`D0yVZ^>7;g!Ee2a5n7!sR5$=avFb9Da>G-5+Du69;PeG#Y)B;9W0JO+BQJxx@
+z9W;J}fiLPMDgr>P##{(Nj9p}^3TqR?kJ)SQZ~!x<S`-H9MYb4<wF#&8I%1JbtkA6)
+zA>hr6!6p11`w~3@!&kAms2Mhta?T>4oQT-Y5QA3IIf}rLggx__&umk;P!fHJI_hLd
+z3oiM{ixt&Tk`(joBuHsnLsYEAP8pY`+!l+T37b?t#vnEolQ8N!vX85w3>*qA1$g=8
+z#p@%se_TrLZ~_y2QK3VD2$JfEx>}ltG87A#G0m($tU(j5MSrN6ixvRWFu);LK%a1g
+zjIm9yg+atzq~6D%y#`^TEl~-bs>Sv<Wgx1G@>l^s4@@!Z6xLnGVug;D5pnz)Kj283
+z<!0F>{|-M~hDHjKWj^DL20*mg4%oy!v}4#vt}tjMTwWd#pz2z13NY*&262ox+L29-
+z!2r-NMbunS8oo+5;EuND77$+o7CT5n%@%`5offBM3BVJOVx-e*Caa^O@KHw(Jn%pp
+z)c20IAX;bMcB2!H9crQVu}aYva4Lcz-Ud|B`bFu$P*907kAA}c0g4|f<W1I7Hqa6n
+zvI+_G+_%V<MHSvKI6{*I697uBxKtPh5n%~IdIAQ5)YW38s;*+%^h=W`$IBrT=bOD|
+zwZ$PxPU%Z83_$M6sz`5y9caQUz?{G$b9Jg~E*GSNU0Y;2a6(S0XcILkErIXY)8+uE
+zSSti|qy?goHHv{Kj1N#{O|8YCHXXcyO$4bJ$}|kp(*UTWn;L@!z*q+?osgDArp9A^
+zENDzvtcrmkW<7HZ+B@Eoz!1Mh?N(c~4y;0xXsHDeeoNwzHMCYPYhp{jua34=)}MF4
+z)u@~sfj%@WAz*7oh){<DLu6CI1%(-yXbD9jLihp=I2E}oahV27orCmN$yAKyPcwwy
+zSc0Izd26yNR%$VbCQ&9LhZp#jpdSCM!Y~*fVy`80!Efnu!JvhW9!TICXBz|o6HS={
+z-53Vxfr#J8<DY@Vz>tV+BN|8r$1nxs0UXsqm>{!dH6%V{ibSoUB~rkm;U0|H^2t<r
+zs6>S37*>G8STxMRc9;=j-gLTX2Y@sa2EHXNCEx5oz@|9<$0)Eb^S~e_MEilEaCvDd
+zS$V2y2SlZgw#PDQvz=lyykxZ*jI(Xfw?x0YJ~|XRf(}Up;*2QC5x6241g458Ia?B`
+z#J5vV9rC0`;&?bY_YTvNfQVnH%FtTDU!ZO0&YdIAu)!cfMi+%6Em%oV(xbDojB5_z
+znAK^}EQ(fx!RVqOpe`wo{^8Ui2NppqgJ3~ZlKX~XgCu7TkpvkOm#juOZSaB4K{X|@
+zBQ}LuXc>2{*~xIcWCf5Mz03HK9Hrg48r`)#t*xa^9GJH)H#xNJ!e+$aNC2V=Jk5?o
+zF~CcC-e@KO!t;zD&I5zMqC2sVz>wyXo#NP};E7pu&=l_|`!W7)TcDWuTBlepSvSNh
+zAMD7dxk>R;1|Jw#hD5X7MulLkTecevqq>uZPyk0%vR0P0WYftL_ef6l@IA|phUp$q
+zFcNE>>U9~P3<@NbxJtB{V|Z1d&A=epm%*Eb@l#EK2os18oR|aNw#tfmMxQCL$T9{{
+z!iy3cTCpy2G61sJ0!AOOfOu)YBGUuz`uFP&9vFJwL~?Kf0IdUdWILjnFpcdUj>lf}
+z4oh?)z%*Hw`#7Rq!+qL?jsimg0v$O`VI=*g$cw0>SgTk(MU=MFFXj#vT7m2o_vXkl
+zoFSPMu4{t*GPFb<28|$(+GrWX9BCLFkw*v#2NR2L53LoQB%?2<age>bQcO!Uj1Jv|
+zMC%~H-KkZV{JpKsmDmJH1Ol8SU`X|?!kr8*r@MCRU6v?hkugi#0|1@sBQG&ejf59r
+zP?$;3L}kjVj;uvS(@|BF0z-9U*gDeCuR`--H9MOT5zr~XM%cVU(8wt##fnR-r<T+I
+zF@LH8ied>OKUyMLlZBlJ1`$6OH}7j;$Pa0$Z*{9%kx>1V!%klRi8|_pcE1dt04%^D
+zjgAtfHSWqzF+w)m8Z8S9xh^|p)Kb?cr-+QgAQqIoH7r7c1yDkV;pa{`x7w7`m8b}!
+zK`%5DAgi8TfJCGS%fQIG<g+dBjX_dV$$d@<P%0u+Of8nFv4LT<Vxr$mk@5G!6n&UB
+zNLAn?(sf}_#wGY@!I;T$h91MsF00!LMEQhJ8Q|LCaRLg(2tgB(v||cEQ!N7X5P##v
+z%?cYc<=hcjQ!vylg1VjQ(<o3EhN+`U4}9PQRWV4Kwm5IjsajjiijAp}Ols2!!Au_j
+zZJ*ik52GCG765YJ*-9q1*a0mRS<)O(b%<(C7z9J%B&sGDLPt^BxJ;>|;|efpP$Lhj
+zk=Fs^PGLArbkc^lZwj=<5YNcH&en$r(Nc6vh@f8~Yzdm^hpZ&h0hKCK1k++6dr@R;
+zN21@du=L9!h^K;ohWNl0Yiwe9x<mZ-5q@<SjnqmKYJ`-o>1lfRRI$Qfcu4wnA8-&q
+zWmtKF*e<X%s~41@y6L2^nn*hr`5>{s2x6(En1SiY3Iu&M{ZtGRGZAx1a+#FNEUaIb
+zRtB?bo7$uRG(ih%E(y>CfSh>zFqWMn2MYq|Xqaljv9Qn5DQjCZKMW!sswNo1K2SKs
+z5-!T<Bl0lhN=$N=J8&6Q-E1@Nv(6I22n@;Awt&1NG{i)`VZo3Qc_cN2JUBzdNB9Rc
+zf)^pYmVj%=TUrW9hn$p8aw)acqRNEoYGq$=eyS<P2uhGhLeVp6-JF(%4sK6{s|sEk
+z=Zvjf5rYLo)e$z-M~uP?B%*=p#dafm#cCog`f3Ga+?SSSyi2$z<uWVaX<NSXOZ9f4
+zIEAZ<JDr>LsBNm&b5mrpQ05gSBnk|!QfHjT0gxZhrp#Lo!l1+&jYb-QNDS$kRZg?2
+z1T4(Ag4mifIa69N1WBZh=9!{QB>FkRCYX@A-LHM`>~+ynmNyhtzwOgb#ay-p)Y6ge
+zBAa+iAcB@Ie$6NEx5c0nr1nvH)E?&s*ou{KjDVqK6xZP7hg@~FY2VXV+iyz@j7myr
+z$F79*%)O@HHc~U{%%Y~>sijy|X@}8PADK^sokyLfHpQhWn2RmL`Y0H*6dH&ajqon@
+zUTl|Rjh~R6+e*Lykl>iBJs1Gy7qJx#iKN!BD*jA$%sUio24E_7V8{?dv~+T0jGj?7
+zPDNn|wHHN=-0lvAw3j2xcW$P9HYmZnV9ExOhV=7}M$Klom5~&IEp-%#4BKfImRGG6
+zyI9Ho;6o2Vy*b97)d=5st+}vcRaCw+=Kf_n>o(sn*}2meUNPUPyNNC>W-WMB7X}Lx
+zKnNAXWCe&s03a)vBQz>#07$iCDK89zkmyuWPO{~6mad~8QV}JJC;}7zqK>W;gQ|C6
+z=#uV-FCl(B3a4V!;94Wec(%Kb_G*t}s)HeE=x|5@sxr)W094+uu|*WJ>=+l2$YWC_
+zVKA~x`|W^3>gf@aF-J($uV2R`RQKY%mQ$>)IONy70$FY9eS{!`J?GvjV22)hsBnV-
+zfy1{BX>f$H0SkZv0bVp%BnH6{XAs)UR|>h~T0u$CO2~lNT0aK+Fk}^q7voNN6eA12
+zLY7hItYL?e*SsD5iY+K~2M(lgq+369$Z*JD3PfONXI0_qhtL*-DcK)+^%!{yalq&o
+z9<f0KNP+%PhdXOq0UMF!rFCGiOdj5H#sVSe<PSd#n&(n>B8at>009XIfDVDMmEs|p
+zt52o{nmi5ppo0!VOPnyBN7#k?0=P55U>}Bj<4)`0QRQ01yGBZrwe7{YS_O(|ERjvj
+zLmDPa!5IdLo0^uwXiZ_ifuYScNJzvn>}-|9R3|{GZA3ej>i)Q)4)@ov0+!b{#nzy)
+zQ2ViZ44);)eDL;kqJj2TcngIW0I6qgE*^t$$2t?$H5e|47KU8tbWx%?Z#>Nei5;cX
+z7eTEL=OliGYqjd=8Ww;0Dj|NGRkDdpOtO8j85OiJ(l4)AQZbE`88?PbQ|;xrD#QJ?
+ztw1n{mP!tCVv~bnPk1aRJUJ*LpTig}08#kv!XVs<!o#4DeTzYP7;&GEbS3~yBOMrW
+znNmmbD+(Uog|MyRWO`oP)^utW3Uns{T~aRVY1OJbDbW7bqbfWhv#P=q+8G{=TLD{x
+zF}C&~?;nlJVRZptCxyi3VrO*#xO*`e7oQWPTqP|G9Ug!|!TK3uP*WWk3iJz7EK&~E
+z_7x%~WKwuSfqGQUt}{~&wwZOdxqYe!gS49X+<4E#WQCu2KOzeKJqT1?0OXn|@}89(
+zWP7$ankLUPAJHsI$UVzKOv=d?=V91KHO`r2Ixu7o!{B1<!45UHbiUwxJCc!IBd3w~
+z-E8X)`E~^?j&-9@QAhdPdEGf2c;KDHb3%p}q6MJyfh|4H3WE-xctLC$=(S}CYX?LP
+zub-H%?Ko$Z@4(RKZY&ywFof5x>Rj_h<od0&teNf_Or<K>X6k7tQ)N2$>#_<|CXaMY
+zmFlOgj51YTX09u<NgKB;R>=Yqg<NNBoJ4_Xq(~QeJK;>GNKOcMh<R2RB*>iKa164A
+z*fe?W5#Cw{$-IdsdL=~;a?3bH+!^gmE;}&f{IPVQvBeNT`m$xAe9Tke;8^d>@_z{>
+zcw}sWNxxPqwj~t~kYzmW7br}n%^HAi=>ymi>o`f?9rx3IXBdlFs7=&M?T&@AXwgXX
+z#spV3N_IK|0QpOy(tFS?CC>_j4!3xJhcC!W`qMzKUq<w~{*FwnR}R}g(`X03=DfJ1
+zV*pZ41$dWaVHoUe7COf^1t~-T+vJXY1P2A6paqvpH$6&4C1p}_8Ns^%)fT9x6aY-E
+zNir^BO?6#U%N;WoGfk4m%&Aq{Z-)WA3tOvAgh4~Cowcym-@4^<1c_77Kf#c%!zC-M
+zh2ab_C~hU%#SY~Q>O*XrJ6>NEM#*`${4IO$);UPCW~_~@$SF!oH_p5x@1=g?zydB{
+z$2;2u8YtgRF&`YRroC|0N-{2;jR6NJfRP|E=yU0&M+&GYrKF}n$<_x@RUlt#(u)EG
+zsDRWZpsB7$hZel9>-0|2F~=O^j=^X@bu$d$9bh<;RI<5#ky8u99JxntPM*;2L@0vF
+zg5eA?2s@4e7@oHzyevEo==x;@QvyRr+H#x#4831A5>0Ek34lV779?LHCA&jWBUg2{
+zHw%EsxcDUEN9}@@&VqW^FNsUdHXU`;Q9uDfL{hLr9?1X~gsO$(IgcU9xC~wZDwtAN
+z3snHJ6mU2vP=!;?!WRlrOz)17JGwwqvMGM$-7ykl)3|Z!SMNqXz;GO4On{*kc1CyS
+z&YiS7r$+6s%fN897(~)`$_Sl~7KQIaY??d1bt9k&(S98%XU}@?)u#m4fVj2_H6Q@Y
+z+%-#ZFARXzBpZZD5@%$Jg^Invd&XoiD!j{SJxdoc?Z6C3a<7H{p(f%Flz<LEs5HJ9
+zgP+J~#I`yI3wi;y0$N~hE5JtZeRTyqjf4el=+lnZF;v&Pe!W`aTz!(fJNT8l8iz#X
+z2}H7+1{=-6jK)#pw!Pnnp^eMAL?LNA>t$*%Bxr1h<rO2FEd~L{Co;1BwvtzN8qoF2
+zh-v0%Hw!VJ?)0ux$?g_eQ|1AXFhyw+I0GP&UCXr?f=PD~g7$?Biu>A-td;Y7lm}|O
+zgnc>Y1dr&SB!Vf0i7l{&psMBMr()g(mT?x{GAc~)VY#GOnoR)*Htaq~dIYB$)QH0F
+zsOadpMto*Lzs?v-Mj~(fRQFUFk`WAX17eg3S)y<;OSidt$wp)EQA#bB?WUYqb{x-M
+z`*s%X4p_htqw`tFnVePQlhLNc$U-MsG_=u)zxUxb?v7XL(jZWK?H6jmu>V)prokWp
+z!X0sdEQvx*(a9GKKntQr`w|SIWb}-xp#avbk^rl>mJVA=j&1WWqyN0+0WX%643daW
+z8wZ=#7Fg7hK*psB5_Uu<u|@pZYd8`x5+jCd!Qwy(^f2U<A?#q^Q}6PpsrpsXO^+Z^
+z<CczKMMcIyh_iPVsX}Zn3}&yh-GLz^!j9WSYCnRv-M)A2qe)Ij+f7@;PDGaLJhNRG
+zWM_#oP<66y+Q(zZ0d4Yqr|bel`g8sYvyW5=f=q+EDg%IGm*|t+cRG%5N^6S;VC_rE
+zK}$pxBwt{V4Dvz*{lu`nU*=0A)Bw}>0n$ScJrsyQl@KfpQb8dUOvHn{8Jfa$c$-LU
+z!I$}xeSi$tzMnv=_sJUC1#??1t-%yz0k6hEUhjUL-K8FIqzlgaY@@^^r#snG3JFBx
+z2KYIvkUBl6qmwy9Xe?Zp_8#klK95OahL+vyON=bXx$PIRI9m*A&BocR3=#$r%w)KY
+ze2P?zFfc@xUZ&8p^D{(kL2PoS07w%Pf&@U+n8lgAfb)2oevz&nVO0SX>&%Y8i#hf`
+zervLAqLVuTg_n|^<RIqe&Cq;5xh*E|>saOsVlapwnsuju)AHVEBSzs4#*-K(oiBxU
+zYPocPP%sw~2a|9b3Mm-IP0F0F?SlyKG}$RHf%*a`nP_=uC<n854#+V@GgK_pUpE*D
+zw8=NQ3+f}K6i6?hY8<I}{d_X|JZ0+oZVU=XkPZtG_s-4kE&y7Gc1PF<c7!NI&uq7G
+zhlR3|^-EE;qzpRJld9SN#k4Au44Fv0D&M(Zmm)r1tFh@Q0Up~=D_5Cu8NzYE;4~Pl
+zO{e@=G5Q0+WXA~?T8j1eEicLj7|ufuX8U+zar=xG*VXT2#EpE)XIL<Vto+q8A0zeY
+z=?O3dK*l2gvU#14W%ClLyAgm{gbaWvq|31pa-xYv;425Q%Eytt`##l3lTpPl)6BeV
+zqVHn$tJqeCA%%ynH}c!OB%@C&5Py!%Q&8*c*3}fM!0zb(BxX#NdL%;?F${FI+t+hS
+zAne{^Rw-5?brc)~iLg*619jBl5SG!Imi|JYg`KS&q*>)dnqEO-$Yc>5p~1aJ0&Vh5
+z<`3&NN-2XS-)BZ1<K8g@KxQKVI*;llWlV<Av=Im<V<;N|W3(w89UwzvXAk<&feDuO
+z=xYOx4>9@x3TDOTNKeij?oH+`h}kv9V150bZiClBr~(#^z6z%}Sk4^<N6bui9|EAt
+zl7RWtY98sAF^D<)Y$-LBEvajT-SPPae;R{6Z1F8-qJ$e^Np~;4rs>@(*>UP<OhVgD
+z^8p0zFFerhQ17$jv&En@pFEI(ArxSn87+sv+F%G!^{rqKBNUL0U#DC;($J|qp9oN%
+z(~lsgY5NOPp%%Z>EZUsPWDK?gSB!FEQ>+YEXY6#C!lt+)OD6Ir0Uh+wWF(Z&%gv@B
+zI!%yG!Q$h+%n4fy0<)rr%tjdG8m0ehO_{u^8K7Af*n~3v8Q)kS@^YWN!vWwf(4)tK
+zzmrRT-2rXNE$;yv)|dwjPERC-LHkG^h2`1>800Qv4Ay7iXO2P8V06UTbWECWHp902
+z1~6IhjeN?iD;Q!O<RId~mL2;n7z(@7QPC%)^9x}DEF)we`k#K?W?r%Y2z^*$0L3#C
+z3<?%-RKgTe=c{ZnXx%^+%}X{h7!(AIYZSh0W%P5aA@F328H_-k24N7cTMU8{qktS_
+z3F2S@pkMa8KZ0PnBpI<G2qgi@P5LVG0Cua&meISB47%u)MAE?^CWe)P0C`jx%#P0k
+zgMne}O=niI^bDJxLrWY9w8=LaK}@G8rOxE!kB;#T@=oXrFuj!zfLwwkf_NfXk5qO$
+z23r6^9|DFxXaYdGDEm&#4rGWY805cdF^F@5p~4i`RH2JT4w9PyXfX?ebWRd5!FOvV
+z4h5uOh#3~vsI>?HFbTL8n^j<%3_=<(xLGg=8tjO`(Ax^AC?jWRAd<<58~GF~E*Sdr
+zTXCmT#-Pt708+q^A^<XYxgQA~x?fP>cgl5}ZLx4dL<@k>2UDQu=nKCnKrzxCpJ3lb
+z4z?I{v_JvH6y{P>%P-v(&|ntCn0u7QicpCBa$$*F&>4d0#MxV;&r>i|7kDwoX%N>h
+zV@S2Cvt6sL*IITT9Yz;jyc~o<$ty^Kp&%V1%sL~UwZV{>%Sko@kz0nF4v~-r(1(oo
+z-+zBL4sQdBB|E5areC6P@i5e*gkk|ORyl*tM$j0!sU@l%BOPkEWjeYjn>uB3zzq5%
+z+9pW{M<V+ywKhs9YG83B>p-UkKnf2~JEvDT;{Tyf5{2Yrj_uW>DKnOuUpGs-^&m6z
+z8QFbnwc9ZWhQ8Dk6$>7bVrJ@dH)wC9yqkOzxfTo=fN?DNGKRAUBp@d$!bYwXxjqbM
+zzQ~gs%oY%Wgfa<8u7MR0F$yFS&@bV|Oe32*J{dYBC+AYZ&#NLj4~)(`xoO>?3?E}t
+z#8C`Ej<`dy1YgicQ>BYqs}^fyDD#uYhE>SBRk-siB^OYV6O5`zGGh0>F~ZMW-dg%h
+zY50@pK0LJo8wZ16NC*ao%n))p8^rTQ4V#R(kx!jtEEqaD1A53w`_9G?uQ_APNeG4{
+zFKJk0V@(!D8~T#M25}w{cA6&yQ3%bNJ_!rS6J7)s;1FJA4`N)jYa&l!#efll7=z@d
+zIl|hZOEJFsP_RXC)D83`O#vWWGrjW`nDwEJSQAnhqIq@nRmkGM;)LNbtE3TFCQ{)Y
+z7z?dpD1#z8JqZ;7>|R|I0F#8D67$93$%RaWgKljwM6}MH#YN*xV?rTpBGM!<bRe@}
+zNEKW>43{8ytRl)5riBvFk$S|CM4#k!6tU%Cfe7{;2owe#@9~IbrzAmXQe0;sj48Q<
+z!HygR6PR*3$O>2-5)c3tE1)^=M;0?G14Fnb)CydTYk!d>vRHLP(z~u(b5bmlaXKiX
+zYrtSE5vBxlfGvQ<B|a!NksY6tUvwFK|NnoEjoEib3h|V=7z~C#Qr=CziPdAvfg!Ca
+zR;R-u^fa&Ikr!Y{{qy1vX}EY8wix6V#t;Y~3<s=?kYg%Zw6kg`pOXZpq{5(>4lEEx
+z3PWp7#fZ7UP7FFNP$bGHQ)qIqld>UHiZ!)oX*iQ{W88p5=8q*(p{&Gcs{7g`EmTmR
+zt!=ZSU{uRIT>+q}O;3m0xuk`nHsqyIJ_?EuvgBGU3_66lU<^WI!O&jAMK(xSYHctS
+z>M9s&Fw^mEDAY@dYGH^GEf|J{LEMG_LiP+m%z+|p3(6exK8WKef(0BbQXLP2O=6L7
+zRG2q7K=73JiS7!vd@|J0J_ZXiZAK`EDT){jhM7!Dk5`tqIb{ppjv2JjRq+!9fMrp@
+z5S}%!^P;xT&Z2p~3xBg<@fZX{XE;M?oB#zwuj(*TCJVliPf3tcN-0ih*&!LE9vJdt
+zpf~Zj1;em|L2e=#q*CG!kmar9!iWQ44zAD#q{5)MIk5<y3OkBWh2a!%=&s&5k}5t}
+z0<=n2hMq~}L68)ZAP|XWoSBA<Q~BCS74ByUN8(uB%xG0~xNQq(t>O)cN6u2$YcDnq
+z!8>-cyD$ib6s-^&QslYKPKhZ{v_=AL@=aP<NkgvJSU~8CQvwWW;9zJ477W9}AU=cO
+z@d3IhA4|gPEe82R*u|WjQelwV34^9a)>9)38p=eHVm=<#SvBWmh)DWpt6oAV{4xMb
+zhYV-7<^&?9l+Zu1NZs`p=yDD)eOX2tg`+acRP}9(sZ~w90Epv7@xbovLe3>xYCFpn
+zK)vBc+bwbs1_Q%@#XAlKL&rPU21B}B!I1MOE%P}bcx2D1NE0g<QppzJqN$D09aV%k
+z0~_>07IT0o1eSu8?XW2nOQ|sEFBC@+<yUbEs0uU6Y$DGm01{7mrOQ)q3xX27Fn-O{
+zlv$t_mi#INWk`MtiTDE|Ar|3LQrC%7k`dQ3W~<azUlkp0+rqW)Q8}zC=8ps0eZg6~
+z&yPWw!FcI!Jo&p3gJ9^zihxBB%7C+L-mF2WlLg<%r$kA?kh&Y9bx?<gkSBykQG5*$
+zm}W>W#F^!q6SdS{=*va`NI0R81gDC~X2A-t;44nbf_TJ@DNIi`2@N=VP=#r&7z<!Z
+zGWGHcxd}A@1@d|flWEac)6Bs9dK&FiVO1)*4D?1;uXcva$Q8))T0rZG($JfeMQ9IK
+zq?OTO81fWRFHQJV3%9`T#b66VVLm&aNnsIdgCQAFwjrNJ=oTe2pv2>70-VE4W5NQh
+zhDx(yBNuc1H$&$-(w$CqZ2-c2BAAC9a!A2yRT*a+KzLVdV=0v!WIyV~zPFNV!tC-W
+zzgE7J+NbMZhwalst!Fkpt{9t+_IMr9A?<~*K;Z)10u$WVyB&jI$bS;%?*)03ko{tY
+ztPO^a{TB?0hLE?&1%f4j&_Dkqkwh?&7e%gfB9ht>&|sLe3dIFDXZWa1d{xk^!Zy*$
+z@Tv*Em*VOv-8C~R_)IgYD%{UZQ++7YS%EAgy0RC9ptzXr76xKrafkAxF`5`$yfK6z
+z8enB)6BiaA)al5CenMmZ4okt%%kT8(k!t7Uo3z=2Ax}kG_Ff_JK>)FI=my}>io(uH
+z&hWA}1q}6wF;Y%20b5Y8T2+QJ!?Gy$QgyMilI$}a|IpN`R={>6U>i~K2wEun+Odip
+zFC-&qq4nqKsY4qCgMe8?B|2;(nYfo6*9JrHzSUv20}eO<p%S&;n4^($PDT{QDzsvO
+z$*PumRfV%JwKb3!4#{VNNlr)#u;r8F4VzZOq?P*Llc9SrU@ohg_;xECLdr(h31LEz
+z0_I=_51ZH%$|NB2=jpxi%HzFpFbIY`;o<7Q(!y}E)EoB{w<#Fr?|_3L6PPH(nwVxp
+z5@tnhSO5lVcXWqIO2lHDs4kV-`<3_9XzeU5+Q|932}GwX>?51PyqNj(p2&8?)N1Ej
+zyKL9OX0c6{AXf}eIHxx)R6N3&K-6y6D54@q8w!I4#=#yK;tyt&MWB?91KQ;K^|B!_
+z`YWhfX8%$H=yKH2^2{uTbkj?16K=WMRNxIBK~lzcyRWIm%wn}<xvk3A=Gqjj5}%~E
+zaECg$n|K5-2iHB$34lIlcdDfnf}gED=o1z~y?gGtr-%bsttyEX=Gdo!IklJ_L|}Nx
+zWVnrdN{=nW(A@J4G3{Fl3f{s@!j=wOB(5P}uq98WTvj`6M?-$`D^M838-v02fT+V2
+zqzMrK5&iE;&K85gwO>c1rvD_bfeBl84hd7VvXUI~BT=^EO)kXx%Z4(0@4dHydC7u*
+zm~Uh;Zkd@7Lji4EW+uH1jjU${`WTEuCWo|xLB2RIx*|fBk+?8dVUl<;x!|bSiX=U<
+zKz-|;kWGWc88NFP=l0#1MihEcGypV0(duJIcJRSIQej!vj6nkiLle*I6*9iSX<*)2
+zU?XoL46cVZhPsPcfx=*`i{@n|Q3-6H0wzor0M<9kLYaQyh|x3>Vk_P(3|4D0?9IT?
+zJKED=FsB@;i(WYDH0W|Y7&Ly4Dc@7g@L0rq?X{P6@H=2|F~qq|dTBApCzF#=d0EDx
+zCN#_^;{{K&Cm3f<7)nl+)O*u14j--vw~++^oSd!X^doN%f_FegcTU}}h(Rw<_(ZM3
+z&XXG({5p`_j!k%FWY^Q*6qSI!z!0eQ<&;-2n5Ek$bTUkHek;&okO$i_Q4uA_Lh>z2
+zdKZka&d{D03JhbNl4UaSdl?6{d!cU{3<97N$ob@gjIjaW<o4J0)Tz<H5Q_)~xfVGU
+z2Mo@SEVo<BXo;f?QDN^K?;^Qg77z|gjNVDn@c&?NZ7=IhN&F=2lo)g%ncLP;I&Xi&
+zMKI`;^^_g0wwU$}tT4!b#k)9QaJwO8e)A12A*#4WsiQ)KM4_{4d0&Q`vE*RBOtM-U
+zp0d1GGp4~H06M?}fLtXxG8zne;dIK5R$Gj|-C~gKjB8o9`EAP3^0r!mV6YX1IjHY+
+z78sI-G_l2CP&jWz4ANA+2M2)8?FcF6OQG||Ajr2EtmyW(qLX2=b6o*2gu#eHo*5x9
+z8mVACY3Sf6cW7bIeMe|kD@Ud&5AR};NIkEL3)c62GG2?LZ~~zBhy~4^QuBGt(nY;>
+zySA4mRvcaoRX!hm@ySF84svj=G`ZaxZ$%-8gJ3-vl7<cj3m0;YqCJOLjyU27E91oq
+zfq>a2Cscupq6<X%be{LxAg+a>OGj7%(BJxTc+7V#oafnZzx|BO2f=ugjEyBb+kt5f
+za}cayASXt{0v#05?FNv=%(nwW(vW`!+#r!CjQi2YnFGT)4GH{tJ7LOsR3DFWY_(wM
+ztA<{r0zk&8r#}DU?Q*9#ohQ#XLcMK-UCe1<j_~Qxz$AZSJ8LzkzJ_ME^9r;u<e%Xt
+z&0%{o5gY<T2St3;t`dzg$yb0X`Cib-<lXH`G`dP8OOmD#c@BgNh|q*dI_Q&lhX63I
+zO$i_Zg|`5331bs3alB1Me?_zgHrq`8T9Yn(&uReRcE-rO=N{_v8{3fQ0TRh3U?dhH
+zA}~aX^GmEeZx7{zV9vtPQHehvIs-t*&%l$l2z@-08JL)+vH3s>(9LgDX_;a?0C3(!
+zIJ9pC`bY#uG%xw?7A(v*Ifx>OgLCyzbj2UZIG=9Fhf}<n>kSStlo5t-JR3v6B8p4Y
+z*m#g;H85jHa#l@Z4@&$t0{{nrENle|hB6`e{x2u$+EO)D)q|rFxKV)VnSr5G+4-O!
+z?Npf+$5zd*Hd6y@Gi`VB3)_OBqhSTCK!^P1cNv-onSe10Ft|ze?FC<q@pOJ;nB4L}
+z55o#<kQJCrsOx{)f)V0^N@k!WpY}&C#rnJMv@o)l;pVUcTX+RJ5C|A^Gb*M07M}hv
+zwP6J|$O?3jSeF}Qc*8J;6&O}vSb<>$h7}lAU|4}+1%?$ER$y3xVFiX27*=3dfnf!P
+U6&O}vSb<>$h7}lAV9hJ=fA@dRng9R*
+
+literal 0
+HcmV?d00001
+
+diff --git a/nsis/icons/uninstall.bmp b/nsis/icons/uninstall.bmp
+new file mode 100644
+index 0000000000000000000000000000000000000000..223d6a45df3d1c2c32974742928111e13f10888f
+GIT binary patch
+literal 618006
+zcmeF)cib&YSuc1@sAS<7hzC#<Q4|G^0R$yV77l`N!GKu|sF=oxj5(mppy;TeVk9Yo
+zs0b(^c&`#ADH$B{j3aZsbN_R`XaCq`S=FoG)oZOc>^@bW&tAK`-|h;}^ZcGv)zx>n
+z*T;S9M_=Kxa*2O8_3w*6<O)}K<cD723LkQXPq^&z72f(SAAN<_UG)m*{++wv=YNhe
+zC@?6nA`1MMb7e&X8bcWr7!>%Q1J^?c1_jnffr0Dw@pO!6P+;JC$iSe$`Y14Py*{3f
+z5e*6qTn`x-6j&bx2Cmn~(=nn!fr0BG1A_wVqrkxR`gl4<G$=4|J!D`|V0{!AxLzMm
+z$A|_62Cjz;3<|7|0t46U<LMaDpuoWOkbyyg^-*BpdVM?{BN`MKxE?YvD6l>X3|y~|
+zr(;Be0t44W1_lMzM}dLs_3?C!Xi#9_ddR?_!1^dKaJ@dBju8zC3|tQx7!+6^1qQCy
+z$I~&QL4kqmAp?T~>!ZNH_4;@^Ml>iea6M#TP+)x&7`R>^PsfM`1qQB%3=9gaj{*bN
+z>*MJd(V)P<^^k!<f%Q>f;Cg*L9U~eP7`PrXFetD-3JhGYkEdfqg8~EBLk0!~)<=PX
+z>-F(;jA&3`;CjfwpuqYlFmSy-o{kX>3JhEi85k5;9|Z=k*T>T_qCtUy>mdV!0_&r|
+z!1elgIz}`oFmOF&U{GLv6d1T(A5X`K1_cJLhYSn~td9Z%*X!fy7}21>!1a)UL4oyA
+zVBmUvJRKt%6d1T3GB7BxJ_-z6uaBo=M1ukY*Fy#d1=dG_f$R10bc|?FVBmVlz@WhT
+zC@^rnKAw&d4GIig4;dH~SRVxjuGh!YF`_|%f$Jdyg97WLz`*tTcsfQjC@^q6WMEKW
+zeH0kDULQ}#hz11)u7?Z^3apO;1J~>0=@`+Vz`*s8fkA=wQDESDeLNi_8Wb3~9x^Z}
+zus#Y5T(6I(V?=`j1J^?a1_jnffr0Dw@pO!6P+;JC$iSe$`Y14Py*{3f5e*6qTn`x-
+z6j&bx2Cmn~(=nn!fr0BG1A_wVqrkxR`gl4<G$=4|J!D`|V0{!AxLzMm$A|_62Cjz;
+z3<|7|0t46U<LMaDpuoWOkbyyg^-*BpdVM?{BN`MKxE?YvD6l>X3|y~|r(;Be0t44W
+z1_lMzM}dLs_3?C!Xi#9_ddR?_!1^dKaJ@dBju8zC3|tQx7!+6^1qQCy$I~&QL4kqm
+zAp?T~>!ZNH_4;@^Ml>iea6M#TP+)x&7`R>^PsfM`1qQB%3=9gaj{*bN>*MJd(V)P<
+z^^k!<f%Q>f;Cg*L9U~eP7`PrXFetD-3JhGYkEdfqg8~EBLk0!~)<=PX>-F(;jA&3`
+z;CjfwpuqYlFmSy-o{kX>3JhEi85k5;9|Z=k*T>T_qCtUy>mdV!0_&r|!1elgIz}`o
+zFmOF&U{GLv6d1T(A5X`K1_cJLhYW-Q|KIsC2(khS3|yaOCZ31dvj4Xk(V`l+sc_tL
+zrYJCQeWuuv&NQI=AKR7YDW{V|t8Y89;`-*v<H;t*#Z#xi!1bxKpzc7yPC?wi{oB9&
+z_jBd{-CS~mUpME$QjdewUth^RN7kHbOP!voE9sBxfsEtRrNF@T>C(TnUSJZ?1yi8>
+zumAe5|IfMdFaPo{|M$7_f1NKm_3KY=ai`*uO#s(KsoZTJ_`nC;@4=>8)z@{pEp--{
+zLwZVT>+xO&H4aXT0t45lMfuWhkLbV|T0!i6?|a{S-}~Nozx&<qde^(&`ObI#pIvd?
+zU*Ged_qgr-?|(l?f@;7BeSuzsXmBo-r)IVO^ZDXfL#kD$)*F~#raR7+G*KX58Y;u-
+z56Y0o!EsYy;QF{JJYRniez;%|gJ{?UD2M~Gx4-@EZ++`q-~8q`zv)eHdczyu@K68r
+zPycwnI9A^H#y9$t8{YP|x4q*X?|?@D2gaZ~wj03v%Hh}}9#n&R&e!^njx|*3bQ_o#
+z)uCew1)>QhY6Q>&@S;fqbH8PP&A~ib#$WfOz`*sM1l;HGh<YFZchC_;!zMUG9DKd*
+zb+7w}fB1)2yy6uvd)dqW{_p?(@BZ%Z{##X?zVxLpefi5@{>oRr^3|_?HEhBov_c|u
+zt1XC&x`1?egi!ETIsCrnHLvlYnp5q6Jy%q(As7A04eE^Qc*|SfLc^$B-xPSKc8XaK
+zz#FICpp<#19TE1S;dpkE0t45RWI2J01=PeI?tqT@13Hj_&DX#F^{;x>tKjP;FL}ue
+zU--i3KmYlE`ImqBoaa2}&;R_-|LlBm{1<=m7cM^UdC&Xnzy9mL`J2B1Ng9AEPy^g?
+zq}9pgj@J$8kO<MBs&ZI<@rz&V!RJ2rx#~Gz>z}E%t`pX&4%LD=4MTeX`)gnOT0Nv0
+zGz9P3Dt>~tjHMKcMX8<k+NL)~d|>=gf;Vt|C`vA>rw29X7U*CE=pYC}U+{t#!1AB|
+z>7V||pZv+wpZ@fxKJ}@8_=kV^2Y>Jfzh4zsp8Vt|KkaEx`{O_UV|T)%rvMiEAdX$8
+zDAWwm@c~#~e{us|k;*-onoF&kP^XLj^sHw+3*HONRqnwTz34?0!r%Vw->QeJph5tr
+zE@&jJXi;-@DSmq(59aik5>vj(V_!tiadSg~f$N4KCvzHH7fVg@nLJ2j3V{WD7)@{n
+zuHXB;-}~*~{_Q6|@rl3j8^7^uzxHeY$A2!a{Q9r|`V*e;gx~tD-*P8_L-$|()nBPZ
+zRe?5jq4H=9W)~zO`kBvsW-9lf$LpF)oxk~;zxkvmJxR5+hnrRYM}PE3z^-E+*AOeu
+zkx(InUeL`^FQxeHG)$a!csJO15p4Q47(W?~tgMxR>yu|_G1d$g*)E{w<uZbtYN%l`
+zVG5Ri^;duOSAOMJe)*Sw`Imm_mmc@H$NleJaou0t<7STl;Ip6oY*tl(%vFw`?3Z)y
+z3RBDevi`sOyT1$0ltf**`V|$Xq*^z)4cHY;C{ZK7^E<x-?_jP%&OCRW(x6N<q+P#!
+zbzoN-r=3}!!T4nX`G237h(CEYUC=EKT%SDq;F|MEdRZ%$i;%+|Pz$Abylf)Sfe%2z
+z7aad@=Szp_|F{qgLL7IRJ*6CY^6KQ(E8xbYaswFIr#$5;Y&58P1d3Bd4QGw!x@I5y
+z*vJ0jFaF{${K79h<}r`?`E$jAQ-AU}q(_semf_Zaeu9P+tveO+E5&K2Sab=@OJH7O
+zJd<>Mbz~{|H-u863H_ctvo6pU2d+<;aS_pY;Bv^KQ64g*#!_=@`MSJrpaU-0fhouW
+zJ*Pn~u(RMX;y>{dKk=hK`lCPeLqGJtoGU;6<3IlR$3H%}mI?za22{<U1ZV*@H-L9t
+zG=`c}trq$7=dAH>xcI%_`@LWLwO{)+U-LB&d)UJqeAjn<*Z+F1Xijmc>7V`CpVdPT
+zGTd~Lz=8kI9{^-+Q7o>&dkPoA=v?$CFo*gE<2?5G>PZO1QID5S0S;&{mC}Lhr4-xq
+zez+#3WHlZ*gT-rQ=ES_v0n|VTFKnU$)DZ0o%g7cx2DH!loX@%b^{@XCAMp`am?|Ik
+zVITG}AM-Jv@fn|S|NGzn`@jGD!Cd8Wzq#lEHRNg{HN&z-1<?%geeQFgkNwz>ovQT;
+zs=e`zZ~Vny{Kb!a<RgFJ2Y%pDk9rhn>!H3e+0+r_f-Pt>+`JA6H{L!+UCoMaBuFp0
+zIGQII*FDKM%7^Q2UQhl_c+Q6jz%x}>Jo9M9Jy~#hc>HpU>qtodd#p@Pb8syiOk!n^
+zdEl(7_>}X^@PP>|$Kz$JL61QM#vlIS9|qMA{m>7c1l|0_Py4h_`>CJ$DM|wX8TtZh
+zHFL<pjivtF&;8u_O3Gj9lUv^MmMr-9ec$)p>Q=Y9>s{~q;0HhW+rRzWc?&8BaOj3{
+z&B3zz=?zLrTM5r40CfY>c@FLYe`ehy5&|3y^Lpk2;;3_Dr2C+o?T+CtR{L0aw2sOz
+zSGev`JagqZ_^Y`XYl13W##l2_JaDNevrB{@sDJL~e(q;}=4U_~03n58z3pvpTVS=@
+z!PT#Rb><$jC<+w{pVb^Y%l=;Z%2!@m?MHpoM}6Msect3#+PdBCZf7iTO(Qu-Ag^7;
+zptSCa4uCx1yNx69jAuN9$Ij4GaR4rG5J3pT*>2h|(5@Zw<KWJk>byMQx&bd_r3i8r
+z(xT)z*US9}XLP}}><~-D=VYEpGVc@w$h@HSCx7xMfBL6?8m?jR(T{%gHLrQiN%$<i
+z_~l>z<)ZI^i&vmIw)LC7>6@0;v*rEQxz2THDjo>%#t9LXM`alu#pReAZ^-^i;Q%-z
+zE~keSap|F(e=g}K^hPW0jbs`&;Sn+(oHZ+}aK*ST@C=%Q*`SyktdJ9Svy_s9Ey9x;
+z4#n}*rW=|jr9w#IB+rwP;taE2uq<f(u^;;}zr>!eyMra&ggdD)AmZEmg(IN*)^GjR
+zO*bFpI=dWi{7b*|OF!}>KT@53Z+OES-r){+kR=dV7%3%Yq=`5HJi$I{K({=bw16Om
+z)#lik_?D5tzTg@$C;1X0H@}m2uKVIDab2^O7{n+SAQKO;;@X*5;S86uDF=Hf0Z6ZO
+zh62&F^lzMS{wJ3h3Pi!O%~DcKn=JR$u6DH<eDQ=o`IA5SHn+LW=YRg^i;ge3<dRSS
+z^iTizkN@}&|L_m*pSr;fZou{B<U^1H#+oyrhW<`h<i{TR(1*&o{ooJ&;3FRKi2L2|
+zexLPOpA}$E-oNQ0)gc*3Sxw#`PS?<#?|kQnKm6eaE^Eh^h<`2y=bVGK#|0@Ia<O(y
+zHYWDCuGu|*d?;3){d!i0>zb`Kq8VkbFXTe8RntN?<`S|Pf-H_IlPnPDPS88jG%RIq
+z!L`olhIUOWGf6ULBpKq^FIEhi{NCgyH<^UPMHgN4kcT{kK^M0&@oXG~GQq*DU&sFX
+zJ>T;^-|!9J@Sq1hNCw-1o86`f#Us?n&2N75zW&er%+F*cb&uXdB|VhFf-H_PRbbj{
+zQ?|UX>I=W{3#GW_x=oYye{HVNFq9GnLYW8_xD$FP=$3XsAEAouqBmKv53VW3n#<)F
+zyHngym-CnZV-nmWOL=#}-M=PW*DS`_7--fxaHjBK8IVP_mPrfTm`idCTz*Y9xyUZK
+zhszgetAtdf+Wk43dZ-J)(S)#(<eTf^tjb8UYmBuiBzb0zYa{ti3IA7o#aATh6f84v
+zLR5aNaFs&~&VC&Syb@*5p@1X}0PmSNgKG+;uU{Svp>z-3qIsmF`M|K5NP%+DNwaMI
+zv$=BjyWjm@_qvz)HMc>cg2F%YBR{g~{>kgS6ut)?VvKNYHoV3)eTylD(K!fm)AKN0
+z|5HkA<*zk255?2{rQ(=sSPiZVi?J`*38LAZz?qnlQV=F57DdzxqNHe?3g!IOZRD9f
+z^*A9p4qU4luIUiCmNYZZ%R+%C4;-kO+Us5KdX3C~^hba6cYMcpB<q!5;N`n|iW6&&
+zNruhiGy}|nHWY&)M9W73I4lR(f&3lsc*myxPx_=!qGuxfp&q{_xGot074ipQmThew
+z&#80)G#MRpkAN&}bl1-L{Ez#%kGtnR?@3=_5Eo0eI8x)fMzp4B<3w0mR}6usa>aFj
+zjSqG?LH7!9U9>kYlS!<v5e+^Jap27KSnLE!7DY6xp@ed#P|2`68FW%aBnX2F1MU6w
+zYWf+}H1@j2^;dn>SM{ioxCUp~WW^L#+cA(rne;L&12ykm0c}VR>X~m|{kMF}w{YD7
+zguM=~dv}^{F<7Ki$bU2s--a7w;WxV};AQmFqPDJh#Va<Q{E!d%5b!ZNB{hH*XeZ}S
+z^RU7@1nH#})At6eV@1<C08$;+^JtQ|WYm$Kr#RLJ*AW~;J)U7U=-!{XXRU?{9oG%0
+z!(vQiqam7smUS^1O5uYue^Qc4LPqQ+>1txdN^HN5Im4uvSIm@i(Mg3$hyf`rg0v^^
+zYFx7>qE~$rKkAP>FrfuW3qqxmiZJIueoR7%&1ErZ0KX6lT;KVf-zl+t>7|!?gnMlL
+ziEJ|)ch#$2b#es@Z~>-gVX$t3Ga$VXu{Y#k1Od4&UengYXFl_p{CR!gA?PQSLQB*&
+zIJU?Q#DW(@a}4HaXqZV4BCkp$`Gx#9y3vg+U~6jF=JZRx<V&z4C9UW%V$#D{Mu+ej
+z%3CMe#Y$IP*9{}$ywNruiS153;me-PJ!_Az1J@XY%Ro&yDQ7HZqXo_oEkLuJDR8#N
+z36SeWP(ccRwNJpt@go35x9`cj$dB6elXU4M!J}}jxzZ&rF0;$Lf@dS)aBXGRr+(_E
+z^3SdMn8a-J$mFT4lvcj`yT7~nt7RlQW4vIf#OlEU*F|_j8B&8Z4~N0@y5c}CuBk*P
+zqXY567~vXx)TU<j7$z1_p|q37b%Tb{lj~mhx=lStp5kfPjWtw|CKzSC1!r2wUpW|>
+z<Cyt%?25=s9{`-HcQbTHiRoneygq1O(6|mea5+*0EQAy9XlcPRwg%A_V1RAl%$byN
+zjVsHWbwJXjt(X$Gu_;N^PzwZrA%MX{vA*stxne%J6M!QkAn>dqkD3*>_WMZL-t7j?
+z08Cl)**q?7j$*8{aF|_7<ieK_wpi@Vov?r$p~UhWd!1B?s+vknw;>cnD-L3>AxNF7
+zLRCgT3uT#ml;?Pu2)o8LuF=%f_!7-uo$?<vk@|s}r-4~A6(}i^5>H_w9YS0Bb?gdP
+zjW7VXo}jrdan3Q9M^OxSxZ`(E?R`cbzi@F~U_y#w0Ta#9%)(?IHJ<XWL54XdMes{F
+z2^FzaB3<!s86zSG*Cup|D^9{$E*7C-{XUG-=V&1kMFoKp{R2CirdxQ(T;=1#wbZon
+z^4=S;m|y~7Mvd4jFd`U<RxGR5x!>|vCe}e4^`z;VO74B{d&61^iZRx77mj3%kVQXG
+zt&}Rt>jtJU*-a%kyV=cX7|i<0ul!20+s$8{x~Ouk#2El;R#?wjXZWQ$xE6FcZl*ZS
+z8a5c0RH0s=n}q0<XJfb<)x8dAUnsZ^iksi~WB3vg;*9aV>1}2ji$%=@iI9*b1|o>A
+z;SA~iDqYMT!PK{X+qapcVRs<QLJpI;{>mZ{A%et4r1kxAO%X*bsSX_`lcbIu>L;6c
+ze7Ke;7k5axH+V797&WGl<kM^jNGnRFabr+PSWV&ZB^2m}Yq_|l66rpJN=bxHaTy@@
+zI5TDNMSnsxUZ~S}zwYb4uBn83kDDp*3*+u2qM!ZQpUq>ZIz%o-jVA*D)cVZlp&Qky
+ziA?KzP%&Othyj4R0i6xajJ&59Zr#&K!lOkjCQkdacpvdN;In5O*A0;C(|{WHNfE=!
+zd!&bfnp*Y}0W*!EI7^Be>kO^_#9sL8H-Gatf6*6xk;NX3faO$f2iCav_)eVm=X?53
+zMd)^1aps0`By2!rb&B4S;mOWyc~SH&2EX{?iyMd5`mQKC$ZFQ4NmIiwdrBE9Y%~Y}
+z0umWMOAXXA?dI04f^&?X{Y=>-ANfe0t-=TbiztS>3p*SV?lG?zN1)6Ac}-Zr3Gd$=
+z(L;1rkVrxBl+ewwivU<S&b#1O05vlWykU2Ocg}zVYFu-!Yte8F$}rupOAI$HL2Nh`
+zNv3I66KU&!5IdEs&MdAQ2#3Gtxc$K&T)^Uzbd6mA5TKSE!$$&KY_wxS#Wdr-zmn1~
+z_<}F!Cu@4_Jm3KjAf@rfHM~F5)nF_-&$Mv{2tReif)F-oJqkz4x9>)-fU0F1Ua9z$
+zPx+Kv-tv~Wzy0kk1>s}xS{YC|H<Ao5tdapXm3V{+CjZ1+I=cC*5F2HnTj9MRR4`aT
+zE$7D2Ya;XG{lazE8Borx5%F>%+PHw4H)0K&c4;kKpc4R1{RVrLt6Zh-1}zF=1zEKK
+z<T!MrV`&c!vF1DhYMe?8s8!DI;$8TKYo{p%-ASbI9FQox!09A6FVH@e_C6ILH;tZ6
+zTo;~VB{T)XP|VDgf(xL5#Y}_DiFbblam)?70MvvhJY^uLYj`2C)HMTr?Q37V7N_}R
+zz>(37H?A9zx`u{}PBS!vGLRC1atryugpI*66V!AGoFP}jiuE)WzW`!f1_;Osxpf^_
+zJgyS>?L82{*MtNDslM-h@7pwCstYhxqNpGBRGUOuSp^qd^TXxOo5!8%L*Oj3FdWv9
+zvf|RySF#+4uV(kCR_DP`UcIS=rkVjYy7_C2HBAeQT48o^oT8?MR1VGxvgp52Adz)z
+zUNbTG%?q+T#yq~v0L_L_9%KbLc%aQ{$05fQtl6K-i$vl$Za!<c?h%dD@XKOCK`A)}
+z>adtU#x4+A`~qQYrLGm66>Z@ouyZ4Mr;RMlpK@r~0^%BzO{j|C?aYe|P(3l((M!DX
+z_^TPhwXSuorepHP1Tvbc{w2(DMIeO*1Zu`nilBMi8dNhrR3B(VJq^%rw<4~mI#j5B
+zq+|8O<4_FO+;8?;;RetNjfbDM5E-Jy6oE6yKs4;I)IeQur)B^b2=~ixc=91mL))5S
+z#aMICK++r>HDx$aM3hF<xGRG9O)t(611oY-OvE8+$>?*)#o8hW?qAL2G(Fj?rjuvw
+z^i1Kpa4=#YM8h(330d5{6kd~4F|`Bi;EzdwCqyM(<eczCZxbQzAGu<78&RJ><?GrB
+z#N&jA2=V$7Wgp5FH&Rs*p~Mkff`p<;0ePLO@1A$HEHQ;UqDzboQ};^P$R@&(FqYNp
+zpJk`&CcvRz{o*OPDW10agKjirRRitB*WTus1hr==KwMxzRjwQQL&w4|i0NmnKL-G7
+zXj;KS-%n5V2+9?|L;|_!^JsF$nln(+_31FOAc#gSed&qNT(OYGDn5;>hf>YVW}QpX
+zVrjiUIBP&|`g3-09nv9Y1fFINqG1_$8BLTY{7jo;j+2XiU9=hj9GEIbnanUZqCzr>
+z%i<|gYRN>y)Bco2vqoADjV71%g&Nv`xnbZq17gO5yW$xs-9=Ve3b->gV`1;K+dI<w
+zECRjT-R>rHmAs!G0ti4EyG)m!_hGN6*n0LTO@v%*H$+S}A*CiK2HnXjqaI2!+03++
+zY(3q|6&ZD00BVUTy%MDBBt%1;8kl~oTm1sK>ux~s@~i{7JM4}O5YZY(2&EMFCXsb*
+ztT7AI18Op`%^PH;X%lBu0h-4f&&*~5Z7mYTl=LCLb>A8^ot@J&g6jfm#3bshSbS{Y
+zC5mXCkWJLa(<A(@Fw+X(j~~TYGZ2h5<^nalK$c?B=6!D~rRjDaAgg3@mH;b`Jx(V8
+z3qOs;XS+3_SGtF}db=kFoAH7+y&+LRWf__=8pzDLGVX*R_bzw2i>V(8z)$#uPbh-g
+z9{?9Y?VEtvO~zLxaA#Gj0{%0%r8zg?0>ekcaEyT(SkOOantP9=CcasJjdFmUHvKe;
+z5Vl55aD?V8b@V)AjYK7~W}4|Abt(=hIx;Y++?wX<QzI3l6_ZWy&`Rj1MTImfI-ux@
+z0_hFF_Y{WXc>FBj`bZ%+mmwzxS(2a9nCt?V4|A=c5HpIb#f-c@K^!-aQBZ`3cx^*~
+znuFz-99mFq9i#gx0j5OOh?(YXDgf>xIKaD=5_w8u9J?|1Ah^cLX4Fw-i7XgyPJ-6;
+zv-Ekl1Dgu!Flp5DURzqJGNV1VZ;?wt7jeSn2L#k`jTclC^$5$zn}uplQC0Sm)HRhu
+z)(oQcoQDk594Ed<jJ1Y1`LqX@K$eX9b;Wp_nzuaVki;>=0=^A&D;iZe5(@6?Mvxwi
+zpJjBPI<6b>M!m)<Wid$$?~e84b8;Z1hL{G<By?jj$cvJwZp>w@iI75^zU<4sY?7z^
+zZGmdZ4uLR(!ntLsgKJ(WE;Hrz<0i#eiUZ=hhBgzRW;TNS7{1Vh0CQA~qEB$uy_!Fk
+z1CJK+n<j{*Cin&=x<RqsUcsoF=FQTvyjhADgSgr3CIhPfR{Kb#JD@^g&~=`b1a<wm
+zV-FTw*S#eVkQJH;yLf062#zPRF2<S~;enHoK38Vdjf^6-&q?4F%+S+cL0c<gqEfj1
+z{3zstcV0TuAz%RBqx(24?{0OTBCZ=g@^%WSlSC5RW|joY$OGl<H%kk|asEn>7;ARi
+zoHg%`fncdw-gwkKi^-4K;pAB0I)%KI+%LSF6u#1xuGC0fPE~$bT-VSh%&aOR1l{C^
+zAQ37y$kg*>e`YRPFXzERVF&8(n_vM6Ev@LKl9}3?KlNV3t#5s6h~vugtg@aHlw_of
+z#t=T+p@pVJL%43hWg^?a(_5V^S`MN?Ne`pt5~0M~hto`aU?O!vHjKC5v5ikIYKtB-
+zHOAIcAhL)}bYBMO{TjwXrc`lriesarX4N1t)E~WK&50{LNhIQ#r~kXb@Ze9K3a%S@
+zD||$Mk{nQT>I7@V1D2D1fkzy~O+57{cAP^F-2^GYwHsJ!W|w<8neX*>Au(_p4WKI3
+zra1K?!zGto(k#R(?9PE34vy;rZ8Rw&9dyT3p$S0}BlMGBP4{vt^fn>Irl_z;OCflg
+zC<;UqG2fannI)Q@tg~E%M|!WHVVBK|F%=w9wpb&|-h>@<<)y+LNEGN;I_UtBDL25O
+z*&td}B8wv6QnM&5Qjt|I;&%+iM3FV!ZtP9XVj0j=8x;{Z9zu0eCH-o*JZrN!P9Sek
+zbJUdLz!kY259$f|1aN|?Le;X}_=Tip2sPyk3r_gpgmGO97&<5j5<VgkZ-=kTqXSqW
+zGf>mR!eqW8S6NAb#^vUQQM@cQmyhiZuCbV}#g`VW^@~r~6k?z@V!&-vGZU}asFSPK
+z+n`25oI*Vb(dUCRu8_rn`YF1QB{HeecrxNvs;LPObWDtFKQs%^*enmGwqB4*D}58{
+z502=}d{V?TP$&SNrnXVf>>KjZhvJlmI5sg(>_FzRPY#W$Z0?ykRc-nfc}TDT)N}=l
+z$qj%kzBlI$csXo%ryGQUVBjfl+(k@pn&2c5r$R{@jGg6Rv%KKRpNIO%^n%?Qi688j
+zqG{$MxgDe91JDo9O&?OcsHe{wifkB5Py7?Ua$>lyg(~bT1ShwlIVT4n(G6xn73i=}
+z{44miDuZ_o+JNagXiH>a99DWOS!C@ZLrg;09Wh<QVh*9}gbkvpdXFpECopX8oIl0T
+z@a{O+R7m7ND@p(!LeYMu5LZbCQYZ632gW*=$7lLh?kP<aE)Y&)j|C)_ZGxj`o?E;J
+zHOWRIJ{-}C{hOWuLcAf-<4OAI*d$~o$t##j#|+sRSwI1GdIEi1GJ~bb=^R|v9|}BK
+z5njE%$-OfH{d?=QO+4f{grFDo2#g3AjX^o|%ZWvB?1kvhN;buTQyvJJM00k8Gf7Hm
+zFoV@kbi;x(1?`i;b>SMu6+wy_LJ%T>G8~&2>*Tj_%1jdu5+|VMh;p#G*{+bQVof3^
+zVmCOY1f*Ws>q{@aw2>dn2q^@hCKzySu~TpLnnxy2Dea7920MHHDfO4%%iz7al-m~d
+zs(wn{5&MEB0?+L<QfVkb5USSx5*qds#P||Ef($Db$S~_o96d?WYhLr3`j9TAC(y^m
+zEyBQ7%9r9V{L;)iqd7`mp~eAImn2o1$~j=5N7&SvLSw`eh}8y3z%)|NHY&)ehA5DP
+zX$~|k03<vx&MBht(1%8)c0}L&3LQRE&^~Tl7ZJj{f@qB6_0h?w!GD8jN)I2AC~F;Q
+zd$>kPCYVk}d7y@Fn4R1Y6BE%K7pQR>K)Ba%nfvOmWWa>)HuIad65<cs=}vcQ>XB4g
+zgrI#eUPyQ3!OpFuW~?bzQat<GbMK)rkp!3yB;oRk650TT9eiLfi8N#(_TedR!nGO*
+zJm;B_wWdp$Gn2TG$t>LfK(Q)-sE4;q7>e5fyj*Td9-N5*rNIFs5;%^ty;MlB=n^0s
+z8o^7+Fxe3zr+)D=Bf|dL6SAcE3{AS;NbABV&~F;j4HRI+DLuAZ_lSh?o;7G6E3RvP
+zA#5BWhz4hbMG9C(UO|}x)MgpT12ssf_&iiJGBVJFii#HZnI~-|DyJMLLWtm4&uN$2
+zX>Nm1d6JrU%?;($sw(+X@=Pc9)89I5P&?!3tUXv5gge|P0#CsfdyNJ1QLGhc<APuK
+zWw7YRLarPLdx5CN3s6g3XUPHKcK{|hXfM;oI8wIhhTjI)gh2|<6ep#vbsC;}7e`Bp
+zD5lQ<oQFn}H+AY2yTC3duN8CyHKoBV(N9r!!VUFPKEiWOpn%Q_9}8TGkn!p;IBQpN
+zpt#~#&_^tJGU5V4q6UsZpshu8(29Y?2{|o}A0MuZ%orn*mLM9UsdQ9@Vkr^4qm~^|
+zo;gjDMB;*6k)l{_bBmi&TkJ2TO|<BNnCzvi!6TfX_=%rrY6jP^j5gK*R=XBpUZqhO
+z*J&~9INCLwxKf0l%EcWz7E>~vL|cM3g^3Huf*nxi4XK(ej;UhuOsbiCYJmxZW&SgZ
+zrZ`Yr5q=6BPC4^8z3ELoi|-MY^n|FWisq+6$%A@u*8MO=w*#`(L|)1h(VLWnalRbc
+zX!;}8CSVMQxPV*80l+u|j1a1v1SUNj&(Hwz9hTXJXfT2l_ggT?Qd<dNNdwm+#cN_j
+z&QlZuwE)_g9itT~4XVQ^g6q?gmSe(oIAv%7wUH*>iqr^>mAFh8a7~U8(;a6jfka8#
+zm}QWf5W<*RB}<bZrwA)S4-4E$eq=V-S$fr5jSZt`PN{m)H#s3Ws=_R)9;o}-9L`?G
+zbsYFQtvWLzY>ERMnP+`42zStd+|qJ<7<1y%8cIKbMHRqK!Hc;e&TSqP8Z&AbL|xP5
+z02QMa$tMpwVC?AzfpML*xW}K|PcU$n#%3s)X3NR4x_~n0O?~~>e?6<+C%#y4K=XL=
+zS~^Dj^iV0r+6}x2wj&W7?#D)x0a$jCv#owU`DB)WmGPR489J)K0MUx*YK|t+79GL`
+z3bap!v&Vt!!lMFe#7q*>`~rHyEWX1mRjgo~Q)y4KL`74i($0)Hq`Pw-qyjgZme?=~
+z1WDeKWuet)fL#70o$duClie6f8(=84kjZhi^{++1euj1`oI0jP3$p-<IU|$d6lfDv
+z2&Hw|$3nFJfP@D!^5KjurHz$ww`fR(i5FO@s>gLrPsf0ecuhCB$}Bq>zza;l9no|%
+z_pRxET3<#K&`ha_ok<b@fif{Dx<W|?AjX>DF}Q*Y+>Z>f(GaaU$%IXxQfeq5xD(5p
+zf~0~}t1W7T%W=9U`&e-uQ3<HU(MC;aBRH~SHzkaQ+`PmolqWL{(YSe8y!}uAgd>FH
+z$WN}@{R4w)XtTLurH20XsTZpSiS&O|G)GIsq%(S@Dm|QBw7}gWd&h*YQ>-?Cs+BO|
+zXD+b-x^cwhbxpnIm<4B^K$|?nwfjjpFoH7=iYHHX)7!Dvss*mvQ!N7z#*62W)EV7E
+zFjNA4c0X&Ho;)Se(8>_gEtC>FViY<?Q9w6W*|_+GG1h{Mc;NBY$bhyuCw;&^*;cv8
+zXV5)bh&!sGQ#aWM$91?<D_#r=yXjAQn_~vc*aS_SD|#4h5!0W-dKy5OhB$sb*w3mI
+zVwM976tPJmKa>V>df)>eSpHfcSg&Hp61>sRNpjKy$#9Yc-SD<%{YZ|z_H{Nv9fD8(
+z7RbyW)GXtTv)a;4&=(XiKz%@6(}!L2RN`x}1tQ{22hxx{C<Rre#3eH=grk1xc}?_g
+zYUu`ZklJvcV&~!lDIWEk8`s^)G3!ZPbEL@_q0$G?hGI5CZMx@|+d$Ivia{ZVgb=8q
+zo3}=Cw$vVd)2`g-KKJ1vB-W^Pm!ZwG;NX8fCR|7P7hZ>wK$j^|G?WFE<(7P~u7Iti
+zV9}YY#!*KWs^Bu8>73WZGba@xqrA7N=YF{$?TR}%$Zsc6s^S+}b=(l&ZTGmxJ+!C;
+z^a-9~CAR@LX#*lBE}MMISTu)UC(oTt><$DL{cfr%*HcxrF<7y`c$a7t7XV~3#teD+
+zHgU`tDQPz`CNKgHJR&LQhrO<Io;HXuhlu`t_^BJ|Lqcql5L`3;lt1+K`z1CkcFI@h
+z7?UoXWkh%m42pVKQYOPMi6SRB?grgZEkB$P%H+t!)m`l?Kk^D{5EUvB^{6{Q$S`|m
+z&2wbWzaAFXwRn&XYTp34J-jJ!!(UnyB?T{56qtxKp@9C3CJIxn5}sxmm{eN?fHuky
+z6;YcSU{H94O)w}T?q{rIbu__JaOU}ej?J7-azR9923G6%NY5x>uEl;gzdVl7x@Ty6
+zlKLQz_u^4#PJT++blXfH>UtPcP$ia_$hJZmlA5LRS_D)!7-yv1Urcr!T`?Cci5&`F
+z_l%JBN{e-uTrmW-X_P(*uBmI1!$Za<I{6#F@f-D_udum7LVO&YbQP1$kpODHIwo67
+zSENq3W)%1XleQq$3hTc5tG}9$r<gjYmuC9Fb|f(#w<ORmtZ`6tryl+Rj}M6J(%Zrs
+z9+v@ffnbe)3zCvrD3jF%j3cNzrY$+fP14&Uz(^Em$CIaWu{dhBpF%}{-Z%x~HU;m9
+z;`~l2<g?cgjd(b<{=v`=Nb}vQD&#E(wWv5IKPk=ia(_A4)PZtCYET=9rGUATW7jEL
+zL}rU6Dj8+>`%|K9coai%cWGm+S0+FEYra@>O;21&Rkgjwbk020%B058B1LkTO%APR
+zT&|exU`NOUS5WH4uk@^tjg8=~u_<uvmp{<2w^4)1I7)yhvNDF2KqGFvxL{KnM~iOe
+z^H6t%ZlRuE1T@S-?S=>kIo%)ErF%KhVcj+stTA;cMn*{vHs4rQ3P+I90t4pK8Uuxm
+zM$dlg1lK$shmd|CDkOyRrytaV#SC=AN^Ul-o3vXrGm&Hco7=WORiQ}1xDG<<eJbgR
+zjLso-kroGy2t|H!XH&zb&NR2>+2*&o$7y<^^*|fH0H05eYZQCWDJ%e04>sLMRR&UU
+zEepqIW^*YJ(2G?i0OGjq`RGnb0Fp)&6}YC6_-SejuA?scz|9t>9L^Bd(D<KB3}-(6
+zC(S^f`TTuPRK=FLpF;4U;vmIw*mSJu-Uru(zlHC*8ZnDk2AHwe@CahEAMwL^Q_M6c
+z+^V50PUtCPX&H5g6j&USUFfMEEM`U<hfpQ-CrQv~3P(<OHNQ<z-*m2E4M)9~y+#yI
+z;Iz;=2cdRIO+u77%;&`CgFi77{)8O`-Az67J#TKFJWUOySLu?baV;?vfHRamg=LT3
+z;K8O3t{9y@tAX$^jxsZh0w!X*G?xNR7L#lfX!q?>@)Wf$vDa{2>@{5Xb9ux@A3{LC
+zh?#s5p(0}?I-nUQleG5EGJL~S2(aT6#}RCVQmye8+BVeK=X5t*m!3q%bWgcV!p_SW
+zzUaJx(AfMjnFLyw$wo}jW^GyRP5bO&2SZ7_h63sduDNzH9<nisw$Rh!pPqL{l(ZYB
+z@P!<|_O-8_yt98cS2*W_DV|0zc>9ogw`U8f9W;mzoTK_ssV<bE>p&iW<IW_yck5FB
+zROw_;S;RmGbc0rhCSkZ&JVIeB#3pH*G3u?SB0T&qFvN7wX0;XBR{>ogK*`%!N@VhS
+z6I;u5FPtX6W*s0pez>5x+>ir#b^X6gvd<NRiVI5H$R3!Z=W-BcHCUPg#m(c=GO$kq
+zP5&|aab1`j$F3M1ex?4fCN%76yW5o=aNRR8?2BB{P7cm#sSobAL%(sMaVIa_K_#DR
+zGC&SxEH&Y%d#b<_9ikujKPBS<*PJnnKO1_|3GPWZ(i83w%^<03ed){#2<kDfEw0zq
+z!xDKn)_AIr+Cc;ALi3md1B^MyuhUSVpgY2uO6qEN?pyO<sk83q2O)7@s}Nw3DUB^d
+z)jXclRN^+H(|-bxX(^twYzdgK4r(yJ+%WwXx41=gxclYGj@)4;Ga&IE;ac9Tf6bE-
+z3G|{H(<P!vGUXO(dkxoI(B3UHWhNM*2a<<pUjTuo(n<2HsyOO2#=)Vz6xX3V-suUh
+z87w8HdyJ!gimLpgu+s>bV+tzJMkq`Hy8e@nHJi*dxkns?8jL0t=hrcpOw2-EL#W6I
+zFA&qxvb=>|*8sodIqYa`2dYxAa;i4ZxA_mXpis8bIJ|CS$p9y%?u0L<Cxzf>j^G)N
+z(M4q;ax4M}C`g@yaKT@(#+^a8XVq|g&_<uS&yLfU-{$%zN|wRuDqiS6TtERtfD*5d
+z2w7)h+OcN0V-wcykBUPOawyLxI&N+&r{stCSQeXswkg!|R|gi`fS#&Cz);(1>`U#*
+zlS8<c`?YAiuEDXy0?8+G{C1C!UPb?n#YK3>EE*VhjQ6n6UWDsHc74zj{Xt2CB~GA+
+z{wX?a_-N}-#TgDZF$j11_oNzv-0NQVq5&`wx~aIZl{;tlN<JI_<H^G{j<B%J<4y%-
+zWLQ5-aaxyLKUN{%B)!{QuYr(G>O7iLq#-+bK;ERMs6I3&LMe`2fe2#b9_YX(V((cs
+zsK?kFtZmb!?eD2O-y9!ViTm|UC-oMZ$Pei<BBDjN`-P*1-QW{wl)xk~G-?LIHZqNq
+zX8RYil+>9JJFa+R9n=}<X`PZ(5EE7P0Z2IyVtj6==~og6*Str8K%ej-hfqwIg%V7X
+zqFs(F4}@$Rj{1)S+S}tg3_^2K5m4(7xk7Uhv`*?jBpNjs8a^WUE1`0mUjl|Q&~4qq
+zWD2oimaH05SW$o`h{FMsc>`*hlcX^bQ$bHrQlD`(o7RYK1jfbwdWLqS$eq{?=}#fJ
+z4i`|zDxoJygWRZ7)Fy-`0_Z@+F(Q*0tcik!j@X?OgZ9p}Dx)sYjs_z<DZR5N2YZgI
+zAM_zZD<TT!iUX9f;6zH?B#Q+SAejK!8w%DLvJrGeGi&C3A{Lg5NVZW@L1eTg;iM5f
+zrSD9C!!k)z9Pki&SKK`yOp;{=r2gcW{5qDnBiOp3TF}N&oYmD@<?c*F4{nL;LhXQB
+zAM`|jj2DW9y@8&fgDNu+1kquFN1~`r`csL!?kVs@w*XmsK^7%1>D17cV?ihsNbv}o
+zu+%^uVgfbihr;Ad@uKTz9ZPR+!f%b5eMomq&(__GxE4@{hS8AJCgNv~7`5Z3Vgz@{
+zF@eFC$fP^b+*1IehBFTBGW=*Wz+{Vcn-rz6k2SCDwdjWWsSwRCSygiCAc_JJh$YoW
+zN?8g*#V(Mjem+#V$E>(5RE;A|!jqgQoD>2H1Zrx*gqPX3esae>@JkPXGwB6$#eq{Z
+zw(7^M<AC-yxDL@mC@LkOMjZViKf2957Oez;Ms4hZ2+EB_5hqMRdE%rvMp%m1ZC--2
+zVu3G>AYOc~nU!Np@?<s;P;tOzLL~+oXA#pccDQcgkW@+YxD`R^_A#OFn5r%E=^z4G
+zgF2QANE6hcF#3}^vWE+Vgi=-LSbnDKd?)v?-3+&<nD{^&JMdA>5&OE)V;a|@YD<42
+za-qOE+k4p$5wcc4?56xd#{KFqPfZ>a>Ge376tEy2S`k|AG*nu?(uk1tivFs8wv~kQ
+zp9wAd0`H`bK>_Dl4kd(1Y*UF0A=Y?MrY;JE&=O<lRu9zZL!b>%2ejHp;yP3cSwdB<
+z^X^EC{^*r~8xd@>o1A1QqlkzWBZ7LtwFe_eehC%nB4*SAuZ9vpEACKFSR|5*Ks{Ji
+z90bvbNl)gLI{H=z`jiE~OV1aH)2ZKF3*-!_6ZkO4s0Y7Tz|A9jtPfHsj$LuxUzu-=
+zV7T!D*LrBDp}Of)r$Y_WbT8s}nf3j*587Wq11=+)>}@@qa;y?6f^p$D5<fJd`UK#n
+zs~AwTt_>swcf^ullQ9Jhi8m7ykFf?d!1^oj_KQo;rON)RKdFcIAh!&e83EI3zQknx
+zhM+*Wjg<g(Kxoh7Iy4DYYfz(!p6CyS6ZNIf3N57nw46WDhXvOGb?OPUqZ|Z2Y)vv4
+zFk77SLSdOt%W+M6nE<sm&%_o`!#ItHt*DJ+qNM&o>Qv_^nSM4e7V&d{P)cv9@f}GK
+zA5_UC<q5ywj0<!l`J`0oSjRCmgq9KKK;i|@liz+JLc69+bG$t(^B}4cKMtqxkTc1d
+zA%4^#y2+k3=`}(qB}=LSnXl-VP_eeeuXv1}avk0goMaZc&4G;<;_y?p?6su5d#tp)
+zR`nfZ3v4j%;Lx7Ibs+@-3#d_pV2~?TAglYJ*pLl2R#negZDV9CVkUTu@%k>4)N>`Z
+ziIvz6QcC2=9<AlUhd=z`4P~5)S?qOVkpO6msZkQCDbhqJoG9td<|)xSS6~0P=liMO
+zStPbli3FC&h1(NQlM@sZ=AdxGA5uZT5iJB{cj7fswg8T*gqF;ZUOqW3x(V8`gQX8=
+zigb0a%JB~T%CkmFn2Y$y_cEz03vw}_jUYj~G~H#+;xAw3F0!_@$4Kmfngp^ec+qdi
+zWd0Ob=vBHGN1%hT?pJP@eAoJ6p}h&$Ap#jg2LdK4iG>ZQInTgrM7nCQ-r8VH=^|#7
+zToEUz_xg{en9^b<8Yl!+sk2lF?4?2jM;1DhxxeI+OB&ibz3+YRE9Z$OD9Ps`!%Pxy
+z-&R+XI~kgu*47TJKdnbX?a&8_Hd*R`8c4|iQN#ku4K=tfv@3PTpx_8$6V_n_yc0Rb
+z0z3HR;-((jR0sZQv4Qq!k>dE;4Ut1$qXuotpJicy5QhRpz5YD~^IvuV0OwKwoN;k;
+z@lHu^zg&&nVhWZ~!f?%AdjwK|y_ayiEs_5NLVF(90d*2(#Zm{<#6~|EP)@RVA-IEU
+zVn#LTXWjW^r;$`ioh8a<L1MBwlb)p<dZ=17XyLaR3c5~*y@D-sa?wQ>)lHOR%UUq&
+z0>bqUpe82(i_ZKO!h`G#N~{U-a~xA57$i;%Ivt2>M?yOcD*ZV=h@Do=8Jc0zW0Al>
+zTe1TBkmwPQctjDTa=<oO;zGhv6{%@Xh$jE0x(KafyJ?l1%YjV;WJ1&|Z{{{e(BsUX
+zCi+FNp0ePLmfi&I^n81|P2#!?pC*rCm1hvwi>c#&2h_;`<jt&~IKM+XtKox{Wpp{P
+zt}ikJ)JPg_8Q&7Fi^8O`7#e#&Hji(A%5h?z^nZH_obH_=wcpTZ#!_>nW2p_0y8^Jx
+zG#P_p%8<aA6rf`j$5_Lx#HP@epe+$mpe?T4<d9!}pdHzkL(3WrhLw0rS!~*Oiz$b0
+zs1y%EH;X3gB>@iglk&-H3S{I!&>ypK3XkBWcg0hK1(0+FXeUDsbTZ5UsH^xAQQ1;l
+zH{n`60ic1?X~ZDeZ$36TAx>mT%<Dx<D>)S*Fmd8$Tzv7x{V=_D0nr82yn3FwZZoXt
+zNn)82!{=D0a&N@<l^l7+(gJE>#h|8C18QjvBPCr4f|wG^cnFO5+5ILRfgNnOS%X9_
+zBDeu<pr{ooyc83|9VO(<D+*7_@R8zI-@rDhtvI4dhGPe<%L3xjrlnbS3=lm@o&bd!
+zKo0<Q5*P#RopGIktHh`?*~gubUdS{Y-;W|9PI{<&5G`NrmB}3Ulluk>Zd8!k6g>>6
+zWr1{?;h-+KK=h>KEqBGBXg12w)MQPlBah`CQDgO>ruhj8-w$BP3EM$VqFph<e%cCl
+zxRSkSsNW<d_<`J^0qq9bF<wa@0g)uR=~vQNw%$5Y@cJ99ohVB?XbB>XU%0@D!Y{yK
+zwH<7-+T2}M8{GJ@pvSG%J=j@fvU__C8pT*=qB%Leq_%)g56w3**05~P6VSFXk@@1u
+zSLD21MFMpUq62E_GL{;s=?WP$G~^$u90k~Gvd78i%v(aX$-`+V$@i8h<4s+zKn<|O
+zgK0*5ShkHe7NqbG?GT7B7(|MaZ=?hyC>Zep?H<}t!`+ohBb)?@?UrEdzv9#gUVlnr
+z0SX@D(i3SRGsr{<V?-uug-Af;Vjr=lPM?DW1nA(+vVdR+JBv*A46coow``&c0HKdD
+zWhoeIVS?@v7|>=ch?cx`JtbGh3)Ex}ijfP^pj!{ojr+~v5iN2orGWVM5G@hJ7$w1*
+zl{xd<U~0t_7<s047P%-}dNRj%TRfuZ&#2Ji$)Hct4kbbfl}Jdj)I<WP(I4f3*KR!E
+zY+oQVGQKnA*Rd-o6F-WV?#}GqW&!hnb~syeArYeaFESq~CHVvu^p1Sxvq-!7R`IDR
+zU_m8QMSrr?!leRgT!Wn?Js7Xa#CWL<zaXNRY`N=VvbT}UO}JKx0cMJstIv^6@C(=E
+zio&7)^^*$X{!RMKK+T#9F_>o1Ca%!!moiK~L7m1f?&I6j7>ZnwUqj}%2p(yVkDuD1
+z&h`|#VPVD&dTbk-9N#@fmi7lVTMV|qOR2)Le9pI?FOC7+CIbvN?)bHIst8PhwuDA9
+z<TGhB0$<#}bpH5=b1F3#ju>Xp9UU8h$AS}hu1^21Rv{@VwJ6%mV?0l@4-%UsIpzsW
+zNHU}VHAj?qv&GwN^l`%*-cX(31BSp@aIMcr(&|WDt2Vf1RRPe{iHQ}kN@21mL2bws
+z4pqR=gSK!3oW(ByE@U7`Vrss(;Y*ZpR8T;1p#Ge~HPt~r>4!qV9C%|Is1tfD)ni8z
+z<oIqVBIJM+DLku4QEbGFrADR1XoQ5Nu0bte0ceRDt9nu#yW%>-4dXHo4FLzVYc5an
+zC9J_6M*Lg^`LDRcWtEu(887(r(!Jf_OY7#cT_@^<nUNA2N2J;1WHp7-$zi$z)NZrE
+zX2X$9r!si5Mmz@^MrUZA^tSH*<ncVNjRkx-1EP4ULzi?Lx)nYKtGx-->8B;%1=?)1
+zs`6eTC!D2FA+H;dc`sC=0?Ur+G!$@3hS6j)%<*v_x`LuuI^IbloWR9N;n@?^EOI~%
+z&R$ZGWUxVpU&pRMHzP8c$;6!j?S|<!gB(Zk`i&8<H88i6krMebE(|n#2NcqhB$@6d
+zy&P}QFgGLu5~y0;0oRN*gT+!m^q~)(L@}^T&TI3v1lotP*9O8B$q)pv@&HzQCcDMW
+z5EQf5^Po=W?Ko}VthT&2QUIgcC<<X?*5w*3I?!xT%*x#Fe)r>BA_8O0dqEktY4Sq=
+z)=Va)pr3jhMl{^n`LtpBo~Ly;($88>=40wfOU<>eK^;UxaZ1o_i#Fh`MX2#42ec>I
+zS~DxhVHtqa!vz!)Yej~MA~>@|#F)R$7{M~R6^CYG0<PICtnA+|34`Ru;miG!z%|Qq
+zEOG}Qt?Nm;G}-g|;wF1d@VFnWA>W>zHHu6~v9k(jZ!!dZuY87*qoUiCgA^Pm9IpA{
+z;yVriniw)r*SpqOYAfN!;ml+oy!YefqEHkx4^qcPLHV#?%io@ZlUHhT?QmSznU3uV
+zYI?5$b>Qq>S1TSB2jr*uaEXn5EPH4!4rtFawBcPqK@T%1WDl+xIL5k6V?|;!?P!w1
+ztb`nhq$LXl_}(Jv(cy|^(lK@%0Ak;$-#jALHU}46&-Xchoy4`_s3F?PD7g1|;n!H8
+zQW0PDJ+vU_9^Iynxy@!`Qe+|p9tHgn6_KTDlo+p@pf(ly06KywS!*%bBI%X46k-d4
+z^cLAcdui#FK+Vl^ybUq?d&=V>skV*-)CJMOHBYa>FHo}xJUt9*{xqQ7bFIG;J`%0G
+zGa>*KSAt<Z`OEQUh5*VUXQ2?EN`Y>Mn-O=tk?@=XHGC!Sq)y=CtX}boSL|=T+uiP#
+zZuH&jugu`uC<1LOUIg04BCJqgyk8#gg-U)1_2qSszDurnS%%eyW#%5b>AK{@h3Zrp
+zr?G#^7eIj8`U=@Oo{V%^bC2mlDRiL+lg+yby7hTc0kl%06AIF6RBlhwLgf1K)TtqT
+z)7705Wxb^?p!O2FVz15yxdAms!?lg$2DA%<wm%3fF%kRl4jfEGay#=XVr&zivwX8g
+zve(xe3$7=>ctV)%z04(Mm;y2A4!$@5J;c=MuX?ggw|iWBs*IwRLrt^YDZGLjV)k+b
+z&!pEtdsAk>@_4bfb!7~<!ViaZ4+_;GchdbZzrZuG{7lx7lhY4Y=q*e@8PLwJgY655
+zrO*jQEd=H;9x&GM%<(pat)Dsws0qm?PzTZTpf0!`(B6i9{XH0pk7R?uKmiPLo|)`~
+zlU~4)tE@rc*bA8KwJEL16;>216;VSB#>JH>aB-z8U8$*1P~3NH^2#Kx-5Ieo5aL~$
+zJ`aL_WhINNV9gB6%bJ@JGo>YSZV|=gr;c>eTjY6jP%_+Y;%mB&y{79nCI9*GlH`(&
+zM%t53ogPGIY6n^TZdu%13i2vZ3&t3L&!c;inC0T}fjaY95@llQSn4f7UE_LxXg3<K
+z41C201rfz$mz^1S<5mr!a05f9vOtrdCe`q(Dq>bctTssiQfIOFwED0mg*V~a<3%_N
+zx+Ci8iNu$j0N-1501-M#gGqOr?3Vr3rA@wv74K3F=pg5xmy%Q>vA|?cPH7>INAlXj
+zCMVyNI#sr`@TO7(>H1GOKza@EkllD2F%D%mQMk~}K^|0ts%Q+AYel0HFOw_EXt{o#
+zx>)LcK;7VaKzkGWX0C^!xQUfSg}m_<UwdxlBxs9^Cn4N}-4*O03=yyhNzkqGx=<a`
+zr1!k%J)y%5Gkt6RG=pn*)*@P@G~FnjiNqQvapnJWPNc=S*%D=&7S+Hh`>R-sA{lOW
+zK=^D*%k03WwWHELK8!v|A{VWv74;)RisSim{>HcIutFp8Hz+7Wfbjxw%Cp#RR5j#=
+zAPq4aiiJejbU;v>!`i`8hs%ktA-a@3W9<yE(4?ov%C2OjMvbR6v?aTwjO30sWxRX2
+zCCtQ(fRT-eR*2dB7TP*kM9g_yr>eU0`ZxpBG2Me}hyV~~$S}nnoO9tbRnrg36{eY)
+zrs8<ujI}90;WKobw%+s#+hjd1dIwgFBbP{}D3bO^mfY#rQ+x~&gl^Nl!FT{3baO>;
+z&=|3@(7z@^P3`)67<6_(jnUpwDu^xz1KKqQk30^GBl!i|%mi6t&IF+dyGc;%>yp6C
+zy_m6vb}c{k@sYjiZ`cOc^;4xeLnG(K67gg8lY0prz#@kx;|*@sn@RiEBPz#CGdN3&
+zr9ih;I$~{0cP3}G%7f)V8jY92^B33qMOeiw`8Fjtdr--&I&Bb)v-Ji7-82=-^Oq2x
+z;huzcAx@!;gEI(f210VfmsSd*%fX(|ZakSnkhLC!(KWOaSg{U#a`CCPRYgQM9e8;e
+zQf8pNC-s)%T5}m!KuzG|fwR=K7OMvu0Ahf^MSWRRCN$pUUAxZrW~qT%##@*y;+9ym
+zOmq`L%5`%J;&j@>#F?$<v?Z=L?{HbFeT(8w_j}6YD&a@zFpTRt-HS(tV^CPeaQD!z
+zQQRD#O;C%8EILKl?V)W#Rxm|5BM~*o4MP?#4QVVisXdv74tq-GnSHzrGtj2+lQt2`
+zfhytWta=5z2<oN-&~QKVQLMHKQ~Ca5UyAFrTPrJE1_2xooLTB~Ht-+71YQIkym9Zg
+z)XT~0k@C994~JZ=E#qw>Y|~o1vgGWlSG}qY)A;!+&l@yIWPVMuPO%n_G|m_IxYHxj
+z@}4ESs)BR^j44b%bn`l>sfaOeg!+orCdrM3DvWk;mO%~I2ZT17^y;oiW=)gz9f!+)
+zNkT#`vH_mK0w6FG^^}m=Snm|qV((bgNz7ukNf)nPRfT|iLVGt{$5>-4bC%!&mW>52
+ziUkB}W)%7$$om~&d+S@@x*1wdnG%*7sA&NGnY_nhRF!x^$=W==y-9GW1YXB^aa(rX
+z4GJUfos{|F9(Q_#FJZ1tC7M>Dtfmg@Hgr=^7!<=zsZK(>a3P}WR5_KH+GdYZi{WPd
+z%l(d}4yf~cD63s)(x)Io3coX;F8AztFw;c&)1FOC4kUF3+N^fMZHNF>fCYpHKls6f
+z8K~ui`y4VZfQ%K|5acPD944bQbn>{?G|@E*3X1Q+@dj#GVD(}&0}z&!5rh<wfilxK
+za$=jdmtmvbwrL96c4z9RDEQY9&DuhunKJO?35drnGM8QV3W?X)HFRWgo0~miIe}N_
+zRHBDqu3DArvxYQRoKKWDQsH*2cEmVVJIpP=+k;x8`YCxRb0`wA+R(gVGo>||{qC2E
+zE&}yF(8h(DCPm#PyGXX<mLme<q!h|D2j~BOu>YI->(fKEQP<fVYr@zQmLdytfKcS$
+zN`q`l?1kCJV40p^MBD~Jq$?&{J!+<oP7BwDKwWcFDV)5-0TiGSQwVf1g8XX7re!TE
+zgKN`pH@n%*ngQl?)5miyKqXEJMZxr^6=66$!X`s6)n>8`KvIyAS3h6elbbzgb-KQR
+z807$K?6@YVCe3M7G(q>G{3NsqaN#eGG@#~{ZJMV(T~O}{Z8S-&9h#IBM9@v?1>odd
+zL6g4ZPlx^OTgjCJwo*3{0OEdqpe;m@e1Hqi9$bj>fPw`f{LSpPxRS5v9(TImQ%I+Y
+zvw&-<<G37gwu3crV+Uaw`U1chCad3Ln7mjt3GM!(MYeo<2`<h6ONtKMbpTXh-qDsq
+zXYbT3^Cn<X<k+_<?iAO1(Bmf1!CZxc1wGdUUBt=PC~wNnHi5Rm_Ex**HMU|+vM6U9
+z)cZgiO^UkXbIL9nEG17e86CqX+tj{-8uKN$?fE<3MEUEXS}9s9tPig9>x#c3LcDSF
+zENB&IkSnV!8VR@84Y!bzglh!U!!v?w8aud#0&w8pLWlRM*+Gjx*+Int)X-O;1lNj*
+zExVvMW9(1wa+kXpbwI6tu`pdhX_N|KSyh4;@6mWY#LHj2S;gBT^Ch>r--BETUD7uI
+zXXW*u($Ek!D>UGf>ws_@k67&*+O_i;MB~c^1nS+OjV3}N;+hnMxdYinVi0tb=Kx%c
+zM!XdS=}Z1pe%)LO<uFsqZ8<14<e+cJmFAwNhArEw>yOr=F6y`=h8wy`0x{4E6Tll6
+zqM{Y|kEQ6}o4Dwri`WkKnqQ|U>O6H^>w})e-+(?n=YeOJHZ~O2?tiYp4!p#eGNa(*
+zC5{-!&-l;Z1Zi+>QdL#~O$?kYL76z3J<TQzOl{x{zu6O2aB7XcBC)njac6c&wx6dL
+zX7y8rx<~)$9`~N_!6z3-Y=So45gSZQ!EW3~lNn1*UBq=k6Uu~oImwthK<<ARrO}Wm
+zG%<aELFAUXq49!l@=2Zrn1}%5ilhXj*ToejfA#CmzNn!u{cWz4dQxrOkmFn|_e|E{
+z;*o8o2DPaZi^KW=yhb-%17^H&chYsBEdk5tB*s|ZxZ-3Uw0*yZ?1}yeQtbYz#Mc_t
+zdi)Ip(Q{szXjEPr7T7yR(7S=bsm~i(T&LT`CPEFHn=t(9SHF4#=bTC&$|s<PYFTQa
+zRx_-579!YaO#mZMfUu=0(oJ^Y<kh5j?`gi|w(QF5ah0fweqi+VlXETr=V@^G^%KE+
+zXqTz&Vh*qyD+vi*N60B*^JO%i<OxqKNrp2B>K&{${fs822&H}SNSs1+p*!>b#?Cos
+z!O=lMsJ?)I{_5AADSV+6k8djHZ~2ck!=)Z|_6@mG+B)CPW&f9Y9L%>>p3+d7AoE}z
+zfa8ALHduyeCD4Wr*WE+QAqe8Y2wKhWLF!W@G)8jxC!aUdF0aE7s24pqaNQ=r*{_Vr
+zZdRetQI}qNDPaIf))uJQK_<AltpMB$BjkjeCn?Ph5K}XAEHzLkLT6j;uM3Re4522!
+zY{(h;ly%&)<bL}idR!$iuEOlO%`@j<@X2N5ghf*24YW;d69!xki(`Et8WT~2qLWL!
+zfIz(iw5e8np|6-Bh8y?s%a8+bIt|7daimBg+ohbp_9i!=q&rhQwW#DNHK<1^)lN3#
+zhSJueR@|(iw4w=>Qw1<iW8gUXFK%0HxS=D^j{jDqg4kPWRz$r&Ac3cXYicCz7L#ps
+z28*HM&_vl1_)UjF+xz}NEiuUWa^yC>#9{6gB}oY7MrHs?*iIFAw)R~aSzrvD?Fnh4
+zB=0&Y)~hI9=PV^xCNH|*gB~Z?s!}0E!9V8-SOv$`&$`wEZMn_F+6If)MvY&^OyD)J
+zlOI~HI2&i*QU}yKK${PSl^8_#;uIw;XaaD~IopH+Ty%tzeo@e*lw9#AHz;`RW{;$>
+z{`2Mhjh8i{cw8lFlK@H0O+&7ytu*A3QiFq;w#sd#6;-L6eBv_h<2X&ub^~uBGFDpw
+z>J-oxuCnRi&jh%iPGB#3Z@l1zQG>5NjkU+KhG9`X!F5cwZqrvrN0p%)=F&(oRr*;D
+z?Dha$B*6{0z3pww_4+`dp&rH#Nm&5`BUi>5W;dm*S$vk7!wl5iY@!H~u&FuQ&M4*z
+z6?48#=`WtU@v?n86^{qtDrCDEZqVkFgSJ?*hjxi8^)qGyixoWwcA};8l#&QS0{@J=
+z-!-V0LffX<q9IxrkD%LN%gQ}sKmnR11atE^kj|Qy;#Bb`RB{h(;AT|yR0{WgrsN*?
+zdrI-RN>mk<qUO?&1E)HWw$hMCwruNscP<-?XVZi_!JMK9x@mHTyFeQp0_}L?ew{)$
+z&ld0#skvD=*6e9hP(bib3)jVDgSKw#vkn^_Ava{yV2&r3mf1!XB)xuBMo}NY8rugQ
+zpn)B5p&nwBn3Q8oisZOrsR<!d8$<`i*}E^l^n*~v616RhoAt`8?zg$kZETsymk=XZ
+z;OdPP@1qI!r2ws&@nSmxCcVZ;RKnjVa2VHZh6CTp0Q<#tIT=vfg{EIo)&q9?E8C~h
+zKwI9D;x(HowlZGyp|^P{bh4xbI^ZLa7K}J>>Y_i%t0SiH&CMR684#^5s;W!<CpV`R
+zkE=vgrLEGO1IdlFr892R(5ALjKG{|p(n^M-PW+`Sa39C{=abN8uYtNG$(=$9)B}qm
+z^k%qiMrWhZ8Ul&07a7@2H}7DtQ&p^XG?K3JG@vrjrVr`x?LUBGXe=*(o?EL1=%5>s
+zF_CqQwR9E{VoBLkL2*DGLtNfRMkwV04|ssR_-b+;@YpL+M3-z382qJwIC62=AX>M{
+zt)7z*6xb*G4Kj7NH?1f;IH;FeZFYwTCHo;(lH0W2hAIxmu`e(O85k@j_@%V{)jhNU
+zFU}*1ETwFQqLRsyzxvJn9`tw`>f1^~c;Qcyx^Baiv{f3~)K+Q8o!atXT2Uwc5bonR
+z!_7%6(B^W(0s~!e4ceu|i2GA1uCNGFQV6J@2eH(F=bpIM=RiBzzgX=66ES`Cvlh-x
+z$DC>wUjPEvs6-Qj4D4Wm*w$3IbQ!NW#+s`vGsdL{>Kf764(RT8zx$>f`=-{HUT4Iy
+z7=PiH_AU+~L^Bz>ZQvw<kSEt?UXM~*G^KUApk4}X-&^EF$!eMkF^Ryxl0{*}sWo;y
+z7z_YmuprBIO29n`h07kH8A!Ot6{MRi`Kw<yD{06CX!J>GODlClRD>Jq^~RnpRZTYJ
+zVs6l-(n{PCDuSlsA@I)wZC0E86^*iP{Ox$-a8VE)Bj~qW$w9fEgH6VFhwD4zT3hK%
+z4{g3Q@01ney&MT`pN*pv;F`Tg9AS$GVT5{z4)iB5Qdo(si?J3LbHAGnzBtll*R`c+
+zU35R^oS?!lbOUmnNgbwgL7sGxY7(yJ7bvKgLfa%P<t(u&9g#J<1>-mfw!jNkDFJej
+zg-ZM}H_MA6m*R1mr4+T*<^1JeP7`jX^F6BubD#lx+R{V{MnGi@VjA+uxppr5DHS@X
+z8**I!l$$-}abQ<J6@mNw4T?R`=8%(lX)!V^-Be6AXcWLU5N=L)K<@k_`{25Vwh<M}
+zYotKRoZaLmH`#<5S%PF0@)Uo@BXl4;NF`FUn1#YJX6zj&T*{iUmgb7F=5@zR+xN@@
+zHmSKy4ITEne5M^@buVTJmK6p9q8T6(O9sduH$&2RPfKn0gYc;SJtp_NkHNQ(wXb!p
+zYYC=!CX$T?9*hG8L}cY5=*2Py%fT1s%80tzBT^`y#cRbpS}E#G$(7vTPWPuFHK?a)
+zOLL9VfL4o+Xj%`l6q9Y0Mjg}*c}gpqphn0frNQV><E%E{l7~rdN$;e|F3_Gw;$i=~
+zC$1-<Ey^&Z%dh5^Q(_{}NodQ1NhT=K255pZ3_V<nUl5JkgFD!Pt>&K0FUJX&E~|~T
+zx8a)n!(mZ8SsQ4}Rxt-`5G*Tr4beJGV)dEum<N{=5Pq6I({reyk<$4RL6qG@Ei&xg
+z?@gelReB5_)0OR^?YmC=D4vy|i9&-5L<qoxyVyRzP7B1`=4OwO2hUQ23cBI=Wbr3A
+zxYHt{Gz5cDChA1_V$C(=*p=uF_qa1{dG^S*nuZ9W;b=m&6cl#T>Z}i0l|~b2OAV2B
+z>F$_pf-R1&P4;1tJ73%WxNe|rEXn&pH!GaNQL!Cy4G<Jg8iBoz9}d@Mi{LuRa9%El
+zhsvcVk(6Z@#6d?gX2CU30N2cC!n`)(2C3{li=A!yR=5YQ>tPBT4bdc)6p>XTM=bN1
+z+8sbGOK=uI9bK_Kw5>A~9F?WHh=6wi9kP_d&bsJNR3C`JDgIiLK?m~66gpfHqtzuB
+z{koxE1MG1+A)16CjuB5=vCc(xz%r)PZIwEk=E`+#>6J&cVmPW&GibBg<WsCI3geB}
+zCY#I?>159?Xj~U)b2$tIv?(j&0`O8K#PT%(mJa3JmOF!M35Oonj3CI+kXRO6TRjq7
+zvv-_uu)Xq?uUxB(atw5^&sFdUf!V)kuFuGsxdUw$L5Tq(u6j#;beKp;2wdo(-T~Ue
+zB4bB$AVP|u8zK-#aS%iUV-O8Ea71r&Y*0+Jr3l!Ot|>0&uWoa*M?6??7j(yb*KO%Q
+z5KZAw2x&_VN@`QBGTD}U(vS!7lorx|yylRL+<D_M*^E)5Y(6SyHQBQZ-CoBfD5-#8
+zHs;vSl;j4*AfU~nxuIx)2G@vF>@{37f<3M|dvJZLTiwbVtOdyRfu(v_{O|w%@3iQl
+za7{{y>(#DywYnk4`oJY9vWoA7nWQl^M1rU!A;A5v6ZkXk_nETPwQs-3YP%Wepc|Ap
+zv_UtGr?AllXsGHQcLrj}g<l#)v=lLWDd(>}!VTs+-3g2y47zJIq7|w`aWK=CO6s=M
+zKiO6qf^G@{w22m_L5#&*Og6_-0?ibsX`teYb5=!{tXm}i<U{O(_~EsyU(g-o2IJ)-
+z|D+sG+H1HLt(Y)EuHc&6LlTGw!lE#H9b8{@(M1i!a%x6Z(h{f-j%$+R9hTlh2((Er
+zrpNT?Dnp>RL}ezXR$CKOpIJ}`;ESMb51e2jh+~?e8z>Un(tfd?0X2k%T#$ugim6P>
+zurIFrD=~1VUU>?s>xR+_I7fjLKcB%(TeJs6V~tAAHFZQ=X~<J_2rZ=N)CI9*vL#sL
+zOU;QCSKOSAtT<OZxMtL1#fW_kljA-<IIbJpT~M5Z`me`<Ytw3ULO^{SxF(_&y7wPW
+z@^LZSi?Pu`G#Mar#D);kLL!1bQFg(BdLL-VRZb=fz(HeD2Zmy>jA+~&bnA=j{^}mI
+zbw79p+Av$(16Za&Ks#zgyBHV8py=C0ZMoU-DIcw<O0{xmqHLK`3s<<}W^m+tWrva#
+zKlKp%m~cI>j)L)n<JzZnMezmH4X$yYzTLiHA`VU#S-AcSfTqsPYior76f=DspjM}4
+zx?3)h-R(9D8V$if?t9<+_BGg~j+<eQqbX9OjWdHv-m<r@z#9P;=-%#jx3fl9ap2TN
+zf3nUeYS4AD)h*8#Zx3xM=Wn^C`;p?3OD@q#D}l>0VDo@h0;fpAIMt%&NIP81?0HZr
+z^=xX$^>R;Wt`+sD@J@HSlMmNY=9gZ2DS0rRVVN=QP2o@i`~g{U$)%Oq>r=t?{qKMO
+z8q@{X%qV+dtqTu-`yzCjfws2#H85T_zsEi95g)QxoTT{5RJ+J}e@iXan2bRVcu_tO
+zt_@S3^MKX%RY_UUAqoWbe?9CKiyYt@=&Z{<Y|VXbT=aqKk`Lb}zMjN2{V5dM9?tch
+z<|t>N&6f4w_GO_!J3eIby$=g&aARwFK|1Ue+em6i*_6jPU~~K&xIO_La@DI|6+^iP
+zH^2GK57__7s+jMA>tn*TkjI>I4b`Q`<}zlW%?<0JEgKKo#Y`U@)Uft|2Rz`o&8Yc$
+zSko3?bW&~)coE99#m}+S{D9R?R%KNHhGN|0Uk`ZE7r4xJNr|s1Z+3S4a5;^oSZ?mO
+zxQO#M8ECucO%t=&jXVU}HKGsVeqUxj&zBQ$#j~pI1k5O}SWF7nC!j+l2jp0|;$^F@
+zhIa=%<%*B^I_pvn?uYM>YcRLMnJ{dEwtZ7AgK6YJ28n4X^VIvt)aL>H!T(Rd6_@f#
+zV<%%q;aX6C+<pi+V<nSqbPdZ6e##XexIW9c25l>iXP_<h+6&}Wu5uM7@8Fg?SnFMJ
+z&cDSH`xG&CE!!s3CtYzPHKn^xLspD%Y3jD146Y>`n{b{tyH7)&ec%HhSU2RD_P|Q3
+ziJI#&^Lw@>XI|H7f<TBp{BY~T&!)YOXKtms>FG^Y+e}IiZOLA6JEp}ajTz-(HW9?q
+zQ!~P~SUQ%`qDE}G)eOzF&eF=8`^`z!Z84*nwr+Hb7{^<d&9jS6y`5p6qHas#-88fr
+z$;K7G=}m9CsOJ7=w5l6&%oQKFKI6E?N2?KLplvp`VXM<-vFia>lr^rnhAgz}g>CyQ
+z-ZO0`?<@(Jbj5wKW&3I;@065oXhnyx*UV_6LoDB&tYQ0$jTybxwXS7FD3eVS)_o96
+zS+~4>wf&tINj83n&JSFleOzOu*9x-eXwq<7AW@4-b9_KhPnuDgx?b28U1=a-Vkk?k
+znvB-|5U>q}IHjf!R~)V_Fl+n}x@FN2`kPHV)(ttfl7xOXQ`ua%_O*X}(UnHGizB=N
+zQ7^WfPbnYjuWMRwHaUNNki1#LSql`cb(zGqi<{P0z=%v*2wwkMytMQC)C~lV!xgux
+ziVo?+`TbpS1FvDlD+X%wgSWWFE$ZuBaW6$SELe2fyW*CpG1;a$n%8fS$rT^CKFjfS
+zElU<TTW`Dx+Kq!3DP^n~h#Jw3_W?Dy?eB_vOM>w#MeeA^lw&UUq$|Dy1VqrKAqS0b
+zpe?RAT+?!Uy5e5MkQ1oeYNiEcJS;)viZ|i>4t|KxtZv8<8Uk{~2d*y^T*J6G7rY`g
+z32idNdu;gYRAeU^TcEuss1M?b^F8{0)>pjbBA=$M#t+#60w(+Fn)_p}c=oJovf|c%
+z)=G7o<N0s4(i=J>p2Ci%8?J9tf4Rp*Nu!0D3X3a#C?9*9dLm=n+<CxzqQ2x4%<lE?
+zU!&M=?`fWxA6|G0*C0FzZGV~+EfTAr`&;VRP``~U4jQF<+Z@<b|2o&XP9uuVsR?=w
+z^{%*A+qP+<++%aXc?i&ZQUprxid!92>e=Q%n9z)(IrRnykBcj=(fUtI{SZ6J_aDHm
+zD|9TMN#+lTpd+gqxZXxcHr<1#d8uR*v?sS?<r8`*Xy=%^AUX$)8Qmc(-lvZmu{4Ub
+z)##9=5J1Kwca@idfNSeK8x7!F51Y6!dEHBtJc?!@_35>*eQi2f_N;fsEkl~DbJImW
+ze_eBb99R5EFdp!Rf$L4o+VZ-MGG=DJBxjn9-NJML5o|UH-R+e1Zy*2{TXsIT*?*uH
+z#rlf58<}d|Yr=WJSqgz8&8XBw7U}Kpic>rFD4JuP*AQ3Si<Zrwmb&7$S!il#PUDIn
+z5Vl8FHE_KM0+Tm$WoH(Ulbjpf=td2ronCzL#a3ADhUMm|#*FUZieLA-*R6XfOAKFi
+zks8t{SG+NTOI>khw9!I!yB3gWG`Mz9|4F+`U2(Eq*Wj3M<JEHcItN^Rh)z~~PgmSl
+z!>oVZ7LHi=Vve3*$j(`|YG;6xbj1g*C!xCZqL;g8Ui-q?8{FUqHQ#eAE;|Uc_jkpc
+z^pVBwo7{;evCOYtN-MiD)TC$@gPAq3GzGLd<c$Wf3)7;uWV9MBWO~{QdKRD9XVR8*
+z<^qxx?`P+i`XN>o)`Joa$;qGMR!9Tai$rDSW;@}`SZ%1k-u13mvp&Z>w5-8yOz@)9
+z{ax|ile8bmWFLB0+%{h`Wa<CZm{BX-8kalJ_R>UieQ8!)_M-{s;n%`W`wfD;`6=5O
+zNsMr)5U^p*QdgXQXlh`rPjOe$f$LuIcD^EwkDHS@G#9-a*m!G^1X-#5p}oH=-l(0D
+zD{Ij0HHyXv?(d456KvdoK)ZLvL2?my8XY20z*6()g#$LbmRK-ZDf3C|HacW!O3;Tt
+z^tpz%)Tmuaz4uY?N_u2me5e}+t{2J4kvID!*^EQ(HK^ttkVt|Vu|1)^zboEk#Z6l$
+zSJvR#X)}cVU2)$(<;V8W?q8)@>WX_mtJgwSui0(GE;?Q-vx8zn?EPJFs}X8kBcPp!
+zPiwc~f$Jloy7UGg<C}rDfV#1*5e7DEA87CIiuYM@9|i6~?Mkyw3~)?LFQQUoM(sIc
+zihL5<%_~<oyV=baHPpM}d;l+q!L@zqE%nd3K?#tafJ<F*iLx5kj#YkIAO0A)UL+@5
+z-t1$GGtg!Sn*?m+fyhnbXv>R@y4WEreqydTGuq_Ds5ObQ9@<S-jSle%m@T=G+Zr9B
+zLK(9f*H#e0HB|2Diu?9r^D>v=oK}cEaJ@)Kw!hi8o@ZihtDqZ86ln7Xw?uJ&+y1V2
+zlNFzF#d*%PZ4!)cPnq1=OzZRQ;d&C<bwiGqzH;TQ`NkEujD&+x>~&J&aJ|1P-gq(;
+zh226<#T6g8UMi5=-|yp1GgjMFPXARPR!qXV$Luy&dQWoc0+l{1etfRDub|d|H8FJO
+zJKuR5Xz$>PQ#*BAYLGWee9cuZ_L^F2yojamta%@;ZpbmMaw@L)!1eYx-QiB3`kjHc
+zwUJ)lY$Snbd5L=)Aouqi+!Z(1+_&P2Wh#vkBuI<sBQM<y+%#5jJ#V$OyL9)1Mu(VL
+zlLj}>MUTmwStTAn+?(cmy5iP>Q&9D|G<_<r_`vldY24vvAIP48w&YCnjSNyjbiJNG
+z38?vt$Ki_Glwh*aJza4bEpzuZ1mwdDuIHh>gDc(`VsBH5vdv!uc=F-K2-p2u@ujo#
+zv{OAOOOMLuuut+Ed;`}zKy~RO);P^9S-}F4Y%L6dwlCdG0&3>s{;s&GpQb0aWSnfV
+zi6sGNX;!>3qxMg*7-k!2@8F6zi`+!_^8cK0!L@ZM6t6Lws_1uNTIz~Z)C~cBKJw%j
+zo()_t1?g`0&u>C*u}A;GFLG{5bP`iD7Z2`=gTQ2S4|>pp8dn@n7ZFG7*+2kbYg})#
+z+S*-eMg<OaTfAkniazMcSjP#sv>+czY+UiBv-8q%bwiE?-6!vg4_q%2#eHrT6%wIM
+ztI?R+X3sz(LHsslt|qbOVw2QW18-qbx0?kj=59#lWOI!x&L%EusCUJ)Ra6h{e(qrD
+z<nm)5``E@6_dPz5wRiDitU2M9#2abz>Ng#-$Pe*;U-Oy|-@adXcHHlP3|ub~#XWB(
+zAv4hC1omGA0?ce{Fo~@GV(*Geyf5l@zd!{9`i5MwOIU520LR4iqP7|{%0=l-cC0o!
+z)NL(w#lfu!=dXYL>jSm;$ok%5tl_%fg=wiP-b@$bsa2*Y?1~RuFOtLkZ{~c?KwCbi
+z5n#ehFtT~zB)IyE`@7;~z6KFQ^sTtEzbkICscy(Ie}jQ*Ot#ZzPZDNy>6h2MWLmdH
+zhgg*g)Esh=b&R!j1vX-82)NW0_x0_%A;&m=!mjwh_5M&@S_7X@u4a=%4#GsP5e%!O
+zKz<Tj{l$a3;$nXS-#6q+<BAK$7g2*N-T;<L0k<C7UZZFn>7{10cg4Mn%~A){(*6Op
+zN&o(RlSQuhi(mZWW(mE8?!^^9neD^}t{2JSp>F>9pa1z8Xj`Gtq@=(cw71+kX@6I|
+zU!bxngLiOOoV#KgYZBT`l<j4iMeOKZaj)0Om9f<2yT(AR*oCQ~|56>&Z0l;L^w+)a
+zbtk#-Y~Xs4Y#i`r*qPacTu9rPC(xF{lGK{Co6W^0sk_5k@n$24O|CfkX&}HkUqq$e
+z70=v#5A9~@>He;`8muW5Q?t}cK%L!M_H@N@w(+<)=O?-FY~Xs45FYks`*oOS+2oL$
+zziwp1shMu(xIuA$dT>{qw?OjyhFoc0D&N5sZxYBhWlBR0wD)(#tubq~rIkF!mCcRe
+zI-vHuXI9+ny3Om@e1MY-u?MaX3)Q8yS?@ISeF1yn_RzLIO$uldV&&q6<%*lWuZJnU
+z!0(-e_Q73oi`;rp!?lp7@k5rn;$rH0P#SvYJKuR?uK2+9QY0Sye(xP9o2+&dz(!Qe
+z^Ky3!iYE^a?uturO*TY?nnd4HS6oJ`hJfRGg?w$bdslo>MhowntT^yyJGEk|9oT|N
+zX<YH8@2p9)H-qxB$-uQw6Iy_0Er<BajH;zUW*fasXZ?Wpm-$YO+@c{P_3!_=yz-T=
+zJdW>k9TwVh!ZVwY!+YaYM_RlK22hhg%f;p?`KYA}RGN9%8CSgdvcL|m_ziD(!x{yA
+zd)c#6WEEt|<Q(M58%KKSE=-Sk%wy_?9DDVf<dkBQ(iAP$chUfhbcm0FHERfU^~6H#
+zVXqGh(%ovC--H~ro0*r$+cmCn4a=@JL7Sj95MYTGb+2D5e*4?sezLjdE27#pO~0tE
+z#*Eg0nm^tlE8fhk&DUT5b*U@f?D1$lUS_*|=H|F(y9TZoiQn<vY!mXC^(tOZXkHYG
+zyxHiRQJch?i;YXOe^z{xE6x(_>59u})d<@Dm>K2YF5=6PpXb=r`chY1BCe_G=}&*U
+zoeT%AFAsirkxA<rW?uUegHL|I!j?)t6Eg|z{atY$X)T#tak4tuR`X?nrLH)S#fK8=
+zwzfZB>WW)DuzltAol9MD8zeUB&UAU%p)_BqJJbfGO+CY27g(KzgZb|Z$ecG@e?;nJ
+zc=*^o+%7Cvd}lMdbWdP9q?uW(!8?DvREIP{x@om0b=KhVP^SaeX93Q2A71c+7tHL#
+zAj8(YzYsaJp3{6y5ADVk7pK>49eLcFQHbbUaiw>~z0+}I{q+s|n9-%KIE^=t-%WpA
+z>WafxU6rN&KKgS4JBpt{T+0vVJGpimxm@|-MaZB3{O8Z?d1wJ@lRb{)$RYPHRGy+M
+zPXAzK8Pt&nbO^WKtkVv~&L>CKU*F*M?HyY2h*kRbk*=$nKki@07EfJHaBUsVd*A!s
+zfBxrxe$$)Y<h%AYu6-uSJeO~;%L%V_o@-JtELfU>wlKU|=NV`Va+__7AZ5?2xJ|Ze
+zi{sdei%FC1HH!L9?UL%r(OrHnQdW%;wkOQx0oT$9HLhRtn%BU!_f?<utY`iH@Bco%
+zTI1SVb?ckI-X!FI_Gf=K18sk5QdPl}_o15abTqE`(yVwdnVVd3(?Cs{XsIi{i4+&~
+z^=6+63lHA><~Of(p3Art3IE{wJ@0u>?DeZ({c3{55w**DaBVSCvDa|zt-6)1OPLW`
+zM3{-S8O>&GcA(vSf!A7&+KgJDV%yA_M*BZCS#d$4<yey@yHPbuUGcu@6<qNaKuv$g
+z*2WP2mF2@ToO7`L9~=_6Hd+7fcfb4XZ-4t6-}pwKG%}O>yyrd7zWP3W=-qkWM-x3|
+z^LDayxxzK6wrpv}YH#}B7n6!mfnL8Y_R<9^y(_+HPsPR+C&S#W6<~9pA(*~wK0QWH
+zt_;@!wO`}1?J8VL`@{9S-u14xz3pwj{r##}z3L?|d5LcalV|H5t=zL>!8>l3TU?W<
+zr#<ayGtf3A+N@-bbznMWeXZkCn%5=vcg48`Q5vSR(?ovzH^;rxu@5NL@$6mide_=y
+zTXswAS7WbhP{TDR`~x5OfEBavd*Azf?&K|RdCNck<3GOQ6|XRd`<&-I$Hy|B^rR=5
+zzcBs5lgZ}ovDew!q6r((jTryu<>CK+L97qoMs%P2<R{NK<N^~5&uYn;KR$>np2aZD
+z1_FJ%mZ&Ytif==W3+^6M7!74CSy>0J3#c6wV;v{F1lN+`FMa7tP2fryJ@u(iwKuPQ
+z@a*4ipXY4e?j0HC>2io`k}N8jS&e4$+H&zmcxFxy<%&yV_Ma?i+8wUA*^TC#P5hh{
+z;JOEOZLH&jzu^sU5L_o|R$k^ZQR3|bA6u~=gD)za%>Hu3_;O{hW1)QDbq3m?+Pur(
+z;Hy48pet@`(7NXSc(~%&*X)vE9U4#^YIRv(&k3wcX+RwhyhPS9)-wM#fO`4MUmho1
+za4lz>q*+OZ=OxX{Gp>n;uf)zk+pEg9(&~}bU)kRkSHqUBxFp_i#hIj<3nuqDr9B=G
+zb>+Bmy$RH1+FE4&*0;V@#w^A<E6q6J0+7c){_zQ}Ez$9=Q<>zls)`$PIkeZY+SJ_)
+zv`r%SUj?cqsvMuBD{itfoxj}vdXua9?gRhxP$=%}IaXZHgIc<b2X1;R%gkQ(vX{kJ
+zKjRtC5KCHV#tF|C5BuQy@{DWHkan>8ZqpVkwkv5qunx=K1@@hty3mu0P$ooTd5c<b
+zV9i^y;*BfL7}-atZp%#BqPCiw&3oEH-1iYmk*~A7p}B3JQ&Q(M^re0WHhc!ged?^A
+z<!9EUb8P;x$K#={93QT?2Q?2|8r<|2_KB?Jei>_-aMSl@xat+8al&nuayiE}fnfn>
+z-q$wk<ekb|kZkf<i`j0+&Fd0eai97HZ4jv2ax8nlTNC|Lq@r2np0+5NLqQv;Ctq*3
+z6T(5D{lq6evB{fxyVeUJheB~*&oSZpNKjjd@{V`BLs<R#*T3Ful(i^4@Mk~!+2(3Z
+zTXQufQEOwJ87>n#obYTkce(Y$i{#ULGn<fG{NR1z0yh@iQlIkdZU^QjN`*PN&24Uj
+zHGNjx8uHzmXr8k2a1zu7+FZNlk)@}bK%FM`hqiSoH^2GK8@dTCdoUjG%5mU&dr+IO
+zwh)DbXKu?zWYT5W<Q*;_Jtsn@tu05%>mDT&9%C&w9JnUHCJSbuE$Lm06Z9>W`R0C{
+zYBmunu6Sebr0*;)Y93#D3e?RPz3buRnAP3~+Cbd|5q%STLR(nW)afG&vd0HRabMNJ
+zalH+wEd^((18SL4p!V(?3VSh=$0A+E5?MQHuR=o0qw9_Jz;(e0LT%cF9O<m(E<$B%
+z)AH2L2fZsU2|wwIOYZI5iU+;>b0nw>w3n`UPsg?ab(+{2+7iD_y37h9A!m=o!(KTo
+zt`~t?0vxDc_`(-jUB*SU`>2H|!fFe`Z9r<ynz$wn&d}76HBb*+*N{Q0O`DL{TPKOQ
+z*>|tV?Nh`-MN#BnlPhi;|D78m20f^S^VC#I(+5_YgSV(Tf!?I0mh^+fCOe@y(3aC!
+z)P(eAlWA1XaeLs=566USZiZs<N#5-6CZ_DSn7UZ%fcix*dQm`Ka%D&-tbX*PADxAx
+z=B#<(WsO-P>w)VU)H#-2Brtu3{O)(Zdjo-kpL#Qty;d4m{ICsqi&=KX%Pc9A`#~M5
+zMIoL^s3wXzNaZ$k^;*PXP4i@J2gG$T){8*xRm1{nDwIL7YLtiytI;;!Fs;*N0kvNl
+z#fH=?ULW2Axxd1_k&bAf%@yzGyc)XgdCH7tPt@bnAwW&HM|<R#U@)M2_Pl<)@s_=T
+zg`UmVeCqpmI6fH<{IK?VPf&YrtAIMWvIf*imzmxQuD$;|aNR&#P&1iBt6lLOq;Z=^
+z@};~!E56OMN8Zzex<I@6{Kt`1ZMp%9P1QATQ~K5|QJl%fZ>nw6^^@_y4~Xl7gSzC(
+z>ae<i8no?)-zZqbyqw!>Fqg0HC$*2yj1~dD-u12*tR37H-vsIc?a5snOUJf30B0n!
+z?!~&49@=sjeWbrlwaq;y{!YdNKNPMH3+g%nUO-)k)d6+$;h4~H;2N~8c4$_ao`5TE
+zqCBoRXf*P?&*?m<18wP-eV|=H4cC*<w$ZC>&z{is{<~T1$w2s+F76p$9}}pP0MGlF
+zTY{SW3|z-E?>8a0Dw3;QN@JA*Jz=tl)pFAvino*UVQ!4u;ql2w%*r(}b%5OeYSf2>
+zCM%h_=(Air?O5u7I={Wu25n0zyp?7ZpT)6O;G5bL36e~+1Cl@bsptkJqlo>Lx}UP>
+z$AsTa)$W7qLxDQ$Pl~194b%hIb+~QzkeP0BXysJcIGOC-<_o;FxL)YT;A!)>8q_n;
+zHWTd)EK6m0L|#0!SAcE1Z1Us9CA;a`^T!q__6acu#NU=WF6h_<y<@$;Gp<Xwo9uV?
+zKiM>;RkGhDQFbU$4_w!{c5GdT++)FVa{$_tv$r-$u!-n}4%qGczXP-_cm{26G<dJU
+zD@$Hn@?mSxHkk|BCU(yPw0FbxSpapjrR~6VgKMW&a?U_odUi5ZE?8!`y{B+w5jOH;
+zw+GSLymKkEEqDfPZ!~zXp+MW4iB@RT(2l(;NI6#P+*iH>u1i->(NYt+es7QwU-!@^
+zgfq~#_-D^qU{U#|y-Cj|iYI%u8??<nOhVh<0<qes2<@e~-URCT6=jEYzxj%i8~sjw
+z1J^ySUGeJc476=9CGE`H*|}JFY5hi%DVl`OS-!Y3XfML`*#Wg~4_r^8c=Dnb95z8)
+zpnZ@vnU;vi37=);9@)1wL3?{#pD9oeTu<V6=A!)pCZTPHXlF~^JZQ&qYln`6&so0V
+zu+T1Pw3Bzpx5V{X1NFf541_oR$vXT7+CC7;i*DfQRPN&QW{dB7OfEa;L~Z)S&sm0Z
+z-M4i>dmCIAP&=S`%3E5dwBG;z_aDcUmc>iWin7Gi>1}?8AHE5{GuLfFP|s_lWDjar
+z1j{p(<WJtvX}-pls_26nCKuxIZqPn5Lw=I;+KX@v)cTfJFKbZyR7W-x#c{7*nqJu_
+zQML`Jb$j6YNa#)8U=#8h+Wj|xtYr2I$>g)mMc-uU7g(0H;uj*KOP`Mk+9&3aABpQ?
+ztOIJs+M*hPg9SF(`g;?o$<GdpPk_3y0==b9pIvWk&B%v0xZ8AUQ<}1dypOMKR<r5B
+z{<;+!&5rlh6<}fk$c1}wSZJT{<kyzCj-H7J9#C6gldZpfr^Cl>eSgQY<XGybJmo1s
+zoxKNbFuVPVvh6{AhdbP%|7^{`b&tDESFBjhn_mxk$U_?SC_vuy)Z}&V%QrQwz!i@=
+z+6~%gVP1P4*Nw5RH$Q2%{`R^`b_uqnzwhM%wcWo1YAYDGS^K>R)c3yky)D{r#A)Dq
+z5_g*}+G{A#Zd`GjXKs3A^18UP`3(0uT=AWuZNI)i+g`g_Xj)dI)mFQJt6wd)|CQ}=
+zT^s9?E7NleWjSNk!(0E5U4q#Hpw5P(#{_CLAGn@G*`kY&d)(vfOVhaGmXO)MeNjEs
+zY^`Hg<BIP9ZBdLheg)b#=d?wqEww>Ll37*?v_a{(b7<S(x=xp6U73aM<>NbYEZHSk
+z7Ny=LI9vL&)IvG*nR!cVk)`&=O{hI^y$E`nZuWU`FM8CdbZoc(P4`b;w<l^-!)jdd
+z-JorMU7!FB`}j#I%R$-MPd+NIef6tM_czc@4Kuhdega(g#+rj+(YqJcc;Le7Y$%#t
+zf{BWc<vr?AkFrA)Q2SoYQc!!FARViJ#nc7Vs6B8!39%h6nz7p76>qYgPJ@Wm{4R>M
+zLBNKb=7!{*WS``qywO=+`-(SytR{PVT$gXq3l?<J%cnX_BYC&Qd#OC|gw?hw%Xd2J
+z4MpvIGPy~@q@~^l)C1Q$;CJQ`dji)6mm^I@&)nbt$r6{Q2FzUzs56l5p)KKHXI&X5
+zR*&r~uYJWEmwC>c+DS*pfHnqq&(rO3P07Rwmj>ro2pqi3BC^)`XFcm#cK;>`Hca;V
+zdGWxlZnDC`#<1B?w0x=~dk^jd>VfMXS^HeUxMtxQ8D3N&WnSaju{CKc!?ocog0?IZ
+zt0#x%qc-uzvk3zn^(K2yAUBU6iR%Q{{P5s9(_8tjR&m0;R^SV0zP}?6lZ}Flv93LE
+zi-(nifO_D15$LwLx!K#(4uso0Rqi3ZzUfm#dws5W)YSISwq}yTH2>>cvG!LHx+a0v
+zMA;?aZLqn|>6W-IGhA?;z5Tfs<;%ADu2$0EwG&<<YuiB88wKxasYBioUl&Xr<bWj9
+zsN{<KRPmykefYJh!M3qs*2;btLED@!r6+-wC_8gr663`cKWn&Vuk*#~8rSS~`C7*$
+zt`7ogax!qe2y{o@?6YW%D~?k~K2_gfxk8O=$E$S3qocNmHorxPDrgnD3SetjoEv;h
+zA@-5>nlec~y!OKrU+1IMNrwAm-V>higvsw<dM&pk%}}FBoLUY#nJByC9q(9Yzk7v0
+za9v~SAji$#Dg0_Y-M(f^lA4#i*6NBcg|<%}`7)rz9s<|~*L7BWAIH0Sc6(fxe0Z6>
+z&L?iOBE{O#e2l(Ka@mL@GuQHF*$Mn%4||xENVQ7e8PvmGZx6Ta@3ez%%^k-U>v~CK
+z%Nl(CwRxN~zgAa#DYPj`dJnFJvDxI1p==hYG}zqdbbDM2v9mH<uHGJuk^rxH&1+20
+znWQrdUp`$ebyk16x}?Nq%xJBe@B4sy;Cf4}ExOIh(#93XFWVT}b;`!Y^Ho`r+CS^@
+z6}#d~p?&ei7hC3W>h_wtNJO8Mc%3@aw|c58CYw6SJ6!!YG1==TS-K~vSAc7~%5V8P
+z<UF7b`&V1v19Gi?b8LrFn=Q<g{<BKa33tBpog@D%{@p&-ww0V!rrEhP_WI=G>l)Vy
+zv5PC-y!4SbxhB71ZNdvfo1O9Y2lWbYeWyF!$+scSAhhK}`maCtNZ;m)&uy$2&h^l?
+zhxUzceB<Xn_qp}bloQT}7hIRrS#PqlodV&^5^>(RiEPOh$<+kfmXaDsEdvJu^$Kup
+zRW_4tAcr-$2dT}gm-Ys)xwgZx&);0=o0QhbJ@R-Fw5?ZxrsTs<9@hoh@fLK0$);+W
+z?T_T}&Cq2*X?gp@jJ#Fi&0d#>0`)p@ZNir`W;XC3U_5LkW?h@mX(_aM<}3JWz>#pS
+zZ`dB%z7_cYw|6fu*BsRz$45etIEn<L2wtKwL1QjzG;d;vQIlx&U_z7xf?@^^96A(1
+zgCH-WsGuUE5JSWpVo-4EOq~d#PIRE))PEqx#Pd1UIdzJve)`$BUi<Q_JxKc5@7`Uz
+ze_h|MRcozU#WA&zGaR-vel!2-RUanZEZZERTH|t5%4$t}$H)~gXydxuDQ1UIp9a?^
+zDWV3R+n@T>r*=!_PR=Ih-{y4d;@p0oJwG3;Y@s-f<F(K>fvtQM+;;WfbGfc)*CD%F
+z<CAFfq5blgzf{%Meu(WYe({T6Y*)ws8eV*@o4HnwJ$}s&w>aH$iGTn5-$w1jL|gK|
+zwbcSxUOd|Z+_wIid|h|lb)MVp9WTcs+V1&jFuUSatd6$aT?<1B+PfmUoM&~ewceu5
+z8kfE<5+|HpmUqd3m4Wu_U;nze$HzGut4wIj;NHFLJu1<3MbYZVPJ?S9ek<{zEwRw?
+zPR7~gPQnuFDiwP))fe*v-6Pr_>1G`D#$AMib<y4})XugF*FILQg<_4@iM9;(8MHt9
+z+0TlMv^Uzre-dq*3(HAc>yDoW*PzhnaqY!xAqu=4l{-1JXyy#s+@#(5k#hHi$sT_A
+z;kEAXv440iw2g+lMSDfA&qZ5AyN=q{gVa&mHZk_dYtd$T8ri!c+n=hFS<boo-8>nt
+zMY{wM3ff9)C`_~y0GB(7oZ+@oaUHMAfeJZY1f<-3R=TJ6>i72qK52p}g|94NZ2t>^
+zE3UYrg~DufUtDjDHrG%$^Mdds+8_GRhh(s<ctcNyYd9Fo3fKP28%eR{sNBh!pMLu3
+z8MIj)a;w^YTaG>9A9>`F74Pq{e+<0tEYDc?QY(xzycI{yD3jSea=iiCrAVnU=*lav
+zY_G+mdmOU8!^a|@e3g58N?Z$Mi+WVFrRkch?gYT)PV(fFPjU!!gLVCrt=_E#D0g4N
+zxyr_?+~1@AjBfnI6HjzR`%_J!E=TLqrArdCcMG+%t!{_crswC{)gU*IE(Uo)TOTmV
+zYSHE{n?ze=WEHeeiEB8x5tVBP%0imLEJx)|&TN794BF!I-DXVX?#p;N?ZqHEu#!O|
+z)SiT$8Dnb|L8VI84i7fqTI*|}T}z95hPUhZEE8~lC(-6PH|v~#VxJh-7CT!?)1qw|
+zKF8xu09@`Qwse_6TfW(No6v0!CT^wq`+KDS`oIGZC@nHVt(s7`?&<Ek@8)*iA<ONl
+zHsg8~w2e4w8<tVKqU}a^Xe((uiT3^X-#?#)ICdD*_Ld9B65*uTFW0NLIdh3$SHsnT
+zb*$a*w-R4j*KJw}_^uUvWq*P8TIw;=t1EU|Ms07p-Xn$gte?&OC2BcBt&~t#cEIWY
+zk>Zxb-5zhu^@?a4bUL(EJZqN~SUqG3=ZH4P+P(MQJA?M=agB6ox*ghdP=6)>&uyBp
+zf{z=#vfLf;g<f^lRqYh49AAC))x5-KF>-Y88;QR9)vu0FTm9P2M|5nNNV^5OJKHu~
+z&!a75W3Fw~E@)e+T}N#<x<%XSd%^2Tw56z>h4$%j4F{uJ$91tf>~XdYcLCp31Zf6s
+zc}J5ANvsVii(ih8;_e6Eci(-A1&vU9(>1owG;>TDn;nKb|8q;OS4X?<&1aFC9e>>D
+z7rp33^?IRgdEkh)ZwUfUqJ5HFn@araU;i4>mdIyMjQ~8iY2xzb%OZ5$U|s)Ym32u<
+z<?b8HHpn*Yu-fmR#$SW-2(>!HY?9i^9dN11>DoEP;|aItdSkTR=oW3;Lg9BrTeYQ0
+zv`><2;Vo|Pk!$Z*3=5oXxC{6$yF$uYWw|>rq3$vnN}m@ITPr1LzZ7?^Gb#DRMyRb*
+ze(6hJ+CnX&Z2{NF;1cibgzHt%R$qld-i_LBbc?oQKJyW6i^Ztd>3Nb|1L2{E9-8FZ
+zo3i+ndkw&In<m6<J)JtD>z^VZUAVLKd}~5iPf6-}!XE$R{t~?!p;ij4b1AUI<X|s>
+z@Z>pn&b1I&$ssSxzAR_p%rA3oXsg4}qHUuP@f{;|eXK#7b9F?UAxgvc4xTF4!ba@3
+zv(T2lqR(u@UBGvl9H05jXDZ9xfi7nyNWJ6rK*Gi<c?)eH*zd8Dx$^EtsKvQDX9ABX
+zE+zq7=*?Ym?dR2?_E~7F#Mq&&MlrM{Aemp+`^%-qmK)LLd23g6o+{TUXwynZz%7>(
+zObNhq<0ecQ+(C4AMAtv{^DaTU+<l4V!X^8qb;Z{00x7G1gqj<qb0g^9!BB&7hg{F2
+zT}!NtX#e6Dzi^{lwB2-lU_@J0mWuWXb1f%FO@oo>`VQZtkjlo~1$@z+k~~~N9uL^1
+zlcf$V@t$;(u83RA$3U&H_6W7L$=xa^={F0F$n&S&E!P{M&9F3TL)#$LR>G9NVx~5t
+zZH`&y+9%943iKSy+bhW9fqWZVmj)2JaTCA&?QdsN(Oe@xQtMr*2AkShhm5v7G3(Gr
+zs3iw>UP00MdHR<7*PU~{7TPu~VzWWpX2HstT8Z4&pf(HRUmej_%UWdNw7Hf@Z2HDK
+zF%n(hF@+Hx-I%+8FUnY$S@s2Oai7+^QqjKt`s)u9ZFOVpGC4xcpU|#s(v78LEQjs6
+zXI_Hq7VWmgiX0mqwKK>I+E6W<3s?x#qRn?IxHF<{j@cPJy2P>Pk+#NaSs-B2A=|Km
+zJRay{>c|BUx^WW_m`7WhRyzf&Xe+IDXlR34jjs`EQTx^t$n4|*JQux1Kd=zjE23>%
+z6DiPTKcHI9RFZ9rHrs{=ctpFabb69pyC{>6F}bt_+)P|j#KznOd{GVRnG!3WW*%Sd
+z6s)5C<~P4NX1;uGE1ocS-F26moFml2H|>%K7vgM-GP}yjm*aXKZOhXvJGC9KMNIZ1
+zE9Fc}VKg2IW_G=~4h+paz#ZB)Xl_5_`1Ho>a)ELb1r1x4yW=1K_{UZj1Q5D$6V~d^
+zqs^btKFsT#z2%l$&V_F24-}|*fkvoZRO{GhcyKAK!rjuJS(NJ;v^j;^a;8={l-;zc
+z$F>wfaHH$Zbs%;is@tM{akzH*l8U7&bvU<wQf%GrsyBvovoE@{^JrU)JfiKLx4!kQ
+zOOrcu{sOh<(g?MGYF+vq1v2E926n~shjCqk+NRs`V{4`2TJumUTA66G#!X=q$Fn=<
+zop;{ZqHWQxxnxEALUBz8)026$<w)3Pc{Au@zQvB6NBj2MZ*T8-IfnLax7{{_-g5s`
+zpk_vnP@6%w&V0vQXDdP%@Uf-2b_rd+N=2JTsHCFFS259MjY}%yK`leJGElahQ2MF8
+z(Q@-F<S%GnG_L8udrZA{nC^~o?Rgjj>1M46XwJLQy0Y`-?whniemQ<8&n%08qs&$p
+zBh-A|9n@m70kp2(L;%+#+QywyshE4bSmULZsUcfFLz!j&=tn=Y&llVK)?06F(Y79+
+z!3pgP$Tc0r3+UP5-2Q0|f+AX*K^OBa^Q?Ka&8gcvUeRW#PXf5ao6_Du&Eq#hZDDB}
+zo0A@?>e1@N#e6b`>q)d*YrG8EX4#TO#k?47OmP|Y3~vj2Z@THG_C{O#W?;IQT+=~1
+z$Ft8q+p^ppGikp6{qM&>x>+lH`15G<gtvFR9P>(HZ3&9IbAp<CM_R=QwUtV3RF2ck
+zN}L!}*J>q<>lW=A)UF%vs<SG;RLqNGoS4#7r1ThfL~y?R<u6Om>nOhFnrmMD>Q{HS
+z{#5<p-DUby0?$0!_A}*4+YGvxZ}H*Jpe?t2a%(UHWw-pNLvs5+O`Oky+G4ae9w)qI
+zG3Hvhg?%`Z>ke(!xFNgDvK7r{id*d^mi?RG{H9E?If4v5q+{odd&IO8oYM0z4%e>N
+z#s2f3|LjKU_D@q7bD0=OH*19pWyX!h4JGSre5OHrT(rAA&gBe>dw6b)!?bsh(n2j`
+zN*-?*r|UKp%ymV(4B5pL=RFh4Ry13kLsM*d#li~GN{j2v0tahkJitW;C-;b{xBfzL
+z?W#Zg;SWFe+;c6<-LbM`k^we@F6LWLJ@wSgsO@1sW*@n5k91jTyJESX#{zH}GLukS
+zm()TnWz-CDUDhH$AJ26`yPD#XOU1G+&^E=EqhfV-ah-9TvLvNj=$!V^mX&0EkhsHW
+zeqRKx+fG%l*Ma^vkG5Hiy-i~v-K-Vf(HXR*Xm-0}l*{L>Qqi{}x&48HEwZ5|p|&Ea
+z4Xn$O5~+!Vbc43`#dQg1^NJU)1+oj*ikDgmBDi2tL*bgWQ@K`Z-b1zIPPg5=9G~!b
+zEedd!t>O+&mPD&#H^<I1&pfjkbTQw8$xNkU&-2NLIiHnn9JeRh8N{s^0FzMLTdM78
+z_ABuq+5oiRuk4*`uCub=ZsD3s9M`f_)Hbxgn~+w^wN0Y=DnIdwPjn^LPo8Uw*Z6ZL
+zM=sZH<^DX{9*pKSF_3Q73bS?wZBsCXl3KpXG0zq5wnSUiL^(er)coNR2HHkdK{0U%
+zCUmpr4uNY?Y~!_}#IjR5u0>;UZAq8Kt)AP3YbKL$Lz}`^#6RKj8rOR74BE;`J^%dk
+zb&MVl_#RDdHiItaTP9pHX!Ed5ZurH2<-Tu>wqUeDe-di2w@^!W6g}LGviNTuAlG_P
+z8Lzo>&*IvU-PMJ23r?Qvg7&0Q>hkTJGLN?X1z15bkZ#tB)jcys$X$L{V83w3i^YYw
+z0op3!N(PvO+FF|yYMo7BE*{T~TRdK_yCSX^gloN5ET-F&vG%~nAAfuvZDx<0pUt3)
+z`Ie%8Gib~09P4Sge7>x8ci>gbMCsQNYH3lt;#E=yoEs8pHb!hOUrerJy6e~qS9V)S
+zp*!w;gT)T7LlWoVS!f%BUU=b!(GIWgh!`qiG5(&zdB>DtrU<#m8qiwq%JEt|@S4XN
+z;zy_@j&=(PDKGJLFKlkpXmY);{=5y>0Ow?wbS3HJCMol1iwn#A+1G`y((Zf_a_;MK
+z7UsgC{n%rV)u-QC2PP~A_YrEdKgAQ;Cx)~}ahYxS+ShlJ>s7kh5}(<U>v^<MKaaM!
+zu%f0*T-UD7$$*(DLeAgS)#xrf;++feETX;dU-kJBYN6FT?zp3c+76iJEc*g;%XX9N
+zUG>9t&$B((1?@>MvHr<cueSH(f%t;XyzbAA{QP_oa?XUVQg@+}mCnqbL>tszBh>O6
+zyA{C#sZ5&qy5C#kT)&=NM|RY<t(|bK_X@vudn?yLN34I6==!F(@FAlulflEM^E|YF
+zs?Ob&_AS>wxdSf~9q%L5>=tz!s%Q>4H^_3lP@_A!Zdr>w-WAs~Xv=<-d0Q!-JP;S=
+zEQ-AFwc3(Y?BUb0+#R2_;g{WMxe)89t)Da9N2skFRA;G$+MXj^;-wf!9sZ8)Ah}+v
+zo9*z!JLFpL<tyXlY5Qk6hPLF}NuukUJ|MShhnKe7Q(50PlRyshM<0E(E%RGNs5|ib
+z09V@xwY?R(svVMbZ9Gw+&hdKPr&-a>(vMm-rOh|fD^|%%xv=r;ItFzIGiV!>E5(xs
+zhIJLFcFW@q&j!hv6`jx)v})^uR<zAf1gV9_MyQq1yZPpu>n9ypJ7z6mg}NN9+qVzo
+z^EqDcu=}lbs@;y)g>j}P`?Kw<<=ApCDVmc+*Egkn95UK$<9W34JEj)9d>%0I`i^TU
+zwOvV;H@x8uZeLkucmilA*K5JJ!w)aPHM&hId5tE~md8~oo;=`ZV}<VU8h3jtzN~qJ
+zT=BQD+6F1O#o9u_@=V_JrZ=?`Dd3<07wb{24`?UXn^_%2x3t4M7f}1>e7;#{fp>qN
+zg|@<6GEydqu5Uuye0H}y?(l44PxGU;McHjp!3yuCOP5NyU`tkSxZ#HSz5{>yh3fWL
+zT6i*O=XkxtUboh%78<V$<6^s$$(GQTM_MT!4`j1I+ca~nYl-|YXV*O1XKnbUoT;@N
+z?Cln6b@M#OxOWuoIVH4{>&QOYwzVkN=oYITU5mQ3;mqofk?8skv^kmtnA%@^P{&rK
+z&7-YG*<^*8cFRjrfSQL^VLfFt&qaGP({x|oO0M_SW0&R{+7h8B^QfV1&1MC8JW!><
+zTJJ+f+Z=fwZ54^z;zjKkU5=UGhJNe)Rn<E^w3F)-<{H{EvL?~yU$VFONOXNi*|Y;k
+zTiv#KH(Iw3REsu8nF94Ja9hkkTVcHpZ51^q=i2)kf7fj{xjt>K3)*UZw7t3<LtA~M
+z3i5cML^-r2bM8x`bK9LSLe3A_Wqnr>?!NnO@oSzmXe(K7`<NDOg}KbNj~ead`rOX5
+z&<6tSa8Q?*WXs9bPXfN`7>q>Mcc3k<eaL7lMm;}jcWI&(ZJu+>wZzU^v=zHn%HCYN
+zMY{`XuRC<^<@3q)LfD>r+DNX^4Q<PlYp<>c3ijG5se(Kn2uecx+{@YH2kZ+opF`f|
+zm6dBZ`&I<$EVOMK2W`c2%cy;HXeZbE>X5-)LtEL>$%T#3R%U!8y1pY@<G|6jU)#*6
+zEwp#zjW^auSv`QZnt0IW6&Kp826-8^j~ead`r>d6ZMRz~u-dWf0krL_Qb8UM3|qdw
+zFRfN-*A@~pqc*g=E#Att3x`=1QqlhX?|)zB+Q*J|a=l8QS>iMC<25k7bmPf2%hpXO
+z={yo$-%$=)o#!Q_*ws1hHaJtMSoM`IDW#w-S4Xi0F|RUeL)%vD+-OIQc5=O|PPOiN
+z_Qf@{Rri`iTbccDeB&Dx<ncgK)`6pKx4{{-rP03bb+4;dN<9$JSDv(>Eoy%PXeZa}
+z^0=$d?~!Y0Ykd-J3z?02BhmF8JE=(s*_8-OoJSGznJOz5zo?v0iLM8tek#vETa}4|
+zwq2WTRPpz}|DA{Y=;qqV^%7lcm2>WwYiL`uY_p8ovFm|1ZBJZ59uMryVkW!FHSX&(
+zJp40g`=`mh6*w8>#-9e-$@RYa-rl(`Xiruekw<NJxsmAlj?L8AwEL27m3C#*skz!N
+zk!z3H>XTKP%|!Ust=BH2w%yq4sBJ6f`B7Uya4(_i$wrgwRXWKMpE(4sp=}e`Nwit%
+z-}~P8D#+u3#7my2C6w9KIW2GT@M&>wkMTQM%9R=hbZD#OAR%Whv?meU%bUsdu6ohB
+z=Q$9rp)H0xiMEKCl#h|<`i|)*Qr5lj$j^K7%%JVsCyT-{SA0uJ!-Do7{_uw~YO_+#
+z9kusD@z`i`9ofy=who7D-TT1@A7p~oDRw=8woN1}$m4+y|GCe7uDz~9JLV`ucRNzI
+z#|pchwc(fRnn7FC?~t?6lIwl-!-L`)+BTA&L|cm54}S22k?8u4L=LMy_a)=G?Q(AO
+z^2tkSac+;#+VD$8y`93Ktyn9A+^GHMKmYl!fBkD2wg2&te;hK}$@RG%W1$Zm8rKDF
+zKH)l8*8_>=_AIU-j|ckv=Rg1Xg@oGvw9uYktZmz)$<?gZ!C4nm(DpOVMY}DGHrmFK
+z@9dpx#*74eD`-3hCHZvw+JEOe-<jOkUQOMx7|2D~{~CRZzHIV7iMGMZg5{Cu`i_On
+zU--fowr6mmGg!1Gqoy6EyJJ0Sa$SsWCV5_6wNhgJSkT@V*JXi>rRyEnfBMs(*gRIx
+zsde+iAO5g#ZJDsUz)R`Yh%kD(CfCc+eHPjVFQp7B$m4;Mp6=8_U~Yd}rH1W*(Ba(v
+zsovw{x)}9cCC^v1|M<s0o@J1a<xC^T=(eqRu4^$;B3Mm;YuSn1j1qf{*F<AAS@5pH
+zvuT}V{;z%QYn5yFCAnUX=z8W4eBc9<wYUvl3J{G%*LRdDX1H$8;6i5*m7Ygi<*2R(
+zTA7S+n}7Z5Ux&7bgU8q5qaDe0oqg278rKR_;99DlG<%h%*g00rsrLNypa0yFd0cx`
+zwp^>=k>hm*aJhr`zyJM{wYZ_}ky}9?5A=NLUJHS_{b`wk^Jt&7;g?|dx4!kQNwnqG
+z>ciEIb_k<(7}phQ2e@W|m%-ZPS{jek#J~ORZ-ORL?mhFVXIv0r`S!QJjcXG({!BSS
+z?nrXI9LwFA-}k=vO`@%WvEANBqU$?`MRU^a8C>WLHqe}(YlC7kG@z)v4(aRNsIB)F
+zv<*`1&qFAT7Ql5!G^mROt_(XJ#0#nsE@JY#-~EngvVDH`v!6+d@Pw4cFWgYL*71_-
+zj=n|zyzjpICd=%L`C7AFK^_lSTpq{^fw}!@{rLG&TeM=*e`w8!8V)VmfBDN_1ixCe
+z&)Q$0o&PR<yfoKmLG7_tEO4IiGFa1x5zc958LXOeysz>YzxmB?e(6hJ5<`*yW4unT
+z7o~Xe<oDit?<Cqb0`vGCiLUQhK*2Y%J%bCKfypsHY74JSIvK3=G~#q<vo;S3?M1mB
+zp|0k)$%rWlsFh@wX<Q;)VkL}likZO)n11)W-{q|M;upX8#1l_^`qQ75T_8J17J)ra
+z(;q&`;6iV{_r32u3vDx|3i5d1`D{V=LSSxxT64X5v=u;`oQbH<V3Notu~Q*8njnr*
+zX%)1W9;WO0m*cvFn(f^}&HOGSb%B}%Zf4CBZm?z}F~XmI`e}0+5B$rQFU#nY4Jfrh
+zm90;H@{`ud+Bh=f*9%cRdD{29=RK2X+hbbrVkEl0;}Om1+MdCM&cH03M_XuM^1|Qv
+z#y5(?7PL(sq0Q@C(AKeyS<KN%gS?`*=s^J2WkOw{E{-yDYIaKpwKRLVJv`wCYqJ>r
+zf&0aRJCo}gyiTqsxeIvno_p?5GN>k@)dPD>b23+u#{*Gsev*a2-2SwRkk4nM@gGiJ
+zxSe)=w?kW(*0J}F_Cj3O!McUo6RbilyUfGQBTj;uI*>-{0=38cPk!<f^B04)Of$jI
+zYJ}^$#c5`|mO_x@bpXp<6YqN0yC!?M7?9gH5?$YMPu<Y%8C>WLBC7Lfn~6+r_;t%I
+zxBT>{KZUmWqfuLDF1rG?Xp8%d9`Z#8YbRfV>lW%7(yCAkRZBs!#81)=>&2W}jvw>e
+zNDXRs5vYZ&&8&IM4Av#njO^{?I=SwM3;WZ)SCeSlK3=9}1$jJ>WyE2!5SZJa_Nk|y
+znn&9fA?gxWE2SRTcfhpKWCYq}SD=D+*~`yBrso&5vEWtdSQPE$xGq=Gnco#^p=wDx
+zd=AuL#qpgozgaZ}YR(oGxUjXEb@7;qO2{-TMmVQgavcWp*w9^f-8DIQ3GebFjYQXX
+z_)L^x*`C3L&fvGr6d^ah*lD-o+#bCB?Qhq6%dSAs<}8{iXL_Vu*Po5+nkib%?=n(@
+zT1d;?5vpdxNCo%A<Ao5|VyzjeK`qCO1zy5iJR4=OE}3SWX36!4TjV>ow3|fxRj+y#
+z>#Kr19=OF`3xT=)X?4GuBIMA%{r1~iqU-S;cibUxW`yc?1uAtIN-A2UHNNxlx^P_w
+z>o)nsoSOMvpcbcQwuzE}+6=`6hog*lMV(mYw~@L)&0SV3@H(?DgSD!#Ilqnsd2CBh
+zo<v(oK;Dv(==zRfkyW-mgA1L3tvHYN+uruJigSCwP}iBwC|$nbj()DU>+>}gt+>Zy
+zO!3`v-452p0ynuRacZ6fX*uT9CHbU4T_)7bGczycZDlBlR-02ZzspDsYCWo0;3aHb
+z2J7T{1TFrZOP4N9qW#*}z7}*9<ne(2#7$oa%<WIhVLOjDcUenxJr)fVrIki&*wWAS
+z_8R$OvdYCW(eARx7n)@+!F92~aqR)c0+If0TFw8@pTJROPR;x_QdifvyX+w;UsR}C
+zY8h)sB}v(3Wu&f9m#{Sp9Ms8mJjIhOvP&nuN!MO`E&uRHbbW_yX6Cg$gA1Kuz6iN4
+zD#%rFZVv>-q~RI1O1?^+XqWmbVMF#pT(^TYJEU0P{0Tx@9A#xrU0mO0G;HrWp;n4Y
+z3W}#?nNu^r`O1vcpe`18ay`k{9^d3Onne5cuYbMUT|piXJj^93EClBErxjz>6(KzN
+zl2aiyr6sx^%Tg<mFPCpipkj@SXipB=$2DG$gLO&&E*WLg3(cunVn*sZp&o7TGN&%)
+zcL%lcdMsR%^-}gl_ieY`b{5)Znj_Km9r=Vp+uJj^&>2h#XV5kVU4Q-c73X?D3VSXT
+zYh2K$guR%ohU_-xRVJ;+!gc2c_n4}Kby=$=PAxCDL^EqVOQ~n^EVg$$O!I!1VY<wz
+z>qz|{Gd#K87sS);3gb?qEtT3#vw}PxeB~=&@sM8#%<WHG(xN7ZY;W=cO>X!_ipL&%
+zOw_Lo*=5039kPvj)q8gMTvtzc32zmT89#q1nBc)x)@tz?dPEC$m|?l6;#nm~-9nA%
+zYI{#Y{rKaL=XgC0*#6#q%Uj-3$E^0ipvJE<5?$X>he4oodj=Oe1CtxSXQ9m(#822>
+zZ#m{sG!pqquH7tKgcl2Z$fNgc3AA@Ozph-jM!2jSE<rwj_L!M9cbN#jsFuQIEO6d$
+zC2DJs+Om!|o;69d!5Y-b_5SdkYxyikvAw6wG%LvCfypc@ZXqzYKP`A?ija%OPHy-m
+zF;9QCV+hAMzj14dw_foh;@U%rmw@3Ryv1+8W5x*QBoqZ;bjjH(gS9xd$KY8(YL7cF
+zAalCPW$IpIMT--jU)ztvpwPZ(G6&e6{!KR??Wi(-@iKY5k3`pZgg>?iaG^6WHQAE}
+z?z2X1iE5J@ep%+}i=Ju46c-y3A?m#1$H=wGH6w&6QjKuQqB0ZAtXW@Wu;%^N4aKwS
+zgt`(9>UX^39g_*kqvdnLT#pya%;T-v6TZ{Uf_ie;sz3h58*k)3tsr*?94re_xs%g!
+z`OasVat&G9Rxh?5sJp^_)Oy8_lxx9v<F%=T2v@B}NEQjSV%DX~XsHTrW?dFmcWXL|
+zXRM6WD?&}i3&pkTJt(w6&77#6`K$wBU;g2a=<?@*bM4_EN0d=<){yOe&%4PDzpl9A
+z3KI=uT$t-@xASXWJ}+FiPBV{aQw*9Ygklb*(1h)k+iHX!bS3$u%RG_Jv^vxmkn4iB
+z@bUEU8TjssP#4&5zWHW@*NFDva}8}SZrybTZ9byO4ZrLvZY(p>l_+*`iGzh#>hSGw
+zzq2~SOF=^J0#1YKG%JNrOs?hg2oCZ^n0@GgItC-W=6)Ngr5~>a^~L16puOL@_F7OE
+zw7J*JH#@YCf@^47X+B@`P^qqQ@q!DtiJ>g4;u6Pob)6j@*Cl-v*P?hHbRySEXUO@-
+zwFI+LjnL$p5w35P{FCA+1NCI_8Fl1%kj{EZ;p@7J=ZO`dJDFbX{3P@Hb6FTQd6|>t
+zwix7Wo51n;|C?fHO$KmvW5(y?C6qUBy6GmpqP<_o!nK}YamPH`I<xIj%0sOEudRag
+z|1Q*Zj9ix>mpfRh2XlstT-Pe2Ze`)RRwKl<HGq>)^M~8>amEBH_I%q_j+g7RE|XO=
+zITk?M!|?xk3prwQN)~PVZ9RVIp@$xQ^wG1fqP+i+k9-6p^?n@@*M7E1<viM=w38ct
+z;a&bly8z_4xGu{*TCNS9E!UjkZY3XM>ol`;{Vb@3zd!!*kI#1%p>W;lx#ylMz2)?{
+zcKOhrj3q&vdLcmnPb2QySx|fY>Z|8+?ONnpDnw9j)^TwSZT)$Eu5CKW_O8#mdSGJ(
+zSsX`dhZn9*qeLy;JLB~X*QF53Sw%06)Md5)xm*|O4HoiY^p=z4+BKeK=0W@2?|yd-
+z+B2&jKu!ErxOOcMKm2e(`{=lawpt4FqxQ^(U&g6p^qX~DOG?4DHC#_V`6N4B@LJ}r
+zG#-Hi=3L==GFu7McI+yT^cA_*TiAGJ^ry=84B7%oF<ei2eO2YvSIf;>k!#l?Knd+*
+z<Qm$~JoC&v+7iV%!|PyO5BShdhU?J|pXVCX0^g;d`0wgm>n%1=vjLEY3Gol`HSag`
+z`_Fv|3)+^t_LFiD#`U<RtgZSg)Na=5T)R>x79Yz2-lkQ4(z!**MU%($$fM?Zt@-sh
+zUV9i;s4LecqtEpG+?UBa*X1g=CjK*QX|9zOUmj?>{YbiJ*Iu~3|Ni^Cv`KUA7V641
+zzbM;ml^6Rh{x0mQMKvPk=i26&-JLp8uEnp#xmvE(k!Z(jajwp9cI&OTcGunx)`e?O
+zi+%6vb{x@pbbB7N4sEb^iUo|<HsjMLue<KLwrPvG+9z<~8q^#_M<nt#KUDy02JH`i
+z@Pn;fj*p$|62Im*EAeZKK9n+>j9;J2wW*4#hTDjL)Zb;Fhy%80$8&8PKE>$V&2zc_
+z*vCGmfW}b^zV44#d-E)`Pl;;_PTPDlT+25rc_}5|tgO)F=PCJS=W>12rrNrlWb*Su
+zCwt@?)E>*AUWIG*q9-rmwBJ+$XflWV*ts^zYV*T!UGu{&zBXT0{z!hfiVE#+^<^>F
+zxm+LezN<0aRn&N2T-(dW!ubOADqPDdjM3!KT49ckE5AmrJpqozA1;Z#a9!4O)nX|s
+z;fPf!=4Q54*K?_qV*OfK&s9QQ=W@+@KeU?|{Cm1`TVZy%u(%snp<adSL*7Pn>AN;o
+zDxT!Jlp;C&e6zx}oc2;z!Ri&|U#!1wiy$dMY5g@Lt=-tVnBwPhZNy*tjvV;;%|znI
+zYuoKfeQcp#g=^8D0~d4ApVtMoPl;=*O-s>2`wS|lY$1$#DQ<TuZf5Ycq^s<KYf8ex
+z91CQ1{%}dTi{6XFKRMS~FxQ~w73rY%r#&=V2k+<)Pp;cLbsAjP9RcKXmQ+$pKgyCW
+zQ*2AHO)l6f7MmM@M7u<<I1<&gY`co%<hpy*1aoa~8l^BssQE^^RkX=<cc)Hoysk^I
+zEj2AmHEZ#3B~#QRRSHQqDfa@exE@lA3@hxDTzB20`!kYjPzzLzP)j^`$xB|+-Kpfd
+zyHh8_wdsGEUl*?H6uXo-E2g+CaoH*Cx>AzVEW2!SUC>s_tm`c~UU$7EhHG;o`&_$I
+zBh>EHl~-Qb-6nq~*WI03k?SR#X3n|8I!J}<)^%1k=PIR!Wv8fy#4BEgY?Cj6Y$-Ra
+zaY=>}xz#$eg1GB2$#vIT0=O<vb5V{^t8X*8gdw@^Zj(PxmFqT&UA*Fk?6T#DK4aF#
+z8s|V0%dY!#86%SGv4^zpEX_5jncpIkBh*4{<Kl&SzjC~8Z_}xA%@nWEE(<md*(E_m
+zAX~v<j&ZqXV%cI|&^Br-JFJqSAZhI<<sirFuD2}8b%B~eH9{@ZyMwy3#*^#rP7!kz
+zfA|sE;nftcL$*M633#coz#2!ZUCB(}pe-;e15HF*dXiN_^IZF)Z*>A*oIhQAm!r7D
+zyp#g<uYUEb5o#u-BG~oT*nH}qd+zDhbB$cH$K0=rb9dS+<qht({y8hobrf8;Q|vlq
+z*DbKs5|^W5?*ruy3fe|(6(=n6vdqnNd%SiZ>sATzy!lqE;RQJs`X93sN3N|{-=MC7
+zd_Qq&58DxH|D;@G3$@}2ZkEc5^-TvO*UvxyynrT;$_2SW^)f|yy0kz8_t>|EdKZG)
+zX?N>4t6aB3c5#fC@+k#v+xkG8K@L(=IX%|EjqV2@e6Z~*j(wox+MoKK4kNAcgkLTY
+zJ0>Xtf{Yn4LF=`J_}iCdo3>i+6oaSw25X@$Ip6q8>Je(sjkW@+I!h{&@r|e}`<mCh
+zrfph%(eX~b@WKlxf2Z0`Xi?1N%a<);YHyQcw_{v?eOz2uv?YprnPpdNT>6=bc0rp#
+zZmul}O_e9ZghVoQD<RT$6~{c}g5YC^dG^_7JvuJV%k_>TNd6f;jgLI?h&>GrsVkxl
+zYHp25sMTZXptkhV&GIN#h3498ukCJ@A`i7<WczC`&TVp~lM2Y$=*%0^xlKnjURSPN
+zBd&`zt_PMKK%gyC1=@Ce5c#rimpn8BH@Z2~EU)gm$_(0V&$)od9+(E%Q7&9Fhm7wG
+zzjM(xvRI`x4%6PT(7P=R>sSpsRu*eh4N1>|ZvA!nB^Gk3r*Q#q$IK;j9F66w$aQpF
+zuYxu=n*35*HJNT(6@qSKH`mSBQN454s68X*Y5$XFrlKX2S}ClAYcGibtn?YQ+1N0g
+zgjyBNHciy1&0ohi!pia}Mz?t7m>gJskHtGacG~){eswByw%&<)%lIMfX?0xVb@{c`
+z`szk)`xBXKTf%7zT?2QaTTc+(<|;RRtJmHhB-*tvvB@8J;DJ`0dMuzo!@{-yTI8;j
+z_axfp=C((fgqk^R9$n9=TT0-sHw)biEhlG<kL&Nsw`{=2`l>(pVjeKaC+$xXf!Z{D
+zIjEg^=YF&LYb)2CL0;TwX3fPWZ#zsGz7y>k5cC$PR_NLTRUccZ3*8pO@<w)O&p@p|
+zv{37TBIf00)km?Kb*51OH)@X){PL4*N+LO7=0Z;UpY-i98KWrUIVrocVzSV|a$Nht
+zlW23JLECiOz-=x@0Ud@vjb(25mcF9TsQ%sd*m``!4L9&BjxUqM@?u!l7fZFgjAD~7
+z16Fx)AlH|naC~t?)t7l|dHq-OV)2eI0G1cB>Ptc0`cgN0e5sRPUY>9DMUe8k>#n=1
+z8r^{nVr2N#!MYxZrE0OF%^T)gCP!*bh)vhimSJVQSv(}3#&QVVERSLrUcb^F$YasB
+z$D4H#-Z^V06f+vn$%R;MPrE4BBihwN&XZO<jNyP~UI5o;yf8lc#@jxV$CC=!AVyKa
+zN_0K27}m1_+IB33;Uv`9Z=pt|1@gReUhSi}-YmIB9>{JM#+5;CzdQNc@=Z`%1kuvB
+z-0{*}PoiC%<a$e`TkeYCTc0W22Ijg=qP+?WS6_W~`!U;a2zghc>w)?e>=0(dB-GuQ
+zYs*VX`yRqx^=4JN+ndGWa<jZ7nzli)_9x{r1q2k_g5^N&&K$sXhjy86cO9kxUPf>x
+zx|hy_afWF2iWvp$d@VL=meGFZnrp6+(^8492fW-P)FM{Q^7iWzzlF)_9O^%C|1aHT
+z?4G<??w2YV9tiEJ^0+7fYQDz~y+!|w;ksNx?JDJ<>oBFy7!=A&=kWq~qJ0(}Vg%gI
+zs?gZegeRf>*vnu3ax2^`(d9t2y5kzuJPhp@%iinVo$_b7S@mf=d9&Ovvw+E1ZQH~}
+zI~FmNR=Oy~<H;kr*7{6`DSd|3R}4Qrr@ZtQ{v77zg?+KK>&pzfyf~umRVQc9e@kLd
+zhqn4-Jkl-N9oL}dY-}k5waWIjlg!_&dcXefM*Z*qg=NLLF6_<fF8pOLdzl(vRnoA7
+zV6Mw`jUA@EQwN1Ss0x&)92>?Yr9=>T9!hXf;6Q;X<Vx%*xgs6fmR!lYuV}Yi8|b@q
+zHJh-r-p7u2*3I&M{gD^;U`Cu#$;fy1!gamC8Cmk5iUN>n(JpR>68aZ45NQ%e7HpE(
+zBXdtOSckT>WL2j+J6w);7k3sTvwor8m&t>?BdaJdDP8=V`{jD_dRI~JLVc!;hRobD
+zYV$dis6mbUqg&dZ;oA%2BKWO!ZQ+#_SkNxxwaNIMci!24;Hs;xvQ~QXUYz^pg}M>l
+z#hxq99zSq^T<=khLu<Nrq!#VsPAp+T0VZa72_iGjjo|(Z^A2rmuei-|t!%=jOP5-x
+z&DJftJhThX-?OCx$@P{3F8%cm?baqYa96qk&N#0x`FovDOa|0PKl;(G;wvYQmG4Vm
+zLY_Zff#f<~^L1OSXgg@9+tn;Di6R)UFYg$~yA<WFBAGC^L44gGlb=5d1(NHdxJ@0}
+z9o;N*-tzY49n>4dl}~A{?t1)+SG+=Pgrm6j{E-_dkX&ydTKrd9uFI%hX53w@AIoht
+z*}p=2Tq^R)SH4n#n)s{87Q+-suEV6>vY`&`@@JvDG7e;~_D#no-S2$oJL^cTup#f+
+zmOm!He&7lu*9U%sx}P^m_sDqnF%EM{r_dJjl4jPOGygn21(NGyyr&(utNh7BZrQjx
+za>sbR`J2~OAh}*wu|xa(4Ah7AQ}g$PDUe);Nu3R)0$~ay*I`m;L#aTR0?Bol)Y(uf
+z5T-zK9VT@)lnR6?kX(mJoeiY|VG1PIVNz#9sX&+l$#t02*-$DFra*EXCUrKH3WO<;
+zT!%@W4W$BM3MAKIQfEV{K$rr_b(qxIP%03nKyn=>bvBd=gej0*he@3cr2=6JB-de5
+zXG5t#m;%XlnAF)&DiEeXavdghHk1m4DUe);Nu3R)0$~ay*I`m;L#aTR0?Bol)Y(uf
+z5T-zK9VT@)lnR6?kX(mJoeiY|VG1PIVNz#9sX&+l$#t02*-$DFra*EXCUrKH3WO<;
+zT!%@W4W$BM3MAKIQfEV{K$rr_b(qxIP%03nKyn=>bvBd=gej0*he@3cr2=6JB-de5
+zXG5t#m;%XlnAF)&DiEeXavdghHk1m4DUe);Nu3R)0$~ay*I`m;L#aTR0?Bol)Y(uf
+z5T-zK9VT@)lnR6?kX(mJoeiY|VG1PIVNz#9sX&+l$#t02*-$DFra*EXCUrKH3WO<;
+zT!%@W4W$BM3MAKIQfEV{K$rr_b(qxIP%03nKyn=>bvBd=gej0*he@3cr2=6JB-de5
+zXG5t#m;%XlnAF)&DiEeXavdghHk1m4DUe);Nu3R)0$~ay*I`m;L#aTR0?Bol)Y(uf
+z5T-zK9VT@)lnR6?kX(mJoeiY|VG1PIVNz#9sX&+l$#t02*-$DFra*EXCUrKH3WO<;
+zT!%@W4W$BM3MAKIQfEV{K$rr_b(qxIP%03nKyn=>bvBd=gej0*he@3cr2=6JB-de5
+zXG5t#m;%XlnAF)&DiEeXavdghHk1m4DUe);Nu3R)0$~ay*I`m;L#aTR0?Bol)Y(uf
+z5T-zK9VT@)lnR6?kX(mJoeiY|VG1PIVNz#9sX&+l$#t02*-$DFra*EXCUrKH3WO<;
+zT!%@W4W$BM3MAKIQfEV{K$rr_b(qxIP%03nKyn=>bvBd=gej0*he@3cr2=6JB-de5
+zXG5t#m;%XlnAF)&DiEeXavdghHk1m4DUe);Nu3R)0$~ay*I`m;L#aTR0?Bol)Y(uf
+z5T-zK9VT@)lnR6?kX(mJoeiY|VG1PIVNz#9sX&+l$#t02*-$DFra*EXCUrKH3WO<;
+zT!%@W4W$BM3MAKIQfEV{K$rr_b(qxIP%03nKyn=>bvBd=gej0*he@3cr2=6JB-de5
+zXG5t#m;%XlnAF)&DiEeXavdghHk1m4DUe);Nu3R)0$~ay*I`m;L#aTR0?Bol)Y(uf
+z5T-zK9VT@)lnR6?kX(mJoeiY|VG1PIVNz#9sX&+l$#t02*-$DFra*EXCUrKH3WO<;
+zT!%@W4W$BM3MAKIQfEV{K$rr_b(qxIP%03nKyn=>bvBd=gej0*he@3cr2=6JB-de5
+zXG5t#m;%XlnAF)&DiEeXavdghHk1m4DUe);Nu3R)0$~ay*I`m;L#aTR0?Bol)Y(uf
+z5T-zK9VT@)lnR6?kX(mJoeiY|VG1PIVNz#9sX&+l$#t02*-$DFra*EXCUrKH3WO<;
+zT!%@W4W$BM3MAKIQfEV{K$rr_b(qxIP%03nKyn=>bvBd=gej0*he@3cr2=6JB-de5
+zXG5t#m;%XlnAF)&DiEeXavdghHk1m4DUe);Nu3R)0$~ay*I`m;L#aTR0?Bol)Y(uf
+z5T-zK9VT@)lnR6?kX(mJoeiY|VG1PIVNz#9sX&+l$#t02*-$DFra*EXCUrKH3WO<;
+zT!%@W4W$BM3MAKIQfEV{K$rr_b(qxIP%03nKyn=>bvBd=gej0*he@3cr2=6JB-de5
+zXG5t#m;%XlnAF)&DiEeXavdghHk1m4DUe);Nu3R)0$~ay*I`m;L#aTR0?Bol)Y(uf
+z5T-zK9VT@)lnR6?kX(mJoeiY|VG1PIVNz#9sX&+l$#t02*-$DFra*EXCUrKH3WO<;
+zT!%@W4W$BM3MAKIQfEV{K$rr_b(qxIP%03nKyn=>bvBd=gej0*he@3cr2=6JB-de5
+zXG5t#m;%XlnAF)&DiEeXavdghHk1m4DUe);Nu3R)0$~ay*I`m;L#aTR0?Bol)Y(uf
+z5T-zK9VT@)lnR6?kX(mJoeiY|VG1PIVNz#9sX&+l$#t02*-$DFra*EXCUrKH3WO<;
+zT!%@W4W$BM3MAKIQfEV{K$rr_b(qxIP%03nKyn=>bvBd=gej0*he@3cr2=6JB-de5
+qXG5t#m;%XlnAF)&DiEeXavdghHk1m4DUe);Nu3R)0$~aiuKydlP=Sg7
+
+literal 0
+HcmV?d00001
+
+diff --git a/nsis/icons/vim_16c.ico b/nsis/icons/vim_16c.ico
+index de18d1d96fd33a6fec38b24bb2fd52f70f3756c2..220b850a0071a11fe265e9e6cefc40435de4dc44 100644
+GIT binary patch
+literal 766
+zcmZvaJx&8L5QX3Vh^(SWNrmXJtQ3eUH^2o4;Rx=M4i}Nu$B1&0Eh5o!15%`*q)358
+zgn2XGuz(ov*z?Ui%~;j~1(z{1h`pA;CC?kWp*wnknmdiP|1ALg5JEn<Go%M}UB^Pw
+z4=G7R=aQ6c|6A?;<m-W355y3`6(k#%FiOlQx861(FXgx_No&buZat%TA9+t&jO@S$
+zVm-G_)OD^$&&M!Qq=_!X(pu{TfAE|%?i)$nI$$fjio6qTj<FT?99c@j_1yFVm-U_^
+z5wM~5^T-1B(|O*gK;~t(DsTg<KvCz}EEwu`5XgOa73$<=F(S)svyykw_9|$YZ_ga8
+z5zY_JWNA0t2ix8bu|(s|Z~mtA`Iyq_E}d4Br}qV_BQHRg^Xx?*OMZG_eaG6Gzhzwm
+s^#!o5Q0$6O9newpFg;>%eZ&>d3AwJ`sNK__(G)MI>Bk<kk<66YUk;_K)&Kwi
+
+literal 766
+zcmbVKu};G<5WS>Hx>TxJSaB_ej+Uyj67>s$qT5;8Z(t*zmW|)&$jHc0VcxTyf-*30
+z*7@$;d%n9y6)AA6HMlEzFGX%eWDB?O7S8%#Hju<M47h^GIF1qmlK)#_W^aoh+<Ou2
+zRB$>}8{LVG2$hI?@9Hj{h;>&2J+YE-?~&<^O2+7b2DHR$Uu!%QuO1)6f`m2Hby_;-
+z%nWaUtH`U6r{F-mSL_7aNacth6g#nCGCpR3NqT=u0yK>Me3Jwm$oJkx0p}&`qTsrZ
+zcTqq(^GWavUj?xrRzc*Kl?D29IlD&$2E;(;YJ@)jeC?b)vJQNrm9AxY<^bB^KE>&-
+z+9{jG@bwzP<uP1dR&SqP79S!@IOF6+&RJid!H?hu{w=dHA5lA}w`=I`sD)3x3UJh9
+Komp}wXMY1w=z16c
+
+diff --git a/nsis/icons/vim_uninst_16c.ico b/nsis/icons/vim_uninst_16c.ico
+index 8196e68740f7eac528faa71eb1dab16418392566..6b11f288d78034c3579783e3054e50bc5ca11254 100644
+GIT binary patch
+literal 766
+zcmZuvy-veG40e8`-k}am2)5|d0WtLfkm%aC;1RL~#BxKWI9r4|#2f09WT?c-6Cef#
+zMg|6kO5wB976yE=ec$;z+m}0{1fwWUN#!FYI)lH27SIJWp&S;1*#8oV@KKDTgT)jY
+zsqcFP2K#6jbOy!HB{idn9A@gp<hUZzQtpqG23(Fz(sBgHOGO0}#>i;9x(qI2G@@}~
+zu2P_t6UDw|u1gn*m*QK5i9xXK9V4^h+A(&s6VNrzB^77_XpbX%31RUE%VP*L-^z*c
+zEgZtq%SQ1XOB*0Fk)XJ2q)K(+fJK`&Z2Ws`+W3}FT8E}JpVe=qK$a>+J;O*&O4#?)
+zNEwWv-QzscVXG1Bd^i}e5rENhr&#-Ha76rkO$`E?t`v9La0rf@rryUnhQc8)1LFel
+zGQtz?LlFe`wYmDeFI`X>gQGp7VRthOeKzcfp1<dmeG*N+$b9w=zs2)|W@~t;U%}_7
+s2c;awROd-dSJZ=Z>(?~D*wQ)nPLU(moXH#Xg<SG_J$=A@qBXVl58bfQ4gdfE
+
+literal 766
+zcma)4Jx{|x40SJ%h^^{?#CCc}DPyV=GZCs_Md}|2QRNviG;4nXKPel3qa$NShDzbt
+zEu{+xpM3GNpTCq78S%t8=6xm~LF7_IZm5x3Q_cUEtUWl0&{(f|(d_$PhJnWa1UTiv
+z<>&#TjKYy(hBhjQ+K>}4mr8|a&p^4XQ{M2jusBrb8PRhN!(pnrtn)^6f)E)llmt&N
+zm6aVYb7i*XkPt1dwNxB}=ztpyNNIe6ah=jEM4UU{!zoRGh2aN9Oq3ar3_rG*XXg0E
+zKD1-!-}}(c_j;JFIJDLC{w=D`wqifWEM6GlFi(p*If3)qJ}8;$1mBN~5j%l6Oi>!P
+zxmvC$IP|VK^xSZ1`=^v^i={|macxqyVqGQfUeR?~dg?IkUdXo!adG?ezszCcvBPyl
+z!|rYv`fS*Vynj}bZCR0O-)uwe`TVHa8^6?xwLQmQ#A3#wUiJH2ud$_nL#5Aa(Jri~
+G_5K2fTY`)L
+
+diff --git a/nsis/icons/welcome.bmp b/nsis/icons/welcome.bmp
+new file mode 100644
+index 0000000000000000000000000000000000000000..6ef2a9b995cf12fc87058a95dd75f1119a9dd2a3
+GIT binary patch
+literal 618006
+zcmeF)3A}7Yl_vURxFCqgARwrS6C#d)BaUc^isC%aTFxK>&I2MAPN<-OiUTN6Dhh&v
+zr6Qo<fC{!)RZ>-0tyZaBYTMe~`ns)t&-d#6BUhd{J7e$6n|U(Nx%Vb<f1AV3%)KLG
+zuUOw&-&!&32OqlY5!>|AzkB*`AOAgkvtI92oA-K~^=_KJ?)}Tlx9R=kje7n6`d|3-
+z{r~uVJ*ot%1QtdDy<>Zhg?XI%AXNfY0whpzUDcpUVDThSalLqbTA!#&pyImfK$XDa
+zNuc6-@%pqrQI$Z&b=83?fyI+R#r5L#X?>z9fr{&@162ZxCxMFV#p~1hL{$P6*Hs6q
+z1Qt&M71xW`r}c@d1S+np4pa#&o&+kc7q3t26IBURTvr{a5?DM5R9r7!pVlX;5~#SY
+zI#4CBcoL|%Uc5f7PgEsPab0zwN?`FMP;tF@eOjNWN}%Gp>Ohsi;z^+5dhz<SK2eoG
+z#dXzzDuKn5K*jaq^=W;gDuIgYssmL5izk7K>&5HS`b1R%71vb<sst8K0u|Sb*QfP~
+zsst*os}58NES>}^t{1OQ>l0N8R9sgbs1jH_2~=D!UZ2({suHNUt~yX9uy_)vxL&+I
+ztxr@XP;p&#ph{rzBv5g^czs%*s7j#Xy6Qlcz~V`u;(GD=v_4UlK*e>{fhvK;lR(Aw
+z;`M2LqAG!k>#74)0*fbsitEMe)A~eJ0u|R)2dV@XPXZO!i`S?1iK+xDuB#4I2`ruj
+zDy|o=PwNv^2~=EH9jFpmJPA}>FJ7P4C#n*txUM=-C9rrBsJLFdKCMqwB~Wo)b)ZUM
+z@gz`jy?A|EpQuWp;=1ZUmB8XjpyGP*`m{b#l|aRH)qyI3#gjnA_2TtueWEIXitDNa
+zRRW7Afr{(J>(lx~RRR^)RR^jB7Eb~d*NfMu^@*wkDz2*zR0%Ae1S+l<uTSd}RS8sF
+zR~@JlSUd?-TrXaq)+eeGsJN~=P$jT<5~#Rdygsc@R3%VxU3H*JVDThSalLqbTA!#&
+zpyImfK$XDaNuc6-@%pqrQI$Z&b=83?fyI+R#r5L#X?>z9fr{&@162ZxCxMFV#p~1h
+zL{$P6*Hs6q1Qt&M71xW`r}c@d1S+np4pa#&o&+kc7q3t26IBURTvr{a5?DM5R9r7!
+zpVlX;5~#SYI#4CBcoL|%Uc5f7PgEsPab0zwN?`FMP;tF@eOjNWN}%Gp>Ohsi;z^+5
+zdhz<SK2eoG#dXzzDuKn5K*jaq^=W;gDuIgYssmL5izk7K>&5HS`b1R%71vb<sst8K
+z0u|Sb*QfP~sst*os}58NES>}^t{1OQ>l0N8R9sgbs1jH_2~=D!UZ2({suHNUt~yX9
+zuy_)vxL&+Itxr@XP;p&#ph{rzBv5g^czs%*s7j#Xy6Qlcz~V`u;(GD=v_4UlK*e>{
+zfhvK;lR(Aw;`M2LqAG!k>#74)0*fbsitEMe)A~eJ0u|R)2dV@XPXZO!i`S?1iK+xD
+zuB#4&1g`%7eiug-$O1^9;(BB5#EiA6P9}MxxfeJ|rS+OMlR(Awnu&VyiVDzO_5c32
+zNsi(!A3JMoUbfz1n-_PUcUDoq+~5+ZxZdDh&}=})&NAZu{M+ySKmXP7-T(VHqmH=1
+z->d%o+qf~8<0Q&&elsY1eI-Y+xlDI83u&J>AEcgdSP4{IZ&>-~+A~Z7bb%>AzVhFH
+zb>*MZ@$LWpZ{PY~|Hbjm|Ld1=#7BSql&*2*zyHcDqX4doT)4}=^M8IFg%`ytyjiBp
+zqReHOvmS9Q5sBRRILQxHPd1bUDy}z_<a50l6iv`U9JGSiH~#SREB@!de*M4y>}$XO
+z>DPYulgs|we=ZK+`}Okw@h>j>#vgwHk}w`%%&xXTbhGd%S(%sq_MhW$t|G-MQ|$%J
+zlPTyQQALJ)G(JB|=ShC#da~LQsJLEj36C#7>pxs@h+qOWunABQ2V!6S&2<<5>Yu*+
+zU;g1szxdG?|Ml-K`j@}G@Mk}a!@1*ce*X7<a=}-BecdJh^~dlC;J_H@9{BD)<t_?`
+zVz;<a2}Q9g%4NC?%$H5aAAYWF42UWM@<9~>;MtM{%>B&|Se%R(OZ|052~=FqD8N~6
+z4^<Bc0ANNmY=Sey!Pggl@`LlQyZYRJ`0i(abmcjJ_pML=?KeO5!*Arn$Itxzw?BLB
+zch39A@16hStKl6Up%oILJNfQDGY>=qAUr}S_$wTiFZk#0yHUx5Vz0U4Q;r{gLq)#y
+zlM9rYOvf*;{mQ@nBMYN&ZF9hT^6X1)y~z`TvFE?zNjo9TBEx!brvxglJH@gFUoM0C
+z&%aH$`_r$uKcE8{AiD6U*L?1uu7a<>{!d>&^Lv+`@$IjC^c#Qkkt@FV;jdqK+Sk4i
+zhx3nIevvOv|JIj3{++L$b@gQ+$pSD1N`N~=TABEKP<lv*M2H4eg~RgM-~XB$KlaTp
+zDQBqIW|`Mq!E`7#nU3qOW<7xY^Z)rjX(7wNjKF*H=}SCe5bXDJ0^!QpmL_R$`t-ty
+zSB%d~@hYz8CCRDEX@eTM1v(f3ItYT$Pki?hSpMLp7o75y^WOKxb56YQQ}4Op?027k
+z)(M|GGatTr@8|#eq>Da%@|QmQ!AmZHad!bM^g$fI%upy9qJsnQynb>4TagOC<N`NF
+z$+=8bDASjI`oLGuhxcqc6z;~euDXmt_~Z{RR}QM6KmcbhSR}QmQFYBD^Y#Jcmng&_
+zMyScR|M>k>$}`Eu71xtUY3|nyaJ}TIX+D<+iCiJDfDc~`&cJoTd1t=;oYRm0<VW6m
+z_G!nR`N6k*;sedYH*Y=bLx1(xAAb9%KjumRX9v!>@?wQ3iq{5h=0f3NF}Pijgy>T*
+z{@kGOPk+qq&60DOZ~N3o-|?9<6w7+JSmE#go6i8dhPhouygVYIKn{Hw-H7_qk$HPG
+zBYe7t4Hl6D^LA|B^y70E{`H~2itDxS<?O6eOfBYJ0yUP)2_n@{!(+k}EFb&vQ{R00
+zDR27d```GH_r2l6C%xgc6N|(5etq*9r?}WH0QjNHKF_NPkWuA`i&+fh+&5e;|I7Qo
+z>)cO(GZQgXxbi=Ik^<vM#h!kOl3fPu3GZj0<_I(L&d+`v-oadf$h^Ru(O^teq+Wk<
+zbzpZCq@7!jz?@HSV?3hr%+)i%*S?!J=^87p*S`DcYGl6!o;(*NhdZDaN@KiyBG7>k
+zKqV}ncH-+l^xilML^nSMv>^_i=1&<1OkSB-y#w61R5XB-J@E^l<lI5kEz5?Y0q0a{
+z-+-v}bsv1sYd`Sr*PMF7YfgFBt51HX!-<c6ayz7lB}pXV+h5UsJV8YcwfiXKcPx|k
+zA6=<QV4ef>A&mD2=@M68ipLXC@3ZuZ?rF8O;(A(%&3OI5S@#*Z9I|K>L*~?YYP1&D
+z#kzqGxL^mSAPatd%-)j+4=4VLcfa+pw;%J8x4!;`Z+?yAh!c)G=3^%ZuBF1jiUUm^
+z^SY}usL=rII$I1SN3m+e=ffTQ@-N@?swceUd5?ebb07D@XFGZB>yCW+JCAj!&f!GW
+zuYBLzwa|?mH(Mld!2j_9KxRM~7T>_T5Z-}8csgJD3Cy7$d1zuBV-Kz#34sAo&(mxg
+z<7G3-|9WzJ#q}C@^s=+=GjI+IYvty|ywCyEKnE|$MV@*BP(!qDct*b1IiTI;KKHok
+zo;Tle-MU`azs<MUV*8zT-21L~I`}D%d(pA41#^W5{YKFP)R3!+C>fSjDv0KY4|?3A
+zcG`89u2Or7z4>i!b>BlC`kdFk;ze(H?aSWwCeYSGZR4_;Bgh3?(B`<Y4hc7GA5m9w
+zIzBfD(sM43<q3>yUP``QcQxv6TrcI{ew~PV06d23a)vFe;u?3^rdZwe7T1~D6(_6O
+ziBT7BDN{sa<&iLOUR8XGJac?t0?Wa8Icw145P|WffAt1X-F)-SJ3%-8%iG-P4oAKB
+zct!&NIr<E0B_rgZ$5Y?sz<Z7_B>&2u?0b*>c<>h-^Xfa^bN>S$@fU|Y>nYEA)#2EJ
+z!T}t*VO({vtbBHZQBqfg=MsRL0qK~7YrvmdcZ-Aof?-_GSU?c<7(Rn;zB@+Y$*tmg
+zLjAm6;ktnE_>U6`aH`AHm?LW`BhH$W!oa1Tj4n}rpnlc+-*NOwZv$-rgcOc-{|6kH
+zVYRZ8?QXn1cMn+%g#v}oN)A8E|88@`ZKo}Es~c>6*Zbb9^DcEA@Syv77Pw}SoJ1h6
+z-c+@`--l1~jRqvDAdUaIGZBfCzkF^=uwU^-CJw*_4k8F)c$#DL`=181Biydgo<!xY
+z54bMy8>yJ|x4(E{IRV>R3^j=Wr@AKNT6Tyh!a2Donv9)-0G$`K9{HZXI{L(fYZyHI
+z9dEwz&O3F&XWB0x{k&(0z5`sc+^XYSpYrk-O<T@{*YA3>-B~IO1b9`)UWv-XWO+J<
+z%Q+hFk^RcxB!HiHrkoy81f_>={9Mvc=uKAWjma&MCnv_K#C|=zc!6=<gmcDnpcoBy
+z&=UkNA2BDY2<7IeLeU;A2@)=Z6i#BEoD?$5f5Eb#^@w-9#b0WV>#o3)j>4T(7!cw1
+z{=yN^J^iScj=Fd*-}B4C#t(k#<G0#+Yi0Vo$E|L8&%bz}EP=?vlQLqSG$IZ$NCf*a
+zd?wE(Eg(oqUi&xK85A=nxL%jt?DTwIalIH4$Q|k={4#x52J)ZM!V1*RWNBnLAER=x
+z^O8xlipOC<R4x4*Bpm-liJ?FgEZZz4#kI+D-*EdIjlmZte9PP4cE9`I=Wh4Ax9IrJ
+z_rCjW@4WBMH{ErMEw^mnwfik^f%<Zq5afijMh2A7zS1}HV~0NX>2hu_KJInTeC1((
+z@ubJ>v;SQKn4Q;;`jY983}mc2FA%4z=spj7@KcX?u?Ls6!zF^Bi@}j|j@#{m6og!?
+z9WGlZ>d=s6?w4kFk3Y}1Ed0rW`Riu4HWAG!qrM5tfB3ms(?T}x60$ggm>jh{$nwWu
+zxDxc%>l&ujjc6NOYfK8Re|?={WiCm^j3z@I|HX?zlfQfJeVa}=?6}KK9`&53ap>Y!
+zE*^=6P%bzy>#uXaKK~6zKl!j19P-R3%V0ZkvCCB9a0@eXySv=6UH;y8yE8ATdF&o3
+zX`vJrWFf{(fnl#v+46Q#_jvFFq`2j}4U@HhExuu47$pXTF%c}F6Iv+fmUbW?p^EIH
+zl`Oh1;rh?NZT50LPu(3yULHPrk@&QIx5-_<NVp#A;{E_}V%q)n6mZ1g!!jU?YE6?C
+zxW$|(;ED-RzT_8NgYpHmb2O*q*?Tsc$6Nr8Duj(R-&hZ_DkIIWan^>A<e3rILi2s3
+z{EvSAGa~5}Smxk_s1dXxwBVd#^ON2d;FTzY4hKlG0Pr3IXK>Acw9A(V1Dqf>VR_6x
+z#ercnA_c}lBaO1P?~QNn|EPyO@G*xNUvrsxZVnQD+3{~2b$#deSPJgJhIqz=>#K)w
+ztwY<m4md~4mswe3k+`26&EAZ@n7vOo+7cE9*U?kiN7KweG`|yYre?GhgxP<SBAOGT
+zq-cB;%K6o0^qC!SdnfB#aaS(m`cDbhX*$YvS4)~1=jEZm69Wh8=fCllyWQeuh0bri
+z%?+OY>X%2>EB*p6?&>Zi))<ovo7-6im<4Sp21AIJj{<O^Yv4K{f3Jr=s3?EW+ueqp
+z3FY@U;rfri2wdk3fCBLWnB`lG+vB5jL5Q8ZCqN!HY}bnO`8(~l%L5+$2=+<`p;(G7
+z{B;x2s%DJ`5msZ7xNm&#*8vCXXGfzi78u<Nfa}~xdYMk@`X-{mha(O+b3G<Ifs#oP
+z#cU{{oFP;?>`D&3J+`u9IOiLeaozIQO<X_r1<z`uM&cTrVUrh2&bmL(6G)*<dKs31
+z8hdwuHlzpYxo@og=|{d4bq5gsI&j^l(`*aPCpt%v9F_;SF=xiaZ+=t2%jrjr>RPwe
+zRz)K>+iWxNA%91dz%qb#<osD4UU&sTdalLry@%DadO0K+HavCr@J<xWQ3|h?7Kv*E
+zs^)R95x2)<7QQ?8(ZZZ;>bNdI9bK#w`Dlpdpk-YQhBElzj86`&Og!&QGqDY?NWdb)
+zv==K*%O!sHLt3E_YCub~BF)(8O<YHOt!?5*2_ku5N(+*vgGwc3WsVd1F$pC;m&arQ
+z{Dn~9diHCMkXU}`lOO9A^w|6p*=9a&+Z%1yIfDhb65dZe0S22@AOq411GVob6*Z3l
+zQ5Va!wa_{gd|n$c1np#ASczr{&P{RyvA|1MS1?b;;n&M!^a_#W7xLfi)_a-2R+KQw
+z#|J<D&;;lH5w+-}#0?rdQRG!8q5xgloWq8^u{LfQ`0jo=(JwQ0?#6ceV&Gaw>t&#(
+zoQyM6^3k!_L4amDlbkd7nBxS<%}G#!6nwRvfDPhD0kUnMvF`?6Ch}%~{DnqRJO;;{
+zD@{Uixn1rRJPQqnYcsoUz3=VubF)4=F<acy`B7F%Ezf)XQN^#Ok!XzP1w%(9BKTR<
+zMR>v(N@1})2!rAEm=-P<R}`X=VFMHBme!vpT>mB|-#n%+U_x0Z<!A;Aqb0lEe2=1>
+z^?qcfqq}ttj;#s~T5G|X74j>Bp*qCOU+2DwIcxyV)VmnE!-z3N(dNa2_9l(%0aE%S
+z!pUwUe!u^zzGI~Y%eplo`jQJwzyRBTGcqaTI-s)sMNINY(pFrF%W|TIS)c$M0b4Pz
+zu5Y%MUU7)%1mK7WC_Hb7QS-v)ey>-zS9Sq108{3C7Pm{AlNj$T9Ohmla=|5pEhc-j
+zhbEAdm{>mL<xYH?LKIaLVz?~{s-J>(0y6wH1f>ugEx9^5{g^1r-HRg-4+CL0+Tq4U
+zIR%#}e)SQ52)hw{0MpP}G8H5#k`hnpM4irB`s>^`s2XJea4jKoO+wCft`f52j^6Qi
+zM(e$i+`j4JI>Uq(L0^vMcn4uJMy*fNyomGCY(`p?hlHr5BeW~{EoVgK;M#!BG8O;z
+zbvzf3P;~t)9jDEFP3Sxm6qCbYN7ZZ#hKwq&9<HUPJumiNfW-h42y<%GJ{{LxEf@)_
+zIGDA5`YGtQ{FQ-q&?Y@;x}uN=J@%2FD-IH4X4x+A$rIp{efadp7*&$j44uMd7lqvV
+zj{C4MI_oii`AnnR#jig4QsHV*K2HtQys(z@&hX20pcZVn-i*U}%wfY8BvqIf=%yiB
+z<=%ng9yZ;J0qso%*MZ{VZ<BsUiU#*)x4CIuENZ4mlqBiW(t_e;IQMr9@T+t&e*{y{
+zIQnJAX!sq-GLgezu3sq+6{1LdMASYzu9G3^t7Qyf(@CC%9%?6_xO%vjCl_}}xfgix
+zq~X-KLYmLA5g@B5nTEz-&cbR22bXX_H(blb6@^Imd8jxT!$HjZ>%nTZMCQNnN%j+>
+z^@TD$?-O78{Gt%_o{5eFeqo$7e&n;CdWQq<hOsjpBA0B&QwHD{KLToP#(CIAWvU{E
+z_1)<3yuP6Z0PX_l_Gm`r-NkW}KkJ$}c|T`Joo4UiS=3{W_ip64E`Z$p*bK5bR_rn2
+zL1x(^0&ZG|>RDP;cxPz!6Mx~?r@i7O_k73$P4*}hEI!KZz*@?*44d>7%Rk!BL{QqG
+z;@l1ANZEkM>=dn~!<~(p@JrFR7<`Yt_ACgk`CVb?Agh>@CQS{${3&DT;G;nR5Qxa*
+z^VC2s({60tEI8-n*&Zpgegu{soFK4>V$faK5fGurSg{^~G7pH->jEUay>dhg!PXIc
+zUKhtPklRw^&Td4HV;6V@P;=A3%Umcwf_G%V2{W!b9j!)><DopJ>otkvW+kXi;^h5g
+zTB>(ZpuN%Jx`6PYi~HeQbh=*PMsw0NRxtwzP)m;K$K)FN3yp*LQL5ycKm9Sk($f7O
+zc;EJ5O&dE8d)gCdX|VCtaM_ffIpRSmo3tK-Bjwv}MtlRRrfpbKvDZGgvsm)(2i@OP
+z5F7(*<v``!XfnL;N*=H%#4TJf{ioj2(Z#PqY?6U)2lhfxfx%@^ADbr3s3OM4+Y{G)
+z&w(Pho+wWh0BUT+95(f`T6%;{05s)$*loAFVY3;mD2QcbH5DM^TBozItcQwtbKwIs
+z&Lk#KpT4wiy}zRiT&pXNjP6LJU=9dU>;gylX;?F$JtynEVzWQT8#hi|=RQqvUfR<h
+zin+ObB(}D+Ihf3ewLj7$+zr0~)Rbq?r+wB3FEp09=Ad`k<EBk@8h;KrGP=RWvpt_h
+z{sR?Va@jO$Kqjxc3?4ZwBSA%zz!`EStawk_>u<1G4+zNNm3$8@ZjWS9n}Gm6nk|7q
+zs~_^jM;BEX>H<uKMERtr*hrM+S#W`CJY4>~xZOwC2{;Rduw34du|nzDD_IW0PtLSI
+z-&NzmP+q+#gryn-YI5@{9bjWw+87q+cJ(+zovcuQLY;VuShSy%_-^yoEHg3ojRlz=
+zV;o;*fMp{nH}V3aHqcI9yHChzSMnNtuRTjIZ}59JHe9z6P1NwKHxbu-#K#EYbTK~0
+zFHl<j1;V<OxpwGT(N-d0=bed0VyA^JjsJ+y@&#}gE;~ipGxM|ou47<s$u42z!B^uE
+zcDTvTMZ@HcDP&lx=3mMTCbSw-ctD`$9Hj_~+s#2W;=}ZTHm}VBw6|Lk*E1aoR6fy(
+zsm0?^4A<zlF){}lz$O$7Kk6c6h!#@>oIwVnVTY#%>Wn)jGaUlq_VgP}K7><%Vn|}y
+zS(`8uV{l*iq{j(EluTUTjQd9LK5F3%H83NW#6%pDmYhC9F4h)7pnuI?&f4gtXw^pk
+zaihX@?m_V390Sp?%w0kjnimHj=c5SAiSEG1B)}s?rCszqsb$}8^AYGDz2bHYRUiKm
+z*R>M}4Wv96KGqje_PnULCsh;`8pIL5xh_J{NC8<+)oz}(T2^zw9o41A9#ivj*vKcs
+zkuY}OyYJV&m!HBqauu>z?b$ExlAFS`l^^IPLtZtY9r3l*9G#$cF9WC-I8cRahW4<r
+z@C#zv8QvcO&^0WrV4>YkcZC8pArs#uakZQ^GB8Nj_nAPrX#!EHsV{9I6yKOgV-}xE
+zmBXkGMm8I{lx)Lu8=5E0Ms9@X8xO8SXoMLGk7fs=VHtRFJd&rGTpI_9IQi0FU#2-x
+zS0@t7DbpGKD=MUulwUkWOHG+5`n3I#M>9uS4vi(3^@SSNfV<(~kO48{{Hb{VN!c#k
+zgQtKykLFqUJN34Sv^I-C@At@qWv(Lcr-c9lP@Y|;OUv6~ue<nq{wS&laq-;{(OHF*
+znw%JPM^>5iNRrFurp;t)%PoH+qplZ#T4GA81nC+X+*=7;zuB$+0=Vy8K;ZdaCvtbX
+zJ9Gd{ng~iN(V#aGSvQ@v&dQ*s1Cy*E%T*gVV+zPT*m#U=Mw&E*T{)lAZ$q@C*|v=k
+z(b1%h1lJkV;ih@9;Ml-R70En8Hc=a<NBMojO*?QuJc_gCAUJDS25NqRE`>)M&%Mo*
+zj=lJJC4;jR*x}smYyz<0X*@pPtqQH0ONgEIHq<qs&2GpcGg%(ZGkTCQ^UBZ(LGFPM
+ze~6(U3Ba4|zFSt*_6c`MQCW{c6~DYTs({&1&Nl(=25Aoj2l$V<EUI&XUf}px81Xw$
+z0}J_wn?~=6)WA3IuTliq$D*B{f;5_taUM7#bHpa>Jf6nFQ-+AFxn}l9nGPom9UbU2
+zZbfy?kDgSFw(PS1@N=?C19nR*!gP=ZIJ6`wKtBL)wss>#_r`$h0@Q5{G?pPJ23eAy
+zX*1iaFGKlsZkj=H?RP}hVn(b_5QpY*3J&3+zP2Givj_7zJv5=(JVw_u0%=K9W9dZf
+z*aHqCJ~JiaE{Sms)49>1vv+0j)B{u2k1RNDBth-#1yp{bQ71MP)Zl<d+gh5bGRAt0
+zDzp7PO28JuTFT2Aa$4FdnR$d|;*E)FKJwtQmxiQ^LLjRN>H^WJ<^9Qoh!gHHaMl-o
+z3dv_ZL=CcJ%&)3FZ&C7u9}$uuW`aB1hFeL8oi`e94%G}`511!__nmld_UtM##}YO;
+zt_$^sor09|n6w4E<2`Xs1X5~<Yd|KUTNi`8D2eITxtui>3fJ(6XFRF1Pw{PQA#-*J
+zt~nIsmZug)I<U}0JBN4NH7LfJ&Jou-F+ckt^ytsg^7ujz3XG@#MLWUO`B0r-%7KR!
+zN*Wk*wu|WI7e6Agl`X+&)`-orvDhrbtAo&Nev<>$ezScf(w#7&Fz9>CN`kt1yK^^Y
+zfHYf6A0R7aBJ9G@7!W-kk#%;~OgaWmL)y7Avu<P*nSCSyD;OhBzk+rO@s^f@IYImJ
+zC_Mu2SUS!lUI>7P2XCT#j=-F;s11ngq92=)<{-m!Rhmac4RjfOV4VGpsRiOVkuOE!
+ztod<c*4Q2H%2V^a!Km9^On)ByghL}K1lMuUx19ThcZ0$=*mj#j>*Axr=ZothXtz^^
+zzxxTL;)4u5ceZEDm*&g4F-zD<s2?vw&PZm?Mp9Z<(V~(ur4>K5S;U?0bpXVnvY1uO
+z=L97g>1;8C&vs~GX~|HB7T_|FtyR(5Wl;Ag{DV?VafxsYsDth2fe)R?T+j{A+upGa
+zCl|E=BVZag;p-U?S;Qi`&ktyQ4QC-!>Tq!!>0|$8!AcMqYL8a&=4=l4om66JXv`zb
+zh{t)|zCmzZ>RV&^4^0kGBXxo`>H*7<et}0lDC?q6)4YOje+40jZi*DawF`J^ZWq1m
+z%=cPdNDW-Z0w@a8R<gf7TF795a4``pcXyn)VD7li&>ldqFN%O(xT*+>rSjT?Uq$oc
+zqtM%cROFztl4OAgYBIW25df#F2D3!don_`P;gQ{IkFd+;g)<c#F}Au!lsyVN#>#Vn
+zaUxNmVbMq@gd8&yxJbN3RFX!}uKi9b`O1q!D`J+5_+5wUL6J4v?%9iy#WE>OURo2R
+zGzis5g|uh8#l1F*Ljtiu)iF~JC%%!}aif;dPXMQ=f_+?q@77;I%d?!b<TupG8sj=Y
+zcv7(bK_G*E{NpbeRa_UN16Uz5P_x6rWLyzdcBBBUKl+J=F}yrA%ExyHu5~f46(ch3
+z$tQdYHBg!o&^9G=@eUhxqH1j)RA`8gP)|cb1LxacSu9SHSeB;Zgifjy0C7=qE7Md2
+z2pT3vwjY{_XM7fUMrrL9=33fSBpcG-;e^eMSBh-E;|?JK@HDhddPd)fmpv4x6vDBI
+zal{UEUiZnNF_pzNV?HW2+NNRJ@2OcEpk^z0Of&$paBt)-%@F?FnfgvMC<DdNr`WhJ
+zMd(EpNCI^lC|GL^FV_$Co#_R;HBvv==RVTkOD|A0_Yt`rPlp4r575mXGQ6ax%_<7r
+z@GNcNukkl)hU+1v>UUojIK9=6xDAq{AIS}7K^5q9pZHhsYgPt!4cdU|d(pH+mX6bv
+zRwaw9eaR8i5PnBYS9CE#=zGcr(M-MD9lEb`(NJ-3^P>)pzFUoM$|7=-ptl6@5ESc|
+z59%t(K;L8@*ue14`Svkw%h%*8axYNM=mHwcH^GtNwir4bWFz~#nzM@Sm7V}Xy&+K#
+zM$%8iIw8{(W<D28MZ-L@XXF7>j-@{{0s2rf56hCXIeHn28Su!8VD;K2_s#{h*R8WQ
+z!H{!qA<QE%N~(v&U>w@hiA8Yyg=aUD&EdpH41`XmnLk&25t*c=ESQJYPIA))8x^$I
+z2G_aQbX-=Xa6<$_B}fLb31=PoZ9QeANe{v@P$QxUHk$1ldSy~U)(R(LH#lVkq+a=J
+zTZlA&b#59Vg8<YN1FlVWYJ0unmd=lic09`%?9BL6l%M|&03I-J{mqw6)vD%QVLh5?
+zqVQ;^CzXa01d(c!FOgw;fLOmoKY~nzv79WoUc}LzBK6_}ZHOiX0HH6&vjB%O@RjnV
+z`WJp#W{puDBky3w0aKGCRf@t9FwmoH3EKU`GX@h#=BqzjK>423y@d(#QAG?$3e(Ow
+z#fho~fRqQuks=n4d{|UwNA!(XXz)e_?bXJ0R-q=MbsW~mCX)vK2GNWj6G}ue*O9eP
+zxIX(dE;v$QKn>k6+qoa6P9$?(z>Kp1!o8xG(N~U!4jAyAWPH<BLioVF4?d_UM^a@f
+z1kHl+EV}icthkmaS=VG-i$INT<GoxY1!e<jxV)l-HbChP9M~d}LM+ri`ZUs0F+Q#k
+zPS%_*Va}Mug>^2u82~6&1rX&(lu?FE8-N$(X5_&+#w-vpDxt^qds{0cSTqTcJsNb!
+z5s%4_P&ws`m)Q;e*Pf6$#plta>pkhv(SP?)j^H?PMh{=oJSyRNH#TUmDz2OTMX-b%
+zy${X=OB5V5@e0ZuKy8#E@h;PrF24xpVWRaW2TiG%XmMYAdyP;q#EBA8IbDym%k313
+z2chyL&Auxx$REwBk}svtY;t?}oAL2bE5^~rc4O|K)H_Q{!n42D1@ck66=>@Pf8m$I
+zVjHu#;zZc1XPbBdYKiNZazOc=fQcTomucY~8QW-vza_4JbfpxWAx=hH?JPX=E{>KG
+zaTq=Wa14zlFUr&^et}<(yjGwas2L3;Upx8h2sf0^_z2IDKmnZ@J|?(QA<vs|z4Tge
+zC+X;CTm^m95|a@ZP!c5|1_5m~l7m_jL+F!`4b|hThwH2}o{>m%5Dn3&8mU4twg$+|
+zvJ=KLK1Py6;(}h$qVU?r7DuJF_+LhwYOw<>s`F`QgNJh7;<mRoG^5va8EdQoymnK8
+zu}V+jxi(a1twy~GO-tD-BuekFu{vcid91%`gTd4b#G*T(%nGTdSe!G(^qE$3_sjwp
+z2Fv(!$~#?>l1@s?%FlqqDKdYnJM8UV{T`|kEukukN<4h&O{03&^)SV@1G3pf7UhZP
+z&6bC8EShc<?GbBJFpfi9fEFf(9P`Iw7nlBWFeF^FgBf~2{SM3gLRc`0G@##SeMlr?
+zCV(jos6`x>iBU6mF$l~8XvgRn+R11z9iAd^y`i*am2e$B<<SDvo;1>}L`~qjQZJLL
+z-j`$4>CR&)fksK%7-f)}5W*N*rAwVJr--fuJzd~R`XjT!&$6plH5MH`<|9)t`lcr|
+zM^QS9sR!!zXb!R$&$Sx(+E8T<dTNOP0~D*v`{*FOLk{$omBV3-iA$0@+5=cj0qn%R
+z@M3HTxs4lz#u1G&*DSfh!>NVl(}&RftT4W(Ew1sC>nVnwWwH5duGw_5m|eh_V^dFh
+z*<bS7?Zg)k4rp$Vyq1PhKP_}*XYB$kg6~KXoc%YJmg+l~*zqN@t$dukGfTkBSSDkH
+zjw$efWJPsV$C9WELqLHxpvztjT<1Q@peD?eg#5*i4F8cQ%<6ZTWr`g-&PQoay2NEu
+z3~6Uh9MWAm9;5;{mKLr#1&SnZ$+NKPV}P80l1{fk$zXRPUH$PdW+4X0mDXMs0sHZ2
+z8w!J~QE%=nfa28XWa_D<Iph$^>hh0SXzddk9*~g_*Tsyst_-@xLOQs3ft8}#xNgeR
+zd6PLLs@z|UsV{VjAX+qCjD4%RJ*+Py3TTE@#Llz`e_%{J6kFkl3_v(*ipSv!F7$rr
+z03Qv}s*_9@^(v)80)jiSydg*?NU`c-Mo^9o>#|oB*P$u_YH_ruX0!>M*mXA}Ook%3
+zh*KC(ZaR$&{`8uNxb+AnS??>??fxNy(S$ai+kRz6vpX!T79_I&sW*!y%>51SIwvil
+zTXb(Vz_nq^3_vxFFy-ei^#aGOM+{y!rB|FAo8X?pUo!}<r{TZ|&KQ)u2h+`Nhrd=V
+za5b4~e)hn)W(=jy`kO>41p3;W8y78!k0zf(D@V+>FiQN0r_eBl0=iLU&xI3)vld(g
+z15a%2j8iD2x{#B0z}{I`{t{=<Je~+0RnZ1_*>lJBpm!P}8zo`Jb$7}=UVaf`2Ftoh
+z*n(UUCfO3EpQ7to0AU*8`0K{@s7e-QJ~2U2H#z7Jqd}b>{`4p2Uz;c9tLS$L-muTw
+zpaJYaWH@PpW>~G+yd};p``S1`9RlzCn;|p)q}gRKmAv*Je*t}g0uHDhP&ehnuemGY
+zYp?|(>dgi+wiuLyRHeivGfjkJe%X0dv}tN?26qsp0VBhX;sU8YYHx1bY(|{(p3F5O
+zO~)veHh?x1^AU7O^ZZ2{Xqr}WDD;pL0yT7FYcyv<>(Q>-HwQiLQ5ZtR8co~f(Z+Yd
+z+<#pyT=#QjxvxW#Ko>)zWGD+N%Psj}UV-c)153`R8lp}tOhIN%m^rNoG0J-zdTvh_
+zWL@=+9>m*el%nvWV*4y5xa<LkK3t6&0M7bUSE3DilQp1n;<C<F#-cg>wf4O;s=EUM
+zQ~e!PRD2&r1r1Itt3PrP(Ws69kj@x0It8~0V#Y~HyNNM@5pdv<NYOL?x|#E|L4+|x
+zVQf46)Qo6DgxEA8aLx5I{?OOnFEQHC{EMq2#<WY%aw3=mhoT&wl*{m!M$r>J?gDC{
+zSUfx_;dy6TAkb`Tv)BpGNrS2|iKN#|jJG>$e2>id>wIzDR1dnr?0Z18M@j+Q^e-!_
+zLj^Bp6c~s!pg{hdCJ766Bs`5WaH+Nk0Bw??Dxx+ez@YF-H^E?9UD$dHjI53-cnV}5
+z4|Hziw6iZnWJX}st{>SM2bim|y_;X$uA?>2qs=Jlx!m4Xk1TVD$j7M5#<ZbX4rdCg
+z$#?fBS3?<*8l|!<0xAoPb5gF)E<1>>m@DN!b;l3Cp|9H=A?p=2Hk;&|z%_@?o&>I$
+zYnp>0>n1k&$%nsC8`=dH-_Q^*2d7=xWg`+m?XQN(*0L2*CR}q0_&}#Gh+>6xkAKl~
+za6E_kHtf=vHt-#h7$4A*{+L(p8Yj)(X+HiO&*zBi+}hkVDfif)8VYOpEl5ggkxa}k
+z;2c3UriLQMMbg_OKw_a$pdCz}$<@VSX4^xk<d2OrATD$0JE}N-rxg0xwhx7R_-Ouv
+zN1LO}S5{OOZ$4?NN;+SfSXF$Vug@o=8jvp-l+d514zmGsNRM+BF}8%v7fV!f%C7fQ
+zMA`5thC-oPW9-+_`PyIO#i}b>;+rU{>92J<GS9SfsX?@8ksM}`Lu+?jd}FYKAE6JZ
+zpwx}O(z8M~J_1|gQ{dWPe4stwMhOPv7y+ut%XqX1G=j#93r3}J)aYV-mAT7u3+efr
+zda8l$LI`vDI6JPhGQ>$zi9QL}HHHqw$Rvqi<HmAjdW0BFFyJoDF^H+5<k=oN(Q9rG
+zLYVAB|7})`Kl`8@UCcojU5RG1x{-DZ%S`3k3qXpy#(Y$uNTIEMbCLX1g>(oxymJG3
+z6sAz2(4W*J4K0eIM%6yDqNuK`D7WNJ4`}Nzz{kn;8pGc1DKZCDHx|u^qC7~(wX_V*
+zjLR_~pch`10*K?rbX@x<NdRn+Dh94uBs@)Nf$K0A?ZC|zrU+*U)}!H{TnsWF{F7y%
+z&z&m=6~&jio<VS9I+k9V;5@o%Rna{QuCoq==0xWbf+JWNU=I9sf4;HoN8;gUoPtep
+z(@3~kLoqp_-4UjiF?UUuo#m+<UCfOZgis;uCrwak9EhCoYWy}q?W*G&U4y8%b+1sx
+zHTan2947;5FRl5aBm=@6`qTd#Zlb9_?kdU|-}2((&W};Ta;y4HN{#7zH$)4-Im)(#
+zWskW(Hx_O1jds!>B~TvDQD%ly(1|)-n#%!ACX-AOXt(QS<QZyB;;-R4`)jyvkL6Jt
+zZO|A1^p`LrUqq?sSdI=@hR!6dy|X;N$Bb~&c^t$NicL_d@J7EB(wODr%5a@~Idn|(
+z;=z}7tiQC-gRs~szP|Q5tS*;Ln4rzu^4g>J+0z{yCF>dzAcRcCWjthKBHAL)&Mow%
+zyCdzUQ*a^YLMq!Sw0n8fH^{kQ3e#vS-YlYC*}YlRq4P=LOKLWNb3a-krRKrkB?r;m
+zv}Y;GYZkb&CbjR%Wd<sj)u8XEuq<d2hFjthGB-oaEuG~=2^t^DgLi?UP6usX+adcZ
+zplb(E{DrARlPu@4;56cE-T|V6hYN}eeUMitz|ieb@1UT`+L)_$)nzCLWmbZzDNtP8
+zE-eH5G|+H%8d>O57w*QnZ#-Q>cT8Vt(DJrSR`$&baNX`i&C?N~SFDqhFjE>2R_vP~
+zOYg*jJE+8|Is@d8jHxDwy1Ozw$zfn0<lmMu9&n9}nfzJElTC0<G$UGq4zUc9y5^UT
+zS%9D%<J#hSO^s(<nMmh&R~EICFrgXLS?1vmJRoW3!^e<7MtA6E6w)kqUaie#Hrts&
+z5uDRsktvHUL)BSt6yh>Zr~MQ_oX%y(>_jl(9h6{vx#;xU?{}B5;jWh}Tkj4tF#;0o
+z5w7LU+RHpSk$_&1pJ)<Qq?wWG$^HedQP4ImG-M_iVFw})&%XcyOJ%H$J}WASIx`sZ
+ziO27h%(P!li|c{pm%N6DWyCa(bJR{zmA@qHW9XQ31}dOUP&x(Z+OKqMc9W4N*NB5i
+zBMoH#It^qy*S{(M)_)zd$Vguhrm1DI3cFbX{L<&>j>314Dg!I0YV&-X|1b*<##R~!
+z>-H>jl<l;AQCuG_Sr&Mopbj2q=|u^I93BA#97G)_(F=anHAy-9zT3TkwtCRk{$`t<
+z4=~=KnsGt#r1@ihSWVRz+7A~{01=>s^-&@7Oxi2*3|PB9Ok5Jk?|vfBCOU3vMf05g
+zV2^pS8E6-~W|?dQdWs4GhJ)}i{7aL`(?hs6QfAV4vkK=D3pAg~;q7jry$<d7EWU(y
+zoy7v{9nU*oXitUfEOu?s673;L4@;dukEzrJ{%UYCNBw=?G8qnR>L9(-UME!u<bjVl
+zgay!v(9Og}x1w`KujIo4Fqk}CCqDnYXB4;lC@4!hoKwVo?wZ}l@=vWqP}Z>xdlI5v
+z7WfjV!%a68IHjlhTd7l_IFkH-oi^N~HhKp-Tu<%YJAihB_(c`-eb{E>i}UqX<a*XX
+z2Wc%d(I497iKrIa?k^k_-3>kgjU1Q+3_UdmVH=r(q}l$3E=B50h#geC@D9oh=&3z9
+ztp0*xQq=|^HPj-;M>`F_(m=Sz9t8sJgbzK0V#+L(;F28bjVaS~+v6yIHK08?uA_sJ
+z1zrNR_5d%Li=Z`9`ytU&gQ3SK1ivPi(Wi(MjG95Wc?+E>#G<og)ri830x}^S1Wa-p
+zsAWzfjY*gxPf=1k<7zZbQwyaU<v!xF^{U*OUC?ZHw3(hKL)vFY)Rk0e8svsKC2dM*
+zAb<@FrbozhCL37j7&z{=g7%7KmDMamoBo9I1QltMJvrDx&n{VSvT}fVa5j>$_)ALM
+zAd3kSAQ=I&6$<7V@)2xBF=}Q#5f6(Z(ruD-5Hi`)aM}o-(szcxO~!~pZJ@>w+Em;%
+zv4X}hy40WilE1P95_c3^GZYKjI+Wqn=6QMT32~jJ9iR@5q&=QDx#0e5&_PcG#FTju
+z0?}ZKN2BN=`{@X}?k@1mOCY5eWKr5%fXcBDR7#cfH<)q@nefy=9l{Lq!(d`lSae|)
+zq&M5RZsH}*SFC=kcVn}W1*k)Yq2$aaY7}F{q#ZO>N1#K_DU5yzopdFcy9+>+ux4I+
+zWg^Ot@7X~+x!|RsgCaTj$7WyKYtaSGy9OBVJD`9``lb(g&rS%`k{P6>JO!oV7id&_
+zJXAu4TX9)PHHb6~kK}xer^kX3X2F1$(YN;C4x<6T>;O2^UNCn!@zIEFOoUqvXitLc
+z5LyU_NeNIBj`q+W%|?$!E0M1B)Sg`s!MM>V>XdY8X%sJMW`CZE%PfL3V*!^YkoGIi
+z^_?ksG8+WwaDp<C62hZr8A*Q`N#C0|BvsPvYv*PJMYC6?T^s7Ite;LoKeML}(UB*R
+zMo>e-<WKA9o?f6NjH-h}!83i2JGqAM=D6L(#Sfs}59pNK^bQ-3xUvv39<%cWb8^V9
+z-(vhh#`XFu-_?1Nwb$)rC}1Hvvf?$+X{a=PrBEUB75%DwzLkdK&y<#bfp=QRp@8#{
+z9)9`U_HrQ^LS5rVnYv^^`upEfW9U{6)Mx`c98PeKUVFW`4k?9LLaJ&PKF2g*t@7X!
+zgRseOBFRw35K%2og!BT}L5Bt^y0jS3vtTuh09m0!ZNZYWTm<RCvcpLrItjD?-WI}P
+zZ#AHuvM|v%x_d(*bOrS`6><!yBk<vlNe_N?fq;eX@jgTmdgvS9Cv;!?ogkC?A|*ZA
+z(B3FB3|SN*hfu#{h5DHR9{~-xJW;2d^X<(OchSJ)vYXSJue{iB6$fh6wZOIDj#^S|
+zI_3aF>dnO@#&|~Bn|c81(+3NefVVxlG;(ErQcjwb_2H8^G9v<p)x3$x{0%{Ya9dXb
+z6kj<nXphHrh$W=j1T})ECECN_g!$5D2cT&`E9WQnFyorNP2Qmqn}=}_`0zE6!GPIJ
+z&a;GNK266p>}3Gd+&lwYgbCv;o^B;=5)&o0Z)8q2zO&Oe&MylM3?(EtdYC=6ekW4G
+z2UYHv@q}M+)(dPS{bW?xSm)trWQ{oS6enJHHRg%8Z;H@vN~SoUyes2IQVqf>JVYju
+z8S2L*lAG*VkzS*OQnIufka0zSDHTLF8Kb*=5AOs{Gqc{tiH#S6@H4h)5_NwcPBSf=
+zYsO8m(Q$K!_844eQGjHCI!U83&&0Dpu}2o3gjdyaUK=6jEW%A-jFGEMpza@0nm~!~
+zprurf?y*{KeCiP|E+pfln8jW<CJBJHn3^Psnjwt{1&Na0EbbDm%du$x<o&+Eugn^o
+zrPK*(dO~8t91@Q3hgPs}REq%lonTFjEr63MrKK~p7bj;$M?!m*Gvu>~H%q2@vVsER
+zb{?NHXZ4fs<x+VT;^IIHMS^r`x@Ee!^akNzjMN^eX&}#{FWTEN89!x&*;Tezk3a`!
+z-JZE&@Llcmh4v_14}`GfVY!U(u-b{*A<w{@0+arWXsz1dOg$_&O0TGs9Gc}nreaEq
+z8E9Y-sH-xQ(k`XbbAcY5SlCSN-a9o4+4^W}DLGFvAxS|B9p;j-eOq01?qq0qT3svX
+z`VDnUNP8fk#*kLwsRPtNN(ZQ-E@0e919f3tnL7?ek5D#YosNKaD#uyq4xC&Z*8%Mj
+z8S)J!iq)$(giHg2je|DhpFE3s5kLF}14w%9bqdD6>;QmF=7S64TwFY0r~OyYw5O}l
+zTb-iI7~zELFMQH1kkX!+=1RLQ(f>I@dp)>bTEUSqm_bc#w37oxlEn*wJGiE1OjGe<
+zwa89~C(5{%!;#F9Q4g1mOuCnGXhYScK@-3Cy~loRooS+$V9T7e_bCd4U|NgL+Jtbu
+z0#MTvfF)<Vh4K)4B8Po%Lj9bhi_k3?q)r?<8^{!|AKHCFmD{s=5Zh2C4?(-1=Lu*_
+zRzM#Sc~wMcQS)yavU$LPG@Mk4n&pIO`fsR<(mJ=BR`dEew`qV(h?3>aT*e8yo%>To
+zdlIZ$On76ZM?pJUKDpdFah)GOQNjL9T>uo<i>X<D^gBQu8Gu-sm3L_8HN3F0cue#9
+zGN`k)lu{EgCR{HW%;d7qIo;lm#qE=SM4Y%M?Vnr%8}`Z&wZ9=B!Wl)s5$W*M9uQpt
+zSZ<n*K`~=UVGIheu@2|DhFb}r!dim1L_~(RxN;;RzurJQbXyKB=3sEF)LY78)V^C>
+zIdns%co4dIG+8eRaH#LpPj)pRBL_nMI!jOKBY0_3@hHIrNVWpBBSQ{!d|wV@LsceJ
+z*HO66bj5?SY0#%GF&&OgPpA`J67yPUX(p#b2uz*OjL!GSTcD9LnM-4c=p|;Z*&Hi*
+z(pav<<0F<)xE1l8vKs%TsRhi!0)v`S4NyyKcv9NMN0T{MVj2&Hv7X)ENJr=nzS~B8
+z5xI!qDzt&3X-LC_BII0*#8FJfAmL6O9<O`FuY6OJhz^qB{T0fwqsXYKS#}H%Jpmd}
+zC;{{UQ0|n$2g%8GyN&C3aD{kk0QAV{g!IB-7_PtlK6T<3s1QWUS6ea}=k39L&kJr$
+zkkUeo0qXG790zlO0<n{lx9Ez8V%ZqOy!NM%*r<<kkEAjAgHLGpR`0T=f`t{$@?oWe
+z%w)UAQwOM7{sij&YpTGO@1Q4PU3G;0v>m#`H?bED^Naq0HXeu$RcIH`4)#bVMVde)
+zNpAR+Hs-CjM(Nv_@6DaaQ#)7*Dy_eyhL9-z1vtF6lTlt9-Q~5x4UYvqnxJ`fBXB*T
+zhIisR)GQ|F@T!s1i_{j-X`%5Z&Kj2Oc>>xtCNfX2bBUbQRa}OKDJ_O<2vC`95nCZ+
+zMuzyI!bt$br+Y{~GH(jmD27vr6!(@W!=@&D<kf@f<R#AzYJjC4Tr=UrvTd{t+3N)d
+zerSh4{i1_tQREvL0aGYB@e1uWw39{cFLt1u6p8PaU~Ip|sZhN3M;a^t1CK%JskD$8
+zWI%xYbwmu*3XvFFU$!IGDAVg80RcL&SspO4@hM&QI9&JFwi~DdK<ML4c?wa3FhTPu
+z3}|x}R7+mEIV6{#7pUnT6cZP=1KnCkZrqT3LiivlAlx1Umk8pFBEg$x=A3@Y_-!!N
+zVhD^rGdp3*CWqCAy>doSQwg9Zf074YyYaxXeSwU~c+Zr-&V55N!J`sOf7e@L_cjxl
+zE3~8chkBtOAsYXJ?$A<kB1Hwg^)C6$+HSm6d@8XlsN|~H&*Z7kIX#0~ufa|vJvgt<
+z#CR@Ee?dfc*@M~R6I1a~xMsmTU<@&%`iL}VD)@zKh+}ZrAMIp<(7#U34Ai{2TsPMY
+z+UNvy`^y+cK0%qDUEC+H%VId>g8cQ!c#GhX^=MDv@!+<n&<qnZR$#|A5=2ufwkUYf
+zRP;N8nlA=h;AK={Sw83KN4+!-=KyY#0ghYm_}g3;lc6o45gGDvX|#=aTzf8E*+zGC
+zM*y5NqO@dgET+9yD`SwBniOs1alkw;zer+}CWm_h6PgSuK#hn}Z@zevjXq3$S0?y?
+zAuwuK_%Cf<@3XHL*Al0JYhD!q4V@TR0joH;>`qX7<g{J?B^Pk?pe@`0XYmVw3mGVq
+zm>T!?_-qBDLIMsaF%{f-N(!BJVtUcx=9^~$#)%cvKpmmSw03O00$IHavI?yL)TESR
+zv?Wj71hs%A!THFSn$;7BbKm%$<A!mWheCiA+Ra|>?3Wmr0Hx%_`ynKkgtE#^V%iq?
+zW9e2mc+<MEY~S;Gl$nzf8iz{r%aPR-N=FXUH$d$&8*COmGU}rYo~#k(z``V4|M|Dk
+z+GhJZ&&T81vw#mWAc|)?G)c3e+ks>7+M_@n?KI`v^9Ho}Xho%Uh5aR9JcR<WZa~If
+zXe=54%g$qdg^vs!nRJFZUhczIFci~1Z>JE};LA?s3D*$BkEmmsXbccE6J?`7%_9e>
+z!Pz1ONd_Bq`0Ly^(9MZ-W-|3og?7>D%?@%NY%2Y2to_Uhq7;Dt?1!8S2hHCBg|sA1
+zW_xKb;td)xP9ab=y92H{Yi^6DwhL1yih-qbTpQOCXwS=Er##`(9#aBXc>uFLBfDji
+zgP@qd9uMkhyd9@KIB2KIPW_G9mBvue+nAR-$SU+-ki^UU#giU`TM`0iouc^u`;I$b
+z1n{o&J^=_<{Nd-{{?ot3C_rW@MIWu;W6|j|erz@%6eiq3=*jr(cPFS(>n5lJ(NG*m
+zpxYL0z}r-z&9-iSs?h#@XSX&xE6xWPAD$-}OB+ImP2UA)o`{3Sw>cwNj;wMFOu#jt
+zr7PR3OQK8U#^Foc+Mc8C0+BoT%!P+1Tra(JiJ$cpF(AdyIzW4rBN$Sh{s*t2L{v1J
+zagc&T!r>YZ7vCWOWa5#z=H{+7rrJulNe#tdAH27p7e!$xgg<cYk-x{TE-m&MbVNUZ
+z9dq99!Om|wdw=pTn`O=g)a+gX>VUJgu4X(soY0@*#U)$r*4ySjz0LL<>YwVh$M<8=
+zcL54^m_wm^d=m%9S?6J_(AXGuOk<A6rZGoJOCAdFJ2&>xAErr%vqJ!=eP<vq);0!5
+ze>7=)o8#9`9`0TxB$n8pYlq&)f?v-9m5$CAOq-C?IZIZ{Z6+o~CQ`sC*oQC?F?Ed*
+z6L(P5A%*Mpya1g*94~*zu}8e~*v=Yhue{~A{`d0k>oNOfy1y;>H+wUmPa@3rHTm`s
+zDXGrrsXIZP5goY3^xB}l$zi?i9@<;?k_zo^H{I^L<~Pxg^eWbj2mr;EU^q1Rd&;}G
+zA<?%<&O#xa$^qRRHz)4<Lc`-DP{UW`os<b&$ZGq|zb?MtBM**dG#fVRd<?EV#Q@s<
+zx3HyAdwZq!Ux(M89&bUV7@7I9+@rJo7R&J3u*}^<H(M9^aG^R=hBUVC@&*u~e#HsL
+z9sS<pUvu(1+gpzsE|fz5*8lR>^0avunQQR02cYF+U=Ws&-bCf(BF&<1-oARCI)mCG
+zbcek<J3+nMF@0PgR-ruut{aoJjMbu@u@o_U6V936StHr&?Ts1Noo_s$@b+GoAd>qv
+zsZ4?ex&vPbKpSGp^ed&x3O44XjcXT&LYB^@zgsU7;=l@;FtnE=ct&~+v`1wIOph09
+zn^(qhJMeHwccV~UUcHlkm`d@g_q{zW&piEPB&YqbyWDK|ul(CTeCvPz8#Ycp2*z|r
+zKh+sFA)AGOdBS)f;7xeO`51ZTpPF~g1=Q`B8vPDX2cpM=dKuRh+W)aaXa^!_3kbj<
+z^2}vNIB5ZnTxAm!&Mm;?uMKH+&agsmWy6~MEr!*EmJYaRZw_X_D=XOelTKW_B}1Ef
+z=c+wX9K2+v3g*o4yu7(Yw;?T=bJJ`(Uv=b3ts;+=gOcGc6JN7+{54xQD*2DYA9vP=
+zBpXk<@KbHkDf8h^f0FDOi$^T}PI$ODAH?ezn1v<3KOWuVrMils?vH0lluZljAzaT6
+z?O}^IUK)$>Yeob@NL#qqyfXtfZc0@r)0PG51U0P&UPV!}A&4~`6M!_cSU9aVOeoAz
+zxORJ1&g5>Evi(`xCBEbYaBtB8L}(-nX6(sex9qnjjp80=yh}BZgPeaXN>Yf#0+-!6
+zqy@QdIpxb<qkQ2gl5a?zDVz4tHE{^iwVx4&^d`VV>`C&&Y8;XoCE+YLCv*1HGl06p
+zb%plyUOPIJKJac-g}zBC$IMC478iFym;$%|F#<Ggfa|_?6%Y%cF&#204|wz=pu+{D
+zRIdH~7+g1@9l9D?I`lVU@cv^a3)bIFMOqBamM9xFsRmB@U&mnn$%jue5MW5_sQ3KU
+zsJWvLdfX$u7`-i@_~vG}+3Vu|rrG4+kmVbH#AWGkKV!fm;TsH;M}YARaFjmCd4hIp
+z<`tQ=<r#u%ip#yak0$6xC97hpaq4CI9iTq!1uO8>K;41s3hgPOox8Pwwq%!-k=)U!
+zjCWgaDKllDV00r?YY0|>^nUg`YgAj=#(Xm#*KuPmxj501fztNp%tHi#$R~JAaR+iP
+zd}eCe59J%K*?1olhk<j}hWuW6(%U4*3|o&{!q!=iFRg+7_;)UrOBC-oB<<IG#FhTK
+z3&#*aXg1pm<{lvc9_UWwe0WC@Pu-M5Q?||TqnkD!P{Z{N59+Oh<>HtzLq5!8n$lRv
+z^XTHx{Oq+k2)e|b2|~TnVw9pbzn28&?!}BvXgBqzdA<TkPJ-)ZvAMdWw@c2NC&FX3
+zlP7`>V2PP0QVQmq<y~Q$&*hwJPH=wT+Z~c)uRZmIH}&^nHg%_SRI9k%M`^Sd9P=v7
+zUtI5RjG!4MpX7*(-ROu>b=DwZ{Fm4A^&SMelkZ-74-Ur-q}jA)Ib`AFZ=7s|px)`p
+zy*;1N+x8(XT+i;chnY+k$fBM^M>nAz94sbMicih0YU^t8jm685G6vc+N^e?Rt8VaI
+zOQT={4bR2Rv0A(yXaI<y1Gt#4G$H59=Z<36zBe<6rv~abf9zyo@_WDV$q!s|zG<R`
+z9NHg^DTvdJm!+vP*Ic14alLVeNVc!{uPa^eF1ITLkJ4Zm*K)QuZ6{J}r{Cw~8QM)0
+z7v~!%sBe3C?|={Y?)cUzplv3kV2W`jB4!W`8@bEMFtkG;Giv5WdwcHgfHs345tdL6
+zR4G5QY6*5*V~cM<BSHIjKUwzLOH^?7XP*|=@lZ`;#pZwjV-;}bsly3^3A_k8uyJc!
+zn$yXe4~TWspJP7yezCUP{)aBTVANc@Jmt);!Zu7h>#9o?9xG^w$oQIMT{<qmh&GNt
+zT;oc&NXxsI>M9D-DX>oA`k@=^V5Ts04~UI0Upd_FjJ305LO2^qOpSi?)B$R^o&&U(
+z-UUe}^f_db&7Eh@YQMlI9y5+K%Q5mNW^mb3sgDIf;3k?wLMB4DUj-tkM9so$C+%vi
+zuqL`0p}j&}_nozF<*6gMfMw4D7uf?QPkPN2qHGAVz5{IUbgu)Nh|cHIYdkejvjClg
+z1+KjFeeR(U3zW>w!|e@%LnZJ!kA>T^>n?C`;?|^$KV0KVx8M@S+N?WMwE|@|HCVHu
+zn}O0n;kX&qPG}cuJm~8Uk|^7?XGU4%$C`f&P|qFOVeZ-~h^+Zz(4DWD@nlRD`KKAH
+zaC<H)pG27fZC*RVZHNF>fCYp@p7j)}3)FJL?RT{!r66O5HUzm#CMV_4mMU6%T&tRm
+z@)Qgd?typ%H7xLY;WPsvJSis#DIk*;n1A|Xa$=*lm*JybHfjiazx&_&lh<6qP@Hx3
+z*C3j=1!p5=;E4%{$4xSqUAKh9GIkZM|2XILSQBbGfu(Z_(Lyi>aD^vy_un!$AfG(c
+zuhSw^;dWDvbF3ZxJLu(!L9J5lG{z@$Xv$42y__Wb-7!sc8c@#!?Q5=R$|Re+$S&rw
+zgMs@-&inklDWB!@_;rqdmwf1Q75STa)shQroj^BKnjA$#hy{HmDEe=vL2OEF!EAP9
+zabf`%C*m>)qFv##GZoxmxL#WA#o)vu4p;+?aD_nUBdD5S=G^2Hlgi-QFx;*0xKHtb
+z@p074b4@_~)HNxBW+=G+sKvlHJi;bNZ(56$BLE`7?jS~K_VI^n(#8F4W6e(2HV|VR
+zV2vM#Zl+0fDiuwzy(HfW?WDlDi!&u#8q&hbMh$6gSWwRhZ8Ax*_L8~dYm6NrZ-H(G
+zKLAe89YoYV;-~rkZPyat%(0ec71?Cv)kXton-uzop9|lRJ-A5ur7wM!)1myu=(e~L
+zS9FalU7v=%8dQA4;#%rBC`XX(z#6#mgRl&J0l;ufX1|AHvY%=vwA)|a;~@{k?IpO7
+z0iKi`&~*S*AUp!5g|7Uak`0y#SR8WflN_!T*Spc}me+x~0tE|Nt_rp&QbyR6ooxcz
+z9=7eZn|)1%bWLPYHgZtU0&OzM<__mfBZK`EM2rj$03P$EmL@0?OZU;3UL{mt;W4W4
+z;`<esKm07&YDL!vzysaB@hi_8Y}_~tSp_ucm0imU4Y$_~7RpG%wLs6~D}kp#^*1c8
+zd9lDX6o3O73?0^$#|{bnpd)RYU}@@UCxQ}OI}B{u1-*F2_Q(4?{2`t?K&^bSFk8WB
+z<N{$?QG%DW&DsgarNv+GJl0`Ti}6QX=6W}x5SpZI0M5&6Kck@{W)|PT$u&T@t&e!^
+zCbXO6GZ3v`HX%^24BAO1S6-aVT|Wh3>>y<q`(p>tO`qu}fQ!+nw}U|1NBorkx_J5M
+zFF;5obRNwsm#WC+v@7yW{xwdPD~h5zYl$x#b;Z3=e(HBfU!o-gbPG-qwk0;M7A`<?
+zMu<vQ=pRqfUN_<07919Tjn{czWo~#}_h-Kc-+(?X$G~HkHa-;AyuQZ)JMa?Dlp6&f
+zi#WnL7ViWpaDD$nAO4xY{}!2eaJmF#;%NRf?E<&7X*N{CZ|sR`QfpfA+F$f4x3>P{
+zEw7ColI`c27QesiE!wPk><=1%-s2uPd0MD40^0gcM`stKyY;@_8RMy$i=ZxK64XVr
+z*DR(EAh-WcHTXqDArr#~(mwQ-yJ7JH-Sm?_3orxYU@j>E>CMA84nM`=%8o+`?W60;
+zTuv0*tjPI9bt!gzbww>oQ)V(a{jLvyH?s-}*Zl;GpInK_h*l(EaZYNi>kBGQ=Rw>1
+zYv`T;lP+z*_!>!2d+?1&5nyGaQF&=t;P1d~`yF=(oO->H$#t5YeInHGxe<nMcjN5~
+zILF6>9)IY0|Cn9^tJvhJ`<oBL8iN24e6%WnF=6@Gw8buH*ntzPiNk8{@kd<d7JKu$
+zT_K8MA2@yOM9u}^m<GbHodn*7wl34xx;VQ7=em-LvUQZ45jI}N;z^!hVv%In2tmC9
+zugyM_i6O!?cChp+Ug%Ea{(0tJV~#Fa6$ki}(%|S%{pIm-p*V2+QAfVU^@C%n9Ay@@
+z#K+~j@-2<J6ga-FW<^m2o!9jNaJ`?<y)+{+`R;z21v&!StQ=(^92g<1@q3VZ)d-6b
+z`S!Kv;R)A~5|7l`()&hZzcMbnn1#YdJ@m<sr3@g++X6K|$ORXdWq?~Sa>0+kkLF2A
+zqXDtzi>C(ah|u{~`|AQDI74V`v1_L<hpgj-M_g}TM7Jvhz!eyKZe!*M22L&`CoGaG
+zFQ9E`n=<I-=;H7`5Umrb0rn-AxCw!J1<+<%^$UB&4RPGem;Um|d=njJ(_owv2lI6N
+z@>;r`4<F-u7m%bY<8aqhN8F_Z<qYala-*(PQNOOZAlEfjE%7W-OIR(YfJI_7^msz|
+z5^c+lo6839fOhb=q!lK3{PY@XZ>CvR_4Wx3+#tASMxx$jmmROW{qfb}(1^0zZ>R@t
+z>-~XRVvzGi<VG#xc;vI6LXtEjs0%;|+nECQHn}S&3yk*H1y6fI#)h1B>N8)(VL4|$
+z;+xJdW8Y4<D@0KWWGFCsOu#HSSv3Jg6WVf{5o^<4N<~riS9TNn8rZ22#Wr{mWMkv^
+z)J<AG6(PsLbfperd!d^V7Bm4ka?UrA0E$jf(k~7&$wz$Sr*y&61YozsAxk;_$XBYu
+zk&H>dA_<V9uK4KtsLPdcOD@65n7Z<1xfVr*)zZtU_xoGy25pOoEOPHaouSQ@^XZAm
+z^<Ou@Ch!++Hl6{_slnHb&f4wM&P!Rw_3$V*b3|@BmqqGaC2h9{;GzjG7&Z4ypuxa0
+zYedQmP#C!~WEi-_)I2^<jW7dsZ19y3-CyNo+nK?JoUtdTZ8@7q`%B;S_wCGEcjk?G
+zljDBNYjN_}MzRg<99L>*auZ7qf&_q_E@}J#)R$khk<;%csHgSXHq90dvAX&Qx{X%k
+znS0cL0W?Yo=EiX#oj1>ij}AYPl51E47n7>H2FF#GVfZ7D{$;Lrm&5G}QB;_ec3m0}
+zbwx!})V0)}K`s3%JO!9D6ugh#XURG4WoY*aIdn&$9ceU<J10~D+{MDNVo#flYl^p_
+zaNUG<$^-ZJK=X7S(<AE|?znSmnQc@-((<eP6wQ+-AN~Tq4>~|Y?})6GlXC3+cN-zb
+zv`CICJT(ssi3~`Bb05O7cVGNvAA~CQOPusL@Sa*_sk`_6*)kEA5F?o2YQ>86Xl4pY
+z0GcynVY{Ji+UpsqO7w3Sa2VHYjzhoGAN~t<StC$CWoVjc8>-WOGr89WZFx(E*J!5L
+z%Jas|JuHPymXsg|{g@ECgpqV|)n&f)le{`%3g2Ap7M6j~ng<uqJeohbIBJQRz=~R~
+zD_3{bWs)0%y1xAtb*X4nT?+54D=Jb;JdVceU$#Q;>v8<N6WS4Ir*O4DB_?_B{upRv
+zS%uylx6SBmG}?qf#MiSs>y`QIs5i6mfHp$}l>u$GlntN!1t=bk=M}A7+<)sCbTGff
+z7?E{2Yw0X1#FI*P35o;Md4Ju!#}`?da$oGP+Z5f5=k|MvSt}Gq|0eHn?RSE(L9}Mm
+zTP>#{F)Fv>L|O5olPyQhD4RE^r}f(W4hALrAy$$#HQ$CQ4vgzQew-*kCc!ozef%=o
+zB<UK~0E=^rLzXfo04t>Ph+qAU>)q(~RM90Dbkx<aNCW&Nsp~SG5_RQ@6g9r0NbtHb
+z9w%r?^u8YFxRJCBZIl~wIp~b*<!MXiFZEMu>8GW`H#~xr6ai}ITs(Eaa|Jwn2-p4A
+zf_6^qgLVLusJ--a5*#7bHZr<Q0Mb~;%C71HX)8nF(q&k2IO}+a1xnxC3kaNJk1q>6
+zN9EWjX~`tlaN@dH|H3cpoe3dCa~YaVi)bAsPr1G`PBE@G?U2@n1@+X>-gOrw%99!j
+ziJ5z{D4cjqObQGJ0273lkmY+uz%>M=my2n@MAvz+lW{O3j;P20XxNinSE{8^5#+j{
+zIp5g5xv0*Hd^xz_oYQkHK}(njmI_0_&jZ@LHvcPY%DbgNyU)g9HiJ5xpuhQ>ILY6~
+zNg!)3e^-oawMS!83u8DwkJ<h5TI`e;!(P@4ZLf`E6C!O$IKmb;!U*#Y9po<!E`=45
+zb#~T4zl&Y_5b3<@+9U{F@ioXfMTKAJ2IL@<8qDN^Jnf>@G+fI!QBY3{ZG*6kv&5!!
+zM4F@9z_=a+Ti^w&I0DFltTb)u?9*Z{le<W)ISp88%_GkZE~Wu1!5AnQ=DJidIQk0*
+z!XZXQ%_+yZKqt+Loadi3NyE}StFuo7cF)2@=zV;HVGn2{<l;wZG@Mg<JiBbr$bc;%
+zTzs4hmYaplg6lT4Bi2r-zonI%+}WOc-)0no4tv`%kyS{z{@qXT8MtNx`9UU;nblb&
+zEMsPd7!odJZ5T_gESz<A)Al_xfvx=}uTk~R_`Q6l9bz>v+z>1~I0%U5fM^#TpnGXl
+zuK&IgOm)J^Cmo*pWnHVZR)>DKBk{>&Z7)<6OvNk(4;~l?iahfW^ujX+mIGfpS4Pyu
+zZpo9EbhmM|d?+)H_{Oge(_>s86)8bE1N5EsA?2&fF=RBBUKYvHx{;?)LKKxNDo&ae
+zxl1h`C#EAZ8k`O@9#ikc+Vqz8cDn2g?I!M4`+P=RcS2i~VMrHFCDRx&5ojm0<-rj6
+z2+!e~Oh|^KhimZ*p`kr`hw;>{#-5BX2ML!hlPk;4+G@BW|1cwLC%GN8EidJl`5;&h
+zJ_*qpOk=f~@)!q~69`aidCK*T-lNPU!^uH?o5Rvd>a{s0hqm`R;Zc~Cpou|)3qlBh
+zC*1WNUpVCi=hIFMh`G$gZlMqE%`<`Zc;`W+u5qPFL{Sku0x66uljO5ESEF;^gxzqB
+zE2FMr*6~CY*{AE&6Jk0d0|nZwI`2bQrO^c1B2e0%a^p+88;PTvE_=1H+$?`~To=&x
+zEaD4}8@i!24n(DRg}055nlp0(*Tw|lI+Ed7F2cj)vXgKv|1XGxjzPw(k83ftWc8TW
+zgdKFyL63dxW1l+nzsEoR@jLCbQ-OE%z>YUs7zZB>(KMD8(N!u(TjDjfD*^Q`y_<~i
+z)N2XqX$krEJMGBc=Bc>}cm28d;aEu~4j-Y+PfQ<(!KwZ=C4&vb%F@xF2`oly9`R-R
+zJ3I&2?QFupk}R#|iHZu-!5Zk4p}HDVjz`s{Rc=v>$I-J&W}Pre`YF~Hg<<1Omra?4
+zmXST%q;Z|0jdFMp(B_2`!EP+5kv5FC3Gj5U`@p+h7FW6~a&G)}foo1M;rg@_by?ur
+z?2*8=@hl|VD;2zFq<~v|1iF{J<R#Z!bImJX`O0JG@$ZE%eBq66eB+`nBX^+9BRIkV
+zC3Wq;M_z-epV9D59n>p;wy?;v!zmCA-1kYzeG`r&Ip{v3fiV!B;M|%IEMO<P;_#(d
+z%pubvv|;Mqm~j{A4)@)x3mylEKK_j?ZPcY}6cVK=wq0G+l`C?iK4pcpUtc5S@@d$3
+zxNOcSMcKc+7Dq)^BYU=~`|BV8ITa9?ZD#c&Hz)=HZ63`9*#Z=}CY<cA;hGa{;~Lq6
+zYj5hzJ0lfv+h&_>-tmri{KtR%$KU?#-_8ryY{T=P|NQN@FDJBX145p4Rliean#TB3
+z32GS$ffPG*ZRX!Wzc(gN-K6@H6LPBqYzC4*XNJ%5Z^WDj=(bG2Zqn~PJ_8N*UE@k9
+z12N)?IfQvKu$Vm``O7pv@YOGOCFl`ypnJ%S^w%S>9;)l8s}JW?*Q;Nys9da*?z;LF
+zrMZa5rU^@|2ctoa#avvraUTgZL!5?zG8K;jFWxOQf9*r;x$y8NvCrrZ<Oas`mt1o`
+z@ATJjEm|>PL|lPuw1*~84}uMU9k`Z*E#Mp<cinZ@PkriBKs|R{gZ8tZ{p=gw@P<Xb
+z3EGc8l=kZMa6OtzOSP7&jESkOh$&<0jTO{Wd+i-}um?_HArQwkLpM-FY@7IS-+Lxd
+zzu{;I4RJvhi8+d?zYJp>zE2k%^-@<RfaeLo{ptO|5Yz(B0|T<e^Euq8D-fN!=BQNB
+zdh3dc+!b>XRl!_POD<c2MZVOSNT%Y(bW&D)X>afi<+A6F>%w<u6vs*P*VVxF-h1zT
+z#T8css8<8mp#98eK6Be`OY-mKVqRg)M+c(mK+2LGm6S7v<PeOU=!>EDO%BwvKs%^%
+zq`Uw;fx6QM_9X_tNoeiazcDwsKLOY^3E)S)6g&gk$!lkNaKdo`?Jy(i&BS2Y-cD1O
+zigYOBqZUOeRt`;+EmLaZ3My^{N4{5fD6--kJj7llTsJ*<`#dl{cU<4;PIvn8kAIv&
+zUEmraf9*8?Uj6D<kBZCX;cjq)a#fC@bK}}{ET|nXFwoDgH+0Mb>bsrPyXnJvH$7w(
+zkKG^DJK(gGZ@=9U9ktx#fxUHm^)^4Cb?o2UY&Zj9gLkX!%`31Xzyw`eTA8EkaN?sc
+z{bZg`m_gr*t@gdgeqOfduzG0J5f`}9^=2&J`QCRoVc1OIJPp_z9?b+E91nS*kEzB7
+z9B5ZexMpD8I7MBWbdUX16tyTvfnIFk#kGvNwTk8#i>FL8X1#SfBY@$jtaxLe1Ulaa
+z!s>mqNVtCD6Q9@wb;k7@-tdMuzxmDI{`R-OKh3{$&pmexwAHoMR$CQ>++uStNeo_>
+zJx-+f@=!ZxJqxJAX>L3GditUnbNP6?S0r5TeN?Zv*<8vSS%{ah^0^M!8F|s1elW=)
+z`RiA|{6;$r8=yIr-z)}2uede=FY@8D#Mhm;KJ2i=PC4b2X#l-^?K$V1GX~m^d)(vJ
+zty|aZO6NQjXa|SP+<U&D2DjZFR#ZFxkGnp2Fh0J`&E{WtQ6ioL*A~}|S-@D_va*kM
+zp2wxpgZ!fEm6bEeUEFuY^(x`|2S511M?d<}WuQ)f_Q_9vatyQ|{pd%xp>5$jXlFM)
+zcTmIi?O(O(ZuAB>9Z>OIA2Nv+&vXrx!8M+<)2_SBRL}%Bdw&*a<IfXZJJTiJz-6>6
+zrNkSvNmq|}7bPz|55M^0i>F8P&>d%<dFE?g^O{ky_92HHvc(o#6dDlFZX$Xv^gBp+
+z{9OYo9ur{JfQn<qVp6zn@5oUIcJ_~Uu$O*E#q(BOvzIxl1XO&%^5KQ`C_b)I-mH^{
+z&yH&#KmGL6rQAkA`{08QZcj}&VTNmn)c4#$ov8T1qqJ#m-|zB(B`Q9&N_cMNHwz*w
+zxHidWwW&Bb8?NHA$8Ve2Y}<;@QSplFRf@0Yf@{z|?X=UzK>NWDesEhMx83fBmWQkc
+zs5`0nBOm$556$*(zx{?XS6kntxBrI{w0HfBA=UPzuXx2PW~u7k?|!$rL(M{=46Y>`
+zi)jhBxy@~6smQ%gc}jYjPV*n@!DY8!tn=`PKYYfz?s1QMG%GT9T8LeFxOt>=&zsE)
+z*P#7@4}9QtuY27nul;}rJfID2$zHMcDosAw_7+Vg>fQCOcO8l!rvGsG;fD{E*z4W;
+z#r>@KE6Z^HS<iab^u-U|ao_viw^<iA8pDFcYhT1TXP<rc(4A9$_`(;yu=UnkH|sJ?
+zW*FLtq}lAv@AuhfpDD{OFF)!i;|D|kQ1OcEjU3l{@qO=m-xz2gc;JCUo!b9UOm^LJ
+zelyAnD!%2GTbgKBs@gQ4&p-eCV(@O~`z}%OVH<LXJKSNKf;+B#)vM(GhW^Ql^VcTj
+z7Ut3P-H!XG`KoZEmXw+i%4HXCixW(pamE?b6kJ~Wr7wM{;31~US6pxWxYm*HdCz-Z
+z|N7UD^4j;hSNHC1p}}(mb)w=eH)?T8scKVxE+DYgj=lXq&_Ts#hrlJ5T(aGE+cklW
+zil;&U!(LEi#Z5Pw@*&F0U;5IQHY;*&CW)DW4|(FFi|?QFoadA`Px-m9?Xu!lKr|;?
+z7P+QX`dIVfQ}$cB{GIQ7r@1bppnbpr-LC`Qa;Nz(y<7t-eyhLiQ}Ncw+U!*PK@WOR
+z6INI;P#Yh-{eE|8evgWub=Fxc=%##2n~IyF#$}tMQY`XaB`RKVy)nnvSx=lCfBf-p
+zdefUmL0hQX)XX^F@+Q5TyrSIvWT&U}W?4@?I~9N1+uqh(o-TJ(w0x&~4XAiwLskF*
+zbA+0872H6*s5o3pHqJ=JFTM2ACq3y&&AO}xYCe~Yhbik4<3%{X0v;kXYgY8AM?I=p
+zk#khM;(AlTHE17q+;PVob4(|+O<Tnti~jX--5$MNj#`HHjG&$i6~{f=?QDLtZu{PT
+zCnsp{_R!|ny%j*fYPg{yS|3pHSRGSj#qW5>J2s8#B<C^!t>TxzU^mR>l|7RiU;eg#
+zrje7BpRX}cQdps)z)ZzgiE?)qTX}fypcS0JH3)Y?+fSXUweIG<U0#`>Jv*pj%~80~
+zyWHh2Q$5J{zW2R7_SmCP#p2^FpVLjnEp3~su8(}=BjX_;qh&IWqfN!l4w|YiVM6f~
+z#YgKztp7sARoeV%S{`!s)mPv8*0*k!&_1`@A(!0=z*YLP;(97=DK6Hhv8ZGew5=O$
+z_wu?udpkaUCi)$Sj=zN)T|rjdME7<ho8Rno_qkE=+uwdYuRb?H1+LBWEG)qDp7*>$
+z_~So*_`@H@D4I`EobR&7O;K^#vo;ks4QYJg#jiMjQF!q&sQ4;DxU<-b>!OdQ{dm<?
+zSB)9@dgB}4c-z}{Y@)u+&3kuy{{Spakgni-@1x7X<!Q6x?|Rp}3Oy`7Zn<6WZtqL2
+zEy8)gnHB=;b)&|fVv^qMRGjB69;EqE<5h%;TWHz*-ubjt{Dc!uC`u?k1{LoF;3|Dt
+zaXl@N+t;JAV<wOr6uZ@}ZdG)&kK6Ct+wYY5Kznv7ezThmt=h8aW0waG9s9gCHTCwd
+z?rk>g1E;0p+-Tv5o0756HRHNHxI8Ttf5tPO(Jb7#87bbCV<oi{R3D-vD?TF?|L%9c
+zyZi3DH|sJ~XWom2V|ae-24jD}wWQ(|*KM4x;2Vp($1M9Y0d>zkJC;n}_%6NuPn`p_
+zXQ$#eTy3i5x*LzA6UBNHyn0%3-R^d`Yu42p-h0ODT1-vhNfGkG0zCJ*&z-6+8Lfhf
+z+nUK{gEq~x&!jEs?8_8c@nXHn3V4V~yv>I)8Oi2IcICC6YlBP?uehE{RmNQWt#5s6
+zjMs+xo8P=+`NR%)8_dC80Rzvs%udDIOmfd>b{m{F75~`BJ~l=y?Vn0FdV}6(!-5$=
+z`$f;0k&4TH6yZGln%HT-LHml^$jEj^HZ?-UE&Xny()qMhT>7*qfwSI#yOLI1w-s;2
+z-`HBs^vKQ}nlFz&`sjkKg(mEH_c=g&b}C+&ogEM8#`Qk0nLicZ;{LtOhUrX#_Tvw2
+zQ}IuH;uBN#PGLi=pXI6T>Thc@dzh#FFyHnjyV6<SRoIYev*MRuetEGCwe6D9uB453
+zbyXg|vi(R`Z=L4kx^&rPmyIFhmO<^d+irzn_i<-)Kl=NLWfwf{$?R0T$ch`bj$B#0
+zCEMO|=m}=0;+x;Px9%k!(6%Yrj8xqEtb&R^>N!udrN1{g*ih6)#CA}O5PNniUQD06
+z!M5Ajc{r%}+V3`8{q^LSo$$)9e)X$kp#AcfzkHWnI(7v~D=cP!_Uu%=ofY5n8Qm`1
+zu8GZmfMZ~KLgB<^g&XZ{-COtkZfF;~AMCsDzEf4yrs6n&*YLr$ed)bHz~-n%v8A@!
+zyD&{l#chn)6pM3(Z>Sf4R9sJ`Clg-$<u8AE476YNvX||=^Uz#~&<82#wsV~Pn@xy{
+zbEAbLM#a}1)&Xr9@+Mf=kdJ@-;}iBmTvpf+1<IH;acy656H2A8XQbj^{Nfjj#ax!?
+zZm1Bu;(972nf&65F1lz;to`B_zj((ThZg^a_S#Hrav&F1&Q8UPtoW8U>e<t{s3kt$
+zaIYrXdZyn@E}6Kp7}no>uRgB3pgmMmuQ%<IE34)UDt_=&AAjt}PtE>1QsQtuI~6Zx
+zyfYMb3)vu4yyALVg`E8Q&wu{&W4!hYUhsnUTY+rqYp>BxD6RL)*{OI(R{ZJRjhUT_
+zKmF-X9|G*U-n!>b1nm`2@nY8Bt?#&xS8YaojVfn<-QI<1+BIul2{-gmy`Hy5ZV)P7
+zaXmRsS8(Nd=bbkO+U7>y=tegxGy$}Ce`GhB)(dUZ*qZ-VFju_Hitpdu64O+Q2`cFB
+zRPy=Y2S3<ss`Jh7w}k7lUYqlscK3tAhIoU6G`Mjtuj5I1vwnQdU)wuzMk;P!3-frJ
+z&*de~8-$8iTu-HqE4cVGpZUxfXiLttU-$(wdpxEaP~)M!DpdT$?v~6*#bvbYUDkxa
+z=6g19Jr>$4pyEY1Z$YRi+xRtrM?O5>yVRa5KJDndrDx5Dy7_Hxm0yRwmRa$N>lHwC
+z+FNWwK4!`aPuG6o*JfMvZuW$3K#hU+>{Q&2f=#t_zUR}rn{m_Oh1!5KZC1Q+qrEMA
+z>z*?av{yjIi%D*F6f}5^gbS|COEG?(aDC)U+q*DLOT`)LLV#W$x%Ly!Dz2vm>B_Dj
+zzX`cLGutox+HA|-EuPYisWH%=I~CtyzwS2d^ZJsC!|7DQk<lt3u=#<*xE|rPQSoWr
+zsI3p0b(!bsO$1)($ypoZLc+Z?GhUKdQ1NL;=TANL)MiD_Z346QRJ`JPDpj22Vo~9k
+zor*hO__g`E-ku{eSEHc4+wh*i!aZzZs%94xR4nGY>wCMQeZ%49EPUcr6?IVYom#jK
+zXt(C_Ogp%I^2sL`RQ#R~d7#MJI?aKzJ}SK@5eAE;-)zWKJjD9GVwn$a-=283+H=n;
+zuBTGP884<GW1#)m$3C|GR-nzd>h0Cv)?gHni|^a7=a6`xs@d%cDz|uQH?D8`h#}Vm
+zI0mMts;h9Ln{V0MrtPx((C!Vt<ZxOl4sJy_f73m09xpZa?vL!O;kvyG)3j8)94=h9
+z?u;uhUSld=aXpnD&VDiSIR@Hx$0`!4kh8_sz1Tdkfbgh~vs3X~++t{3VT)5b>q=C7
+z_!UOeQgN?D95M~P^bUe;AJXBqH^1A^h1}@0Z(e)ylb_ryV)HGwc+6iu6R6|WVBxIe
+zRf)xhsMAvMx4-@E&5E3x_p-)RyyALxs7_k~PB><#;zvB<5$zX#ZL!T@i~df06<_Z5
+zkRi32or-U9!`@xq(+%x{ikodRl{8TCViTbo-M)9nw{}2#%O{lEM@;KR+f>|IY@S-W
+zEP?v)7Y3;9*3w>YG8GlS^2#fVRRAWsFH`X~c@1C1^;CK|uZvGS@x(FEe&|CV${!7Z
+zv)9{l+ex=hnw^TbC#a0d;O#zlD!#6F$K$%8z1eV-J?*;*+Em<DNOENX>e%8qc2~0t
+zQz8FpZAh`Lt2a7*;U_;>%ZX<d*YkqvwB^9gm`%tJI_RJx&jaRCShqc*+iw;wyLf5!
+z3MQx&8$sOouHE(C;f*B~f7;WYHkByaRD6#|r@Go+d-MH=Ox+x)_~x6NQyPfotOL}s
+z3)75LT+a@*wbwi1gyYt7;#tM@R7yDCi|yTQ1GG`=weNrb`xm;ApuK&MJ1$V%{y2Xs
+zzHRR=@9wU5yW!0^S3t#!1oC#b9aL06J5ljr7Bj6IwbyrHEp3RD={H;lsQsNWD{i@N
+zu^bx*Sj!N*;(ESNowhWakdJx4z<us>pEk5@Qslk%Z7esx*|ey5@ybgB_xrxN8`^WH
+z;ydlOOYB(Q1T|dCiqA;Jy@#>ccPjeY?|!moRJ`JPS|rZ>dOMB#H_B_@^Pcx?sz;n}
+zwNr1O*R2QI^QYo>>8>$R@u4}<y=keqj8^fC%^C7duid8NQ)RUDU6~c%eDl~&Eqm&8
+z@}lQB3MxMBnzbX3JhFHwi%lx7KX}OnCg9m(&bphlU(NAvG};)G^Szx7cPi!uk>SR$
+zU&;zlFDE=^6LNUpfB)gYvac>%@7x2ZrjIVpXQ$%DIINufNGd)w(Yv<-D!$iVdo@vT
+z!&~>WXA)@r<90{%wz*Gl%V+eqFzaTs=7qg!H$*+@q?3m3@AYnb=Y4IekPn-b#&PR?
+zhqgNBzNfMwUJ6#sA+%M?nuXZaU#|d(bH8Q$Cgh;q`NFTQckS(a>_}+OPQ}}E#c%PX
+z?&@|wWC$x_Si|&FNvUw7L&c5#u!5|3F|szc_@N)C4d?HE_q#Xm-*fNV#Aw$V>`+>9
+zJ(c>c-o-W{A2VOYc9+FMp->nbee-CAr_LYePQ`Z^MaADVD;1Z~YC>T0b8gh0<Wu#_
+zdSA~ms`hEAxEC}OMZNEf=h(@x;`;i)!?RAB&oE}$ml(YB1s2=v(Yw>}-O!$$ia+5A
+za?s2F5*2?}cU_X$&41HUag61bw;bLNv02>M^J%HL$pd4{8~Nk3RNU)*iz!Bi%kvJU
+zriicJEb;2EGpsg-lkx8tkU1~5{s<Mcv)P^B(E+#BpyD?lMa75q#qX_vim%v>PP->C
+z8&Zs{jYM+mhiPp{@$SWa@3CKzI;-#TS=78)VNbsCjc<(Ehe3v|SidlU_FlcaoX`R7
+zf{KgNi|WRIY`f7L->IV(%zxiwN-Azm$N0jFUuSWn(^7FM))r(Z`eIrtUhJB<<+^pB
+z{K4g30+RPwxc=b!(|`NT*gyQ;=bv@G;^A4(zy9^FkJ<Ck1k@sX92zNyeAm`2?$w~;
+zcYbF#v<oWE{z&!bhg$Cm8-n&*)V6|u?|8>M)?0q_0?W5oP>WkE%(0Jjv#9as?d90E
+zQ@ftv+B}>q{^!45`rCj0(l4*|Ui%?jpY<W*Tt~j=ue@*Ndg8A`PfS=E18re=G0!ug
+z4Ow?RaR_vK8$=x*7@Bt3=6l}rp2Cye{E0(V<TTyxj~coV6{pqX)qdfBWvmJ#eD8w~
+zx<24q8etjNzxdGw|NMQpwqErEUp@bX&z*VPnI9a&^{ZcQbGZc@zaFLAU-`;c#z5Oo
+z#Y->)RMtZk@98M0__TAy+nPC&iobbQDn3dSoAmd^J{33I{zhN^FaL1WDzEC=P<b=Y
+z<&f|XTwne_{w4YAU;OC&A7A~cAAaMEZ-3>~i$52*e%%M(v+S?o`pD}Gt|_yv=Eua^
+zM;&!k=L^4zH}LNI;2}3^*`{qXr$S1Z72mpd=eKve>=~)}RIS=nF189_r~`Vv*PQaM
+z#lv-^_XF1m30xbj|N4Lb*;jva-QWED@4eFKQ`cN^`nSG(%2&?w>O=2k@P0J=M#kpt
+zvANv!#9xQrnzl5?Yma*27nhpfz<aw_%%6&n+EcNh;`G^atxW}htJF@zm%Hw|YZKb$
+zvn?2|1JwQ|T>tsE3D<v0xc=JjfBMy5U+3N5pZlk){`x<C-MfQN{?cc?s@QuO?DK4m
+zTf+4lj=mn^nzEgL{`q5|efZ&rcfRmzyW90_PilpTW9#9S%d=B)lpw-tIkc!E{@(Ig
+z<+4p{I#vlUn^3V2d)Uw`&33)n?$kc8umJh+AyD^8_;>!#ug#eK#vgv}bthl>w|~6w
+zXFojmAHI9m)t7zbiZ8zZZ$9&m&zxbZ{HsrXr}vM?=Iw#&*xF)Y=7&$BpXZ)??ifPu
+zg<m`Ev{Ta~j6a_X6~EKl614Yv-uS9|CT&iY6`w>Jo7^>qFbXkwr{`keI)mEDva{}!
+z@Ii3hPlkWy@4x+t?_P4+*S>J#g`e`C;x~Qt{q}E9FFic=wa<I~QMRHoW9NE^YnuG&
+zPk(yMY_u1>=tVp1utT9dV?NFyEB^R|>-|5_v$$;hze>f8ZWQlqvMh7~aNP#Aj9GTp
+zLBhZIuYZ?<>weNKFXr-cw0KFemybW^wXd)nRqQWk&FuBcUx$Y}`|PvFKpRwxwftk?
+zHb*MHbH^I-p_(fd*L}q<85WBH#VV0-#jZg<yaaWhf#=9NoVCoq4WK@I?RSEN3$EXF
+z?k6H?www&_zd`BxjBD!QEwN*u{oLn1cf0Mj8v@mc53^Ho8z9HL^u3-xqK>7nP1>wf
+zT!wQ=9_jxE_mR>~7uO>}y)<ksvcC9N|0H7;&N|IByYvDiTmW*+$4-vmI=%7GOBt31
+zxok*<##|5mb$D(2>yCl8wS?`r0yQ-%pU+OkZ#FR%w{t=?{(AfOf(tI#YOA3=(DBbr
+z6xZWHEnSuv_;0Q=Y;Bs^XMc3%z*&F!Tq9g>J?le>gvT2XTfz198P}j;`~BCw?scQK
+zSg~D6@q%?&wiejt-pzkUAAR&xC^JEY=gnrp$&KzX$ch(KoHKgNV;<A2%cQlb>MAb&
+z+Sk5z=%I%m-1uk1&vVW>r?_mEj~8Be;UgdU$VLqZ+wd6}XDPFJ?_q}>))bv{ujSno
+zaXl%he|aqiE)8yY%doY``n{k3YtC9G-0-~-uI3EVAmOof<n`8Hhqmy5W7ccireN!>
+zw{9xZfd?MgRI`<x7t1BQX6R0Tm7wjl1;szv`;}GEz6+>3cZ^|V<^^q_?p)sP%|vs7
+z_9s5^i6U>d!%cR!0A!QH^?E^VBFZKI^~b{M3x9gedH?u5b5Stx4_)^8lP>zSVQZ0f
+zdhK|_S?7^!Bs?~nyPo5k{@c=L%qHX}i8XiL<H0Yw=%O}iruyc+?|pB9-<v(QJ1cJ2
+zzNtzcb+IKdouH0pfVN?RQTI;x{U}gJ6|+Ozyp%iN`ObyhgqEuZY9+5m-fRj`|Llh*
+zqR4?8+xqa=FO)7z4E*fV-uRLC8QwB%Z8}OU_sE&>aMm`LtGK4OwkjF}ZAtH@IvsJu
+z5fiHVsLN3CViTe5_gSLi2R5tfN#9+1>7}E}necm{KHz`@hRSVym=W4Q?Nwi`Qir~n
+z5!%9{q2hYIdp!67hI%(GTu%aOQ^Av`?t|JY51{_Y<rkg&<#R2}JpPj(kuJl)(>uqH
+ze`E9A#HNpCXI*ifp<#*Qs7=U`;pU6{Y;BtFTJcE-6@P0t6_?ywaV>7V{PN4!3+liN
+zXiq!iJsLI%sH2J%L))VAB3*Xlop%y)t}3YK?ysi;wFEd&pZUE@%`P(=-0q_$q6n)^
+z2)6<0VQ)WX@NVM%8m?w!9b3Xyf1OeD*0;WO)F$N3t&>FD{JW*cv;2F>OI}iVpFKuU
+z@%!EHek-oXJ_&758(G_Y>%md90kp*kQ&nfSOsA)o^jimt!`TVdfwr8+R8>fCYFN?K
+z)n?#fG3Lv|Gp^H&vOG@RAJUTj7E@<W9iTqzsx)O3s0X>SGfuI3OIUsQJKmfoj=u4g
+z`Gw=n*P>NiXGG@{x$(|T$PYPWc&pGt$>#CV%FviAzVk2@pGVotWo&=P-d#`X?RRSb
+zIHkAadg%G`jVn0gG7LiPeb+m!;NJ1K-2I^YTNbg}&U(K7dS#%t9y5bF<;qTan^~i5
+zny{K|;~l020}ouwC>Ao@ME4KR*qreM8@Fv~G5Cdwx5vB+xy|@dRy_7Zz10h5ENSHJ
+zKz+B92i7BO$o?Pd?bxxa`p6R2|HBQ2F7bK}bg_7w&(Iaqe^?s^K3{)5BdD$0%Ak&1
+zSpn)umo2|+<weh_xGwB~IbEGOv?djwUKuC4V~@uq&`mN|e4^rpFKUB2Lwkq)hA&;|
+zr_FBJTld1=W_u3Zzw=FZrHXer;BG_T&hTMv82B7<J$Fz)_jO0cz*aM?UIz7xpZn<N
+zJwp&w$oP8hufbftx;?197F2xi)uQ5~K)np@nPHbe{o>xb!+Psp(gAIG9`EKWG;IYR
+zy#jk}82G$!Jzr2a6W|%tF<>3^+h3rzg0(H%ifhpR?svai%radAD!$nky?x)3pna=y
+zBm8zRP4UfmP!FK}!QKvcoubU*(q&M?br-a6viokbJ@yAKZk+1l_B-u(_V>RQh+CV#
+zGv>`!3)DxwG=ci?7oy)2f|{Hwu7jDkHz7AY(tNZ0uh_mLR8+QE#Cp?%S90up@19p^
+z0U9d4+loqP*Sq^8%9uKU-2SUlFA{2(F#emJ@7r6q*OI3WP>+VTsT2=?`V$}av?m<$
+ztfw6M+^0Y0FQ4hfd^FR*tK^Th!wx&|nPuUS6mlS(`LIpj+Q2#2G7GNf1?rf8vh1l>
+z1nP?GX1M*$Z+?@TE^=u3qx4!aWhJ0J$s2gvu-bILX}+m5IqQ712sy8936d39cHT4p
+z)51e58f@ETlOGG0?53Muy!EGFS$dq_(evlu8Vt(l$XHv;lNIASH@g_piv3SU4Qb`<
+zcTSYe3)B_YO<X%SuVc*aNub?1db`z*y?tIg2$nZpz)s%s6+qjBXVA8y!MX-ZmMmQI
+zVr$S&udV;nuPi{`7@)l}TyG4ZF5bCZab4irM>9FcKzq~+zc$;v$8m49^ZJh)?A9~3
+zH93ej&MT*dwh7OmZAF814a?B}{ZGx%7=m_x3P(oDS~_cWtpL}#sT<H!Z?SW4%bNsw
+zT>e|*>o&A6zWCxX&^AlWG^%9@PJd?b`sPo#zC!zl-xxsqm)9n*ouU2jOI~}!L3>(U
+zj{-GIHD*THeChWVJN0%pFwx40S6sJo?VB%s=}Tjv?S)^(3n``s_h!9a59%Fo+NO=}
+z6?*NB71~qbdgB50ZpTzycY?V4OA8!EL0h2R`Hs$M(QS&ze#2A3Hcr+(rd5js?a6Vy
+zQGvSRx*NcwzqLO=C$#T%uX{}k;ZfIn*~h3?@{K{$M)lL2p`FucYfi`~#P!Ao>Wb^p
+z2p;*1O~?yqdqJe-OKqIm*YrMP|K0oE_wJl_euLddzT#)2!ta>I%nI$ukmp!?13`Nd
+zTxU=_X|B>rLt20Q#i|TxJ-?h$7BMwA=cC5gBLO`62fK?j$F+;MGiQJwdE}9!%NYD(
+z$!F(_|Moa^(+;#jeudCpZ-#sg$F--zbxMH8%Xj|$S4~iRRYz<ndd}Z{%hF44;h8B>
+zHUX%szg{oyMqOYN@+P#~?*Oue(S+LqfBy5IZ?BTR(b8P;|G&L6fs>-R{&>&qvg`#c
+z_p-op-}k8^3c`ZQAu0mOeczW54<sreAfO;}xgv53A_{0gM7%GI8WsQ1L^Ns=O^gX>
+zBJql%|6gy-*3@*@^vvu|zd82JXFpKWJKHt=>-zSq<JEf(HZlHx<rdmh9rBP|OJgmd
+z7V-Q=QY{hsJ1Eq9?=Ok-381c%Ck+P*c1tZxHjZ0fJRcs6Wy^7d(UU&p_VG2srddAk
+z@D}dqmWcQ8D-hc@;~!q<Zy05?X&1l3<T_xfx+qf~9Bf4BZ!=HF2X7$%4x$7LOTFf?
+z-OKmhFJceQU%Na4kFv0#t}?<XU)_Q=`-eO5XZ;o8eu$l4BS((3=s01*1nZ|A-!EOd
+z)N+O-=!y&EONe$HEPgq2Z86p&t*uz9wuJu1b`=pN7$N<UFAq>7`nP}@fr7*G{f-3c
+zM$?R}dY0D2Tsz`t`z2xx3A8O;aRkq_eb(u~Yp=a#NyD8SUGWm5jd*<s#R-=c#M(U)
+z++{_=<%TO-_*|n0E|c&0=gK~Q8;-JYmxVt(@^pwO!Pvb5s6{|gm!O8`%(WA2;r(vo
+z#*N4?VCjk@#m~;2JHtDH?^BmucA5H+HM`<P+cup$x{31Jh^#h3Zo<*jkM<`g5TX+y
+zwSf#KnK3Jcgzp3n<l%6wPM7(N_34jf@*NRS6xV{xwgFLsi$eOtQX>zh86?4BmsTW}
+zy5UscbSrZm5qiNsymsx{tFOLVr4r?F<HiO1y!JR^qFT<7G+pr$SZ$z<__{zFXdsRs
+zrj#)Ug~)!Gj}qIye0xKbIkc#oYzMAoKLK3ZjWs$LB2ylE;22hmfTF%A!5dZ~S>E(z
+zzZS`D&AeKXLOt2Po+THyFs7DJv%S{xRkDLvu_}F6+_L7C-6Y{xyDZ&_$gK8;RS3w5
+zwIR$qVfG1gP}tGw-}Y5Bhvw>b&hWXmq_xH7Q+#1Ok+8P~`%=*Z7sG0Qo(=>QMY6o>
+zXZu3>Yl9?cEp-@BGuI_UIM`nyCa`L7Q&LheXCCas+T(C>QO}TMUGYe*cJ;hmMApTO
+z6RaLKYs+n4qBri}sqLD{4xej`3q&Uz)8Ob=AgVuR1~9V5m*05o0HS}xSR)O+nE|u7
+z2d<4h=nrR93aFWDEnFo&h)CBK$1|kdjp%HvR;^OGM!D92WHZ@lb>UlWpp983b4TZi
+z7m?IP^u|RH25<zL&>L4xc67VqA-R^z)`DxXye0B#;Xx!i;Yii7YQLF(=caq_5`luv
+z=-)-gTJ3=&@Su!6cv<P7X09WGE}RcHZroS}6M5*u`78MugiOrO4+!X)d|mNKtu~_Y
+z!O~&<7r9~)Uj;!J!~~jUlr0CmQA9gTuH_0BxE8Vf&B3+IY+IC9OH70NlI01m<;Z%*
+zL^V)w>7iz>B~Z~SSbR#+6~F)f`y)E}l~-P=J{iyzZ+UAHn(T<IHqgeJFHANj(0rrp
+zBG++DjQfHnxf3y|R9wIJsxM=;%Jp5v**ZifdNE_Ba2*w>nd^v%3+Kayg@u-`_?R(c
+z!udn_86>$@xlY!uc*It_P9BD+=5qEYCoq6jyW-}8mpeo3kX)maAm+o>ez+K4i=@?J
+zG8`%MZhPQfZ5~X7YLt;h5y(;FCaRq%8yPVBEyPs+<#jFzRJ00~*eU2&Z`-yl{FCqB
+zzu&USD_OhZk)oZOUuWgR+u^2y0j!m4Witq6KU{L{pARoyycQ{Lg-43%J1UaV7cX*6
+zy5)M`%Jtl$pusaHUNLEO&APSKN4n|zT_UI<EOQ+`abbRP)TmMF-9b4gCkLBE!u<1|
+zJ$qXIJc+yFk)mCzUR}6if@=(8eL)Uw4k|I>T6H!<G$%{~9Q^Qirdv32=ON2&aq4PJ
+zovEp-<&-#P%<$Aw?|W&WX0F3zEuxRXv((ZR$Nlnpz5V<5N8n=TQ^6(G{<rw^q?{EO
+zP)CY(Uj2NydBoga<LM!0>co_|I(3HcrY?1vCi|&_cpPE72ljB;b7CUMKb}`nggObh
+zo;-PSnA;(pfr{>LhYlSIkkvaS%2`=i2)5wxvSfJ{e}z0C^+qS>)L9A9Zcq=NnZC%S
+z!d{b)uLHO)ayj#N#lQSmm~716i&=5$a%Rn8z32uwk>)iB*rZWPOD!Z#^nQ3jLBX6k
+zbK(%~nKNf1Q??!L5*$J954HU#aXI{T?K+JbY<cO3>Y75l&Lz2)Lu|Xr7U2}6i@4bv
+z-@gMBXg6<JcYV=78?L0d5Vc7}1!}aAMCTe_*)ZAHUVCkH4Q^D<hOL*CD_2(US_#UT
+z^%FiwX+#gAh|q?=3TP7Z;q+Wfw8d;Zz6MM-9yONmN0`IM3Y~B$mAgN%A`dU|dd&j7
+z9ijzwa&V0W-~asQKlA3ziwca<J;{Cd-DmMLi4^UWbfaP7XAN)(?YfN{Vqz*L{$_w$
+zaxF}@41#3Yf(;)P-)_z0Pr_GRpbf4YwrZ|6hA2Xv99$zTKf-sPIdf+I{Q1$PGAd^~
+zaNt1e)~(e$7-=~*(`Zz@|1Kgx68FR5TWu5VH=c3BSOZ&!^=rYkL|d9{*&E03Uq)B(
+zqy5U!d!Bi8?cu#`&h4x=gS70F7Q=E|kFRC<X)!9d-Y8EA?qd@4!;uIN+a-Sa<ri4(
+z_(c2JXP?F1YAj&kg&3q*;BFq|)vQ^w3Kc4-cU+WHvyH|x%E~BPG~@8m&TrBPp4b9y
+ziCa_(;dAXX*~*?xSZ%DtVfPvKpkaHLIfwS%s}H>SoLJGGwc^%_m2=b^-R0^=_xv>J
+z-d`qLe$Jbd-|o(cZ+&ubjW}b7CkC{?`syo`qhe>>I|%|6S|Sz89Gxhj`vJPuJMKff
+zg3)A7#P_!ZkNWuelSt8y3d`zA!r>a9m%RnC<|PN(@L+d9d-~Fa*_A4)H~O5BO$yIy
+z&^~8I-F9mtyY<PzHE_Tv8(iac>eMN$0=q|LRL%^iG6%F5E?j8YKO*kFnSpnHWcN3I
+zAT8N9i3n|2LzT+Xm&4>bB-&Wf_FL_Dk4vjPb;*LPiUHlT^TsqS{Ml-<VZpmh&1=6l
+zf?J<7Tw}Fs@7}!v?JvIg0)dI50-$>*dFY{s)JVmu$wqm>f&~p5HdG(xqKpi@&90B&
+z{+5iUxcaO7Q6BGteD9L_mLJd5T1IAolfZ=oFDX6C>KVf4y2NP1p)|8XwtAz_pU_;3
+zcE?G%?e7lv)+Y_uU}4CRA%biC`}yaeV=~P>Dx-4d-Me=?pp9Nfy?Oy23qG`~8qF7k
+zdw=7K&=P!^Ml(HWyIXjF>0|wQznjq}0Ec$xpM$}yN@eNG5pi7tw9O!;PamA{>tAJN
+zXQ^mkIHiSUlr7%2pHQ>I`mk<&GI5QC?3Z7DS)%>dzy1|t)u;gI-br@s*dc?ETTC|I
+zqOV@3PJr96xci6>-SXFA-QN<R6hD8`V7fQ$p;lI+!T7u987%`q=y1V#2%=JYkS%A3
+zl<V-(hW9vJ(a<3mXk!mZMpmYZcF!5Dv}m^-SH0tg(6>IBxCRK={w%ph;m?2mGcsMe
+zM`cvbj1AfjXk%SIFE1d)gAeVRNxLswJXjh`^_DxJgZjj|M)LruJN4|2MI{T8QF&Ve
+zt|LVoGx;XkPaVV_kn$Pn5^W@W>oup17VXxft9INJ0_`N@8k?Oz`sgDS?GHcvaM7Yg
+zQ324slWg9+*#T|j`Knp7ro7{_fb@KrR*E0<8pUr?f3mmSp*9*z{pLAF(*V2HwRaCp
+zJ4c0L`$<a1bvS4v5HS|Ngw>X4kDNclf_9(zZMA5(8das^Jx;ei$+(8e9zTA($~DR-
+zPo7-7c(Hp_M&-;1LN4+P;1cYwS+izYf}IMwGwK*^mO0(uD6&R&s(O>WsZX}oK>hkT
+zMxy|z&+U5={5I`8M(aq4xegO;#D1}$jfiJy%C-WJ*K^5@?d@pab9Qoz5jhTMCm+}F
+z82|d~uPtc*;SYbf?Y7&Z0-$>*S+{N-rort{iz72;%&1zmsx;QJkeP3^xjlK%t~bG(
+z`g8{k)W^FR4Kn0aqtNZr0z@f^7Q))|l!j|(v=Idzi(jzX0&VQnmR1|vHdVB}DW3i}
+zchsWYe0Zf!h5B2cd|ZP9ST_sTc>B&f?<`xk%sncja%KcUazK0P)T!EyBw6*1wyX5_
+zm(0jUrK0?C-qaU6X`p_wvr*4K_5{=y47eB`n_3v7c(9aQhmW?*&4*2D7;6umF)_7V
+zIr$Ltrg{f1>ZC#Y$BE6Zsi;LeDY-^U(4T(#$&U8hZ@-P48c_kzy_2k5xe_aM!L0VA
+zNt3XBTi$V5$Zlk`Tb<Zw*BzUZdc3m+>gPHebpxR8F{mGWx}wN$uv3+u>k^}l2r4St
+zDdoJEFY97Qd*crin_iP`M>{FG#_|@X!R=h*2zF`%9QUY<%9+uxfXi7hv@wC8^&!u0
+zYP7p6QPHk5IwkdYT{Tc2>ty5wY-8^=cp!F81tT%K$D_h^IA|lj3OeK#tBr_fD%z=O
+z-odNR(V+d^_@=|NE&ZjW<QhZ_9z0mfH4eV|>Z{1P6BPj6JIRtIOYn3GhW6;uqY-*V
+z8f#go*uv-#wo8(wCB*P;?U5-d@0_E7`bY;OHvsCs!>)i2c68x&I9t@Y_H7UO>0e^o
+z7vdyiGGC0ffwmckp*UGKI^;+cg0RCWsj2e*rlzF~S$&=z?e*V`Z*onhdIyu0Yb+aW
+z*sviO+HhZ4y?V8KR7T~@=yKeA^UcA~#!7u=X29gIxce1b8)3R6sm&mU<-FmkDStRm
+z1NEWyMvXMtq*1tZ#1L@dfML{s6)mpu#pK?QU}z%}qXlh5PXgKl#$4k~Ns&5~OHUoP
+z?tDAicb^&GczA}qkIBk4a8TV!?SMb`+;i9h78L+pIthjh=#7K!U}$6JKRrEQ;3@8Y
+zPFthn#>D85*SaP(<>dJqs1LR?s`)35a9wEL#83mqD01zLwhXaiM|;DQ`|&^vKszIK
+z#68{ZXs`KdY~$hS0_`N`8aqJ{)4)!&Jo3yl&)j|Y-7ZlXmD3`v4>qs_;~K{?L#PdP
+znA6d4SlpCP_1G42uTD+*xVr}GeQk{@0Z=1ge$;JoI46uQ*Cj#w^=DwUfp*`kuT&#p
+zre&2IwfO=&+N)2EX*|+IJBhhQv+vcb*Oy;@DM7Xuo_zAj_3PJ1g+Z52^4e>!Ik=+X
+z8WB^XoU$e&J8V@t$2HnDhoz=`c7X=!J#CE2{t+cE2Pr1QVbG1wM4ju%&^~Eq+BGAP
+zzi=3#l?#RpQe#k;&rTh)wTB(;RiBS+JSsi8xyF8|-o1Mx*n*vCdF1iOAK$cTlS@=a
+z<+R6-A9vXH1+)ha9GI%iuK3YDH%?<7)*M>S`?(J4ovn>ZeyGumk>kb<V8cA88(gbs
+zTcRgn8qL}vFG73AYfp>h0vBB|Kt(&fLb>rfFS4V(;?v>ft9oQJ5CwGYWSbWScyz$7
+zMWu;G{UjJ;qG1PniG7ZJ`t<qtzyEEyDD~}ce)AioxQ+UEi{c4idF2&nv@gB%Qsnrv
+z+)BKy);;dft}!Idd+H*MrQX`gsNjbh-Ok~2r-cciOCNKI>oCza^X-0eLgWLI;Y_i|
+zTtz#hQrg4^d)v{j-KL7AF(e<?xWK-B``VpLRkSe@N1l!-k{I<<z4+pb4k1?XWW(c2
+z9fHZ*TD@o7%%K$;)vrqPeyM|cb4w#T0BQuxcZt^UPwO7nA<+K%uh@2qbihYGdk^`@
+zeBn$*-jK(3!+}=bTof`Zm!G_^z=C$YPSw=Upq!Lk<GL=n<PyXzRav%_AAb1ZEnBuk
+zoyRDi5b+P4(Z+m&`Y@MwwnpzbK)cYWc2#-r84c8)O)ZQ}e`f=8zu1o)K7H<e(p9b<
+z(6&S>R`Z6ed*Wdv7wB5hL*85zvZ|DycCfFCcG=+?m*1~nzi+<z#)7l@7Lk-9O;;U7
+zY{NO#(@#I`jP`{WUZ_FaW8_{EOSCaLU-hbV?>D{e-EYs`&5d+_I3u`WOuYFz_fU=K
+z%w$~q7PVzK)9*i5!<m|{Xhj2U^u`gU*i7~H;FgX(&R5aSuAVXT(8Ut%GQ~A?K=M0h
+zv=N(V`}XbOAQr3796fr}8SQS}x~X^ESN0gS`o{)sKwSk;f2V_bbyK6fA8NQwPFZ|o
+zMCiHtVYj))m$&+>NVLEET)3jaU&S0~fBZJW6l2d9mc2}q{m70*+czTglX{~o*2tK3
+z<WhllS>qZyVD|XiZ@*Q|w51HLckbL7D{RB5_weDv&eLdJyLMIYxF~zPM&2N5v=P~(
+z%8(524?3t<G%?Zwpq{b(W>-0l^yCCwYta7bUm{YmIXy0t3lv2lhsj1hAd#K(&V##<
+z=j*1zH7&bzP;Yd_TA6c?^#|HzkZb5LXwabVzyIEXv-)=H)~ydb@IW|-#p*Md!*@oz
+zW5<r_9rvM~V$`{c4sE!-RUVS*{ZR+?(#A$P|5^-o9M4|0I8yH1{yYuWTC`=}5JVss
+zCL5z{Y}3Y?7m@*?D~{BhNCq^2?eb<F+Nw7?Cogl}vjfT|*U$m(96$W<gUYg{jMzkb
+z_Uwrjw&B!^Iecfd+qG+_-f<t=sYcyl6lj}J56kqPwS^M>rH|*<hDNFab$a=EcP(=p
+z(h{7XjB6Ebxv1?=ynFg1_?KeM3lrl=S_C&0B>B4ip{=*vzy7*)E08**QR^1!jjmib
+zJGYs2GjFoahpQJZ%19;PjCNsRA!gFTK`d6E!5qE=+VCycrUvttGxA5ei*|<%M$WJ-
+zJ=8ZfFjD+bBcd0Q#+Cp&f<K|;+KRT=^Hns;HuHS_<0N)_VJ&<2ThEIj_KJPmZr!#4
+z(xIO-dC?8^n>SHgc#1N>5y#68*SKC>?En7vKZ~VS-(pkPzJ2>*g>5+XKKS5+4%2AZ
+z5!Rwbz{6bJWpA2Me~epbcUWiS46k6H`o<B@_4N&}A8G{GU2xB80zykx1u@qWZDF!S
+zR~)lvSj#^4g_-2b9Adxy0^*m#tyD~%-LUbFId?2U-Vm$|B2Sr$wxwLAxW=^)9Xj;K
+zAAeL?wv-We?2$(v2?w!QeP-9LT@F?o`?#AnZECs8c$-q*XfPrAXk!C-r4d1(o>xzW
+z8o}@}LM$0^G=D|UwLn{T#Sy>_3trfujUo1tPv6DvY%z6)ogi4nUc6(|jhpU79_?wj
+z-Gt-<2xnTmVSW3J7DtkpYfK1hUvNfsMtjYgH3ttKj1{)w)VpolHV3p3SgBDX&BHt;
+z!)Q1qnrI`3RK?L1^_F^ezTr322J%v2rG^I264w$duElaTX2k{9V(JWBBX}uxf^0qh
+zB=%(suF>0(T#vqP7GfUe)z8;9@+9Uuv#ya7uq@yg0AUKWA<?AmMu?Ti9(ybt#A5ZC
+z`|i8XAyP5+dp2m$z<<HTrPM5=(e&t`jhv4a$5zrqJ*{qWh35Yiaw=h&ro_0B{b9_x
+z#?+Z`P%-WGXYXN399+XY1+fk9IIwfc&U*s5zJ4~s6c3p`Ava%>BPNNt#^yETK*?#Z
+zHZgyB<j9fEXs=kY;?SW(vBEZ-da--O0d4H}%+J?6%+2K5vrCIMq9#_DP+0@@&wV@-
+zYx`9;4CH-YzW07IHcL}cJaCOwY}jiAC5Cs3mFr!F;QHFtOObLH{qWI6To0Qy8G+Ht
+zr3HkVf&R(OHMX1s?Mj;UAG7HpUC7z9XQhp{7nUzy4xf;45R27kFdN{2HfGqg3BQnm
+zx9Pl+qm3xX6((2FKz+8rGcEw?N>!_@e0Y0lSfl*gIOKZo|Gg~iHC$7c1mPMcJExj8
+z)O^x&4YUyftWq1*hWN|l#*K4E8~Fu}961szY{RJ+@tqukkY9W4wc3PV<#LQ>*OdhA
+zwkwV7X;t-5kE-QY)-cf6RzLaxC77kGD{;B5T)nL9=RyNRKU_xsX}`{>)Jko1{_=zg
+z6P(dT!Y?>!hl5zGKC^1oDhIR?AxfL@D-9WVZ}dwfwQ?vR)kxN?Y8t42D)3yB>(|sU
+zs??}{*P#bX2^#UAGuN?dz~RJIkgZGQ8f_I>!Yc+r8{zkV{`qHnKU^Mx%g3=}$6|HW
+z;na&EgF_JVnKNf<6Mi8BZ;P-q@U~uNWX-Lif%?Y+&yavbfmL&BV7CG>m8GwaxelkL
+zx$&9OaBZTEbs3G<hWR9zGG&T0+E^FHu1Pm8Dq81s4njU{+B9v#uktmFmbZkq+O2Oh
+zvVWDUf%<<1o-1p}XDJHR^K!8+Q+mqi&%j(qt0_i$o>Fox(5}#2ZHE5x^y$-`(Z;$k
+zf|^G9ohd($I4TZ7$R|&ptWEfpo@caL?1VOcn{`7i4b<QF_FPuoub^SnsFR0%3iL=u
+zrAFqOvaPChm7Z%8?Yj&l!O^~u#ZvaYwFRsTKmYvm>Q{=lvU3n}OeSa(ejx*I>!o_M
+zTP`v(e_dMx^|!q}{Q{<Iu#gI8X8O3_QGpsKVXkA<n4`iq(8ls>c7Wr&pYqwWXKRU;
+z2eB?3&uAmRfO8P?v17+-6Mktk@S=;Jd21aF)c@_}xi|o7I6lEMDsiD^u44r?>WvoH
+zKC~PAah4^76`DJDuB2F7z`8Kv3dT?e=c<ukz&Qwcu!LV(4U9G`{Z_lhLL+l&z6R>A
+zFY@#W2!L6qQ3LE07QsNGWj*Q7!}i*_UAgz$C~^(7+umVhH<Up83qX6`ym?xp<w1M^
+zX}{dN(o&xJx4-?Zg9AB+;lqay*CzZjGw|MNqTT!^BV$E94b)#<<mnXvH8vJK@aA&@
+zYPQ#rK8}QL*!m%(rl|gAVfv+%+4XBQRP7JY&I*DyjIyLyTYy<d4F6IB=-!_r2)V<K
+zPN0pgZQ6ui7@;(tYoxDkpn>{yPfw4^{wJVe)N9rldkH1fq7Z4@j+4)`y>_oPI-fbZ
+z_F9k*ugI+WYE$)<5uF<@np&deLAZRxGukh`^pZ2$$S<r-_~mVy;r)*-MDQ0qJlzAJ
+zZqTAB42sxhm;`7u*Ut30_ggo(2HkB}7??G(zkoLUxFp5e0_NF}V%xn-F6Egq#pm21
+zNANdo!Y|LoRRaPA|NTNww;WZXhAo>R02g|X$U6_Tnd_4EI)rZA4@U<w*h}Q`k!{c7
+zZ>H^s%Y(ttM!Fn$q-cqj2Z1)mv!w*ky+02bgnYn&0osILo&nW-;e!8mp{Hv=1g(ax
+zn!{2b|L${aEle7;*<QQX2%XRDlD!smw_a{w8Q1;-+VCTl6x$2%W&zqrh3Wj|WB6Mn
+zTyyS_2TS<nxuUxFqwb#06;)XfHxF^QFujAIJ;{VNa~-QD>MGZu8!pfp0UHf{%^Btl
+zyFcti%OgM=KG;}bij^`U>&31#XS53n3bYBoj2wR=Eyw|=v2zfC^`1TbQAo5))-{dQ
+zUoqDqTaim2aGPrr?c0ouJk>h+(Z-%l39`L_C=Ih_&5CEV5ro_s?Vde*YO(?;Vxaqd
+z?{mMwet$&OOFp!jYnQMMd0GOlfp)7UMn=F+VqeR~{L->z%j`tUBM6%o=V&8toAWf<
+z1s7bPa2!y?L>U6qqX&)@Ge8>wxGZQRqNaAN9V`1AX}!#KNB~{>01ejy?eu{C#D269
+zA4!62FCauY(1tUoOA3_!w9Y}uF(-N6dFKW2T>PeM?;c14hs-iS8zJi-`{*qdZ3O1R
+zSUaK7X0A)$x=MBiGOkUuZ#B{bb`|^DHx_&m$G}dsJOZ?_t{u;4BM7;()$Y=zOEJv>
+z|6h37rP!_oKkxvwzc`6d_84mipndj~y7(2T>5R$end_2KS^B@C<XWJO?aB66`SRuO
+zyz@>8vc2%#ci#c+(qFH8XFxtOXCLwo9W=3AG5YQ`cwjKJkv7gm`}<<6ooHw?*Y349
+z=Q9&?4YXU_Y?Ke!x8$Q7Xd}$HooIOk`FZ0UZ6p$Pu-aJKYuh#;#hbWtpxt-a6+j!a
+z;_x8#cgTyZc0!}gTsza}-f!u-Hql;aAQYJW1+?$J`)&!cy>RBt8H5dVPmR)_dCQh9
+z4ptjzw`!#c9fjqvexrs-v>*B7Yvx${v-gmF1|9OmMVq-UeTypD8Dhe<iS|uKTEHGA
+zALZCLv3~t}JJIsUS6_WKfByWET`bLCA={usq+&#0Y2I8DU&fn~a@qJ1So0EA8)zdH
+zd!nPwT+=i;do8iz8fZ6Pphr6+BV*I1O%h~#;q>X#agH{!4LYC=H`*pmG(jj*Qd6&-
+zGS-Loi5HUqZRXle9L<p!a&4l0gHbMEKa<aDV<R)Ho}FlU<clx9fI|q4L?x>QLC77V
+ztYGs?!-ksetf}S74V^I&Xm9`RQ^*i!qW#GUB&vAopC2S*hn%@CS>q}FU&WSdpp97i
+zNS0xLWo2b;-n?0YY%l!nZ-2u`w)6_PcLvPxJD`nUX%l{>l`oGhQOSWebM0R1az1m+
+zxi-=Mm5~~-4Z=rxc6K(>T-u42M?U-PGxTYlFEF;hg*P2yt_IsKhrYTt;TKZXkG*m3
+z=I0LytBq{z(rP1>v-30>b}7bWsajhpa~-SZ7Y|&UXwTQ9jd*}NckYxR+Y5jB%U>`P
+z6)W|^sTbQ@@bC$SHrB<o3BS@aGmr@mXd}uQQb0z8widCN9AvJ;X(4WWCQi5p+Q?g%
+zTEX5QH!4=F2$v5#(elX0AAbyL+z=;P=fso80d1_@)vBfOo=4jH$%}5-{K8>@_JNac
+z2&;{huOY2=OenTj%3MdQ2}OFI_~9C8H<@D~=dAq&wD;`UBSE$oPM$ouc=6&$ubuMq
+zm?(3|FMz;q+Js+7UO#==uN}}v64-e5Mq{oi+n8EcTyYJwkw{vLHe&DZ-MiOLv^?_1
+zKmHNBKGjQ$tFnkx48N3M9r9oazmV;E_Nv7|d*|!VphFI;edy2c9R2$reOCL-r}2z7
+za~-Qj7;jvgXwNcIGwnv($jQmsw{M>W*<Sel?|;8^>C#v!8M0oW?YvnVX^*rCzmW5K
+z-kN0sZNy3niMART&E7YrJQ8!R(V2mRJ$BIGF$gCgYhL@E_h|FlBmXtW83u__|7kQ`
+zk2aEF?ccxOPP9Do_S<jYe*5hq5sTFa5VQ>*HNi|ajw4wi9$)r{8k*U4>sBDA53F_q
+zp&cu(ML<_<T@T>;({~Sk_&fA@uzPOPQwQ%juyaWf*K_Z@ZQ5-&VU}|A^|P_UIBeEr
+z<~r&`%M&)5W~5};8@N%WN)?1MkRaO&Z@&2^Hgv~|+>rGm2stt!IG~Lb!`g&jRccnh
+zVdEWsv_A;iA-9J!rL@s%UG!YbV5ATMTi3xgLdId55sp3B+kW7KH{k7q4euMC+`nr7
+zj>S7R-MHyaKiAjIVy-2C?iCtMHB!<wXjiLN4FQPkM9U)xQ;ZGWArXt!2avJI8SQc7
+z#$oN=e&tA*d(*vlnP|W93?dSvl?EGY#|he$T+7jiG}b29-<e#)RS!F85NQfS80?t4
+z|K%svAAMxiBPQ2)R0eQ8m+f`*yWjRlM8nBON_l$&H-Prx!-plv_5#cz+`VE&ZpeBO
+zgxneJU<to!)~$WZ*7aJnpa1ut(T3$TT0Edl#<heR1ra%17;6l!;l}gKsXsmW`TJNU
+zgkLTaBtgA(PdvQx;q8mIZv@wK?pQK)$%63<=Z}WHX0BZrR@=G8k%klXXjiXZ{qe^i
+zw-YUoz${`zcSyuy^#LUQb{=bw7%>7{VC)Yy<k>`n-15>9i`7Q!6==gqq5l~Vfzb%K
+zwh(O^>!Kbw!mvY!7teg^>x6&y9=5*jd-pg*gSXG!k3V$#LtF8Lyng*kEH{{3-!yO3
+zuVymWS_WM@*kHWjO|v&}18crVj~<mE+Y8S=`z$te$BNvL_2SDrTWzdXU{AXJ%8_kz
+z>F&)c+K2!0e^~rd(GHehKpp?OU3Q!6U{K?+CVJqQ2^Yp1`k)hzNi%GNMNBz_i(LNT
+zmS5j@_pk20eb$Ow;s3*2y9BTEY3q;Gqn(?Zd+gXTJJIq80{E|6w=N`NvHAeI9L`qz
+zs;jQjCj828+6WfMf;M`aafP<4T-%{W7e#cxF&M#+1W+R+J3_o-#tbW52>OanI26OA
+z*_{V>E!kCw$%=V*Et|3Y=E=9-FmA!MBj?Y!X3o^1GbizUxHF8={cZg*hPRyEb{Rk$
+ziFG8%_QDfSJb?|}u_8BQy_f@ZM*H&1FV`mgLXtiV5-|(3>vzv$8V!p$uu9>e?Y5bg
+z=XZ~5E7U*zONAQUZ(*qg)aZd@WR00{7;6NjK_`60zHJ!GU^4vL)l1>gH}U4{#@sMx
+z#JuTO&z^#PvR6$T&+FIGh1dCP^+xH@&dbYt?z!jeM9U+XWV`2{dqN@>s}EpN-WlzI
+z0|#moel>2>66>%6Z44fPHfDVV+GyCYS?G>xJLD2QR|^DOivhKST1=E-OpShv1!}n2
+z!?y=B;V{-1#h?=omw?$T7h!NM7q6LXX8_&%ZT<+u6OabSXTfXNu8m1%39`L_RquQ6
+zy*F0mhO8Gs$eq2>`t|FFyk_?PO4IgjRzLcH1#L8GH0+q8?Go40SO-A;o#|SJ*>6A%
+z?=n2x@Q6eA8*w0EsRh*Nfv<UNH^wh8*6=ig7oY5e%SkiX>%mjUvAuQ=;b3RZzebNX
+zHasFfwVh~r<dH`nx$nOFLLwHc4<HD+GunOo_SGi*YSF3vU56e7+895=YNIiWtUxN-
+z7<k%e$XzwoIJp~K2S9!Hl+RKZLye_sxS$}y3|98hd%>6*f!WdhhNU*4{>>ghjb&?$
+ztTAH-V=X+*&<R%u*UWV=^xQsPcbFdSx^?Tm{PN2ZWP1UdN49R=8Y^-`*1K!hE@!ka
+zy67Tp!mrlnbi%L^o>V5<MOlFa+9H=93>iA)KC}sgkh{mVX{jaDMNZ(b)DmheRl{iq
+za}H1gUZV&;gYGwaH3I5|o7bWTj%90%ti_C(xpIB&G|>siq#1MVHop$%uQSB(Xu72a
+za&{j-e%wy9JhFTDZiHb8iCC;YfbZrIgd7g27hZUwy*G{{ZM$_v>lImnfVM9yP>@K)
+z((1WtvZKzm{Mw=it~#HHb!u2@6Y7(1z>6MB)#$@)dio%qc$kI2!WO#Uu+)GWK4xYQ
+z9Lrm9N4b8sFxJ8|9Fu0uwF7qqzp6dh@OU+Cyng-q*kK_-wighC1+Q3<8?s&u794_*
+z1MP0zx@j)kFgjk?ZR4>60a<~Hf{>%l!<-3MG|Jw%OI%B1tva7zOf8|tIyE-Pz^@GZ
+zJ1|0l%P1zw;DvHi;Tm+mVW|bwm@X4NaN&-Ek+m?^hziT&YXW{9s;GU19&LmK#J)&7
+z(een)BEqnQL@ZVxz`~p}+FiSL)uN4Dey~tx5OO7)DcZbrMe|LMpFJgQpL-@dx?IaI
+z?C*gWxqpi#Ex6@iOf8&G1k_?cjU_ECRo}d29b87ST8%Na+5IlE)PUNYE)zZQqGfAg
+zteI;E;>doLcex(zMvWSQN(r*PfZQDDlgEnOko6)zf-~A3J9gBfecr{ruu6-VhcXU>
+zT=_Bw+C|yEEZ*ZTq3s6Oq6dy%2Od!9frw!>=KnFDfQd4UsnPw0rIu6Qm?gu28vdeK
+zs)lPBCdww=ay`7ue3rTxYO!pM9yp+8uF2qat|;#^!|-U@c;m*6-+JpUJJIq8R=ys3
+z=%J8^#p(mjLCDb|Z`ZD!=CTdrf&mx93mRri_^X)dcf~-vD834r$##irIR}mfdh|m?
+z4;=FeSkl5onK`C@>Y$kVHV4#&Yvh1>%HkX0f&$kvF{VcM+ng(#IZ5`wnQLdz=zm*l
+zfFA9pO`D!LaYBM@FQCVZFf6emH)OroaEjPy!S-t-uu|*Rt+i<Px^kdc`9f<)N+66q
+z(f-k8)tc<Yve$NFE!@9_M;Y9|F{VcM+g#5o9#Gr+-o7z)QTJO6t0mO1*E!X!3FP3=
+zYiT_1yz>scltbRZn0z1(;~<sznULErDB8FMmYbr!g#$U3wqv4yIF%v@xdYk=huES;
+z3p?6a4!ii8!M@)32XFY6y^zK4%%|#_ml(7r3fGota6G1@vG(oNdf_nkU?OG$#?=1x
+ztfdRFo`t@*YNj#!EzGnSQ>#!j*Cl4qr9aHQM2|L7-68s!%Ce=rcJ0~&2M&ZoSxi2&
+zWXY0+3l|2n+QAZj0qucfhr@eZm~64(OPXwRV!U|vEdIF`&mTY6MKflY=l2Cn_`tVU
+z3v-6>D8rK0E%&d#e#0uPXNg5>6>5{{;=Z>Q>MJLYVSDWop(Q?T&AxWqWgdZ1d+)vX
+zEI6xg5r^T?M<0y|w&7HYF1JGva%2_3JfZ!{;hzRegvDIUDPfciUo5a-`i<LW&)h&e
+zisNg^bwDTl^hcNyR0Af6Kqv@Yh8{R(zh~Zli`at+OO0(E>Ux%*XiS<-9>ZLhm_Aqk
+zux5e1ftyE=d;0zN-&a|-lrfma?y7Joi^*pIuR{>>U<tpFffwx=8AGrPgn45#e_wG|
+zT%8q9Ag=LH!YqMU-om_rFJQv!&tMe*BkSdR?>7S`Y*>YLYSm3tg&NN~@q;dR`|jr=
+zRE6aSsgx{jD2d0{$j6b>KHw*B5JfbkNFM?n)*I=0mfPZci&-Wl5wPH_zJ(iSOqdO)
+z(l_3C11Y^6f{?>eO`GrwX*%Iph1oOF6&F4#mRa#c<Qju(bVAS-5djl04Gw3~+a9<V
+zBkTEVmkVQ!*>AB(EeF(+Xh7ZW{B!W!)3=qtqe;wl;Dws+;O>Rlsz|wW_49zbQXBg>
+z^&e^5w(W->eyFmnmNASC2eDXv2F^ClUZ&XZiLGt^t1T`eP3QEb3)NZi1m#-zj*1m7
+ze>B3tD5Jip;KduOEqgkEv-p9f4ijpqSf;qf^#bi${o@5~6Keg6ZgKlA`X9@_fBMs(
+zRGeiw&bh|(1TM19dqaXH{7OqNkDZC?YM0wnXVD#Bo0Dc|PnldRlV(`q!Vm+Swh#zK
+zL?gU)+lGK>ghf%o<;H3lYXNnK3(gB4>N3c+Ks#?h?9uMH!5kxm`RdT20}}R0oMj>Y
+zxdz(U*y0?AVa}X6+Js*jS(&h9@Z}Jz*n(>@D<1#-aCI_V1SG_C0VWM(lu;1~#TSim
+z<sx{YSfZ9msNqN-5!7XqYaiM%9cxDfwO}89n4f&|i6mMS5`t@>jh*JsF%OaO3(=VE
+zPdViBgBO;V5;wX2>0b%TwHXz>h-<9kVJ#0ktk)jii=CKQ;evyih(;))mSM(BL@g6s
+z1L~AiO>7Rtk;@GJLR<?=Q%PLE6l{#rUZ^(Q7CPj$FOQAY?zqv&(fdjp>FMd(OArU!
+zw{LIpMoSc~f%Xe8yx@%Xv}x0j9>tD!g`7%g|CXh$gtOP+S}bybYY{!zoD5f^jM}0R
+zg6obw&euYX?Y&oAaYZl>0USpMY4+^dD%y$5b+F4shB&P)z=mjSuyS=;%zpBYn~chx
+z?2XqvGI;Rd;lqaqy9#l9*sx(>MBc9i;u>EYLCBrao;-Q7HsKd?`N4k!W7R~p*F{kj
+zRIU*`LFL+<48Qe;u{X|DC(Szb>>dni<cJwRe!O#2f&T!S(~m#?C|XPMagEClmi!TD
+z*SU%g?T+^tl{@R9#^d+<@4pYpHLhjo(4k1!CvH|^aSgQLqU=1@o;YzL5{TP1s#2pm
+zyf_k?Yb@KrDFs0!V6Ppx7L#V!<`xWUv0FbR*MfQ&i@*Q<?`SPa$u+JqST_%7*BeQM
+zcD3{E4c0t@*t~!m;)laEu4TxOAp-4$;~Hoq2)VP>c1ZYz4NwU=zAm!Yey(3PxyBx@
+zWqa;JpiwMdBXR=vV`4L=j2?_AaQ3!>?)Pi2y(S*%VRDVuf<7LmE|ZmO2ehmAAmTc!
+zp8Z}Kh|2rzx8I7J6(-lX7A#N#?L_1nXg~JYW6o%g8Z{~_E6Xkx=FpOcYkNQ3nQK6;
+z2HyyuYqS<5P+Puyd4lfe!uJpPnmTnV(o$O*3>nvHwi)04{rgL(!?)MsGSS7tG%_$r
+z#8=25<l2N^3C(px<7>OU#=}rN{8f7`Jo;`6;{^vHOkKujQ$b%EQ!8P<@IXVex08-%
+zS4_ChpWyX03$Q`hZLLBrxklg-Z0iW;g`HFJd8fkpR)`VdJl5{hr;p`MB`VivJ`HC+
+zT%9*-*|~$|+ErtXrh?`Ts1eH|9I2D+GidghF|(iz*e!|?*z3CEQc{20#po0;Bh<Nb
+zXY~mzxCYdR4joFe8xibs5VXw!?aMAhWSM|hqH_(u6yG{m(fTzueIS&XcKtde*BGj-
+zUcEY)ut|R$J(Nk4CaGxCb6sa_O6r?ky}$Gc$@SQ=W09XL>2Hd9f!nul4~BL!acyqC
+zR{YK2mjZt?;g@1&zg@Y=k|i@F*9qNKQyV~u%UC*zA=kCXq@?`*TtFQT*Bdu(Eb(O~
+z?jIr~qt=H!;kmZ>hyUZG^ba?))gRf1@JH|u7n?Nw+3K&IhRs|dxsK<&t29k<?%cVt
+z;yQ11YRdcF1k~Yh9nU$rT)kO^g@yK=Uv{n$1T0bJ!x35mUsdks@&`*f`Np2NUqCQ7
+zGpNG;9k?R+z?+d$mM&BiWrpN>&6+i?-jVn}xh32dSwFnih}4vm=S!%=;X0nvXu5r)
+z?U9PLT)P+IEV}!-1lRCs7jYG^dj;WNu>Tq<d*uFW<jTbUYfEBlkyEc_mk{%2$hPeE
+z9f|YvV<bXvuXC?SP5HRH3UxSKWA!J_#dP)SSr)aEiEA0O5P1d>P8k_95ibR<DI&NT
+zrp{yzToEd~Rafg40?T|joN`^g7x8~`Oq~&PUGti9DW6?nf!gG{ai%)GYo8BiuGKr0
+z99;V|0-XLxxSYu?T^M4oe0aO)ipw;(B4{B}6RJ%GW#-!Qs3GRM#;`Q+7aFL&2ih5_
+z0r>!!Ys;NVK6?#^b{SehY}J&(!;y1PghGNhDOS5MD{dyuEDkc<_Pj34wWWDj-coXH
+zLVfBYyQTK-Yim@t?xJO`Eq5wuxW+b8F~0V3T@<=dB>On>*?XcZj{GLba)Q+^B-%4W
+zk`^bq7HA`s8FOuE9+tO6To)SEho*V|t%G`ZYa_=BHSQX7ZMjona_z?EYn(HR^Jao;
+zb?VHQoU16*FuYR`4GFX2rpZPK@uK|oaJj+6IQD?dUbPre#1T$`xwbS9%UcSr3yo?+
+z%X`o0px)WasHlOOxwhOUyiHcFWmg=lU1C-oCR?QZ5J~qCm=qIeSj(3Axw`bS<_+iZ
+zwWYzh&UK+tby&Lho8Fr4_x&x6Y(3P>wdFP?E7$0X%hfJ3pXTY0;CLoR*;w$x#5jD<
+zu$GNAFQ5&pjj+RrWO#1hi`ZV<TZnqZRjv^#p~|of?{_+=3tJdj0nwf_vjg^ha6eqV
+zO(<JDh=R?BCs03JcEzR1mMJw6W5Mi=pLh{j$uQ6c+K34Q4>YW3BbZ_L{?<$|7JH4i
+z$BrGd2v~OB;@T}fic$1S@j?BA25QfS=0=7eY9yaJr%%sX_3Ek*VLR6kKm0K6SJ}Bc
+z>XqJp`|Xz0KMBpXI>eSH+n)mai<6i@L+%5FC-tHI!r_g_4q#LE9S3&8Z@lN_{ne&|
+zvW08x5_<XNm!Ep-DOJNVQa*b0sNFl!&UK|0UV9+2kVg=ytje%V?~gjD*ETcKz4E>Q
+z>K=po;b!GE2neiT=lbl~vwQaJK}?J?a)ab$V!xrqEf5RYTCQC();Mi+=glP70Vca>
+zV%(SA9%z61F4Fn{ZFI;nJr3tmIIF;LgYJSMgJk;=1yF3+{fD=&yz&Yf%-*Da;R3Pm
+zZ|BaPJ9g~Ywrv|+j<H`Gdxg{&wrwKlkVUa}gYp|siVSVU6s>$smiMf=o5S+sxudC(
+z=7$=&<d6Y&!;||FSGG>025QxaFKWM2KmYu5(%&hy8SdJ(Yvsz7vu4dwZxhPM7hvCi
+z4Hu3C;##5&M{)dMlr4MXa6dB#+C^xiLw?}o8*oBHlqdAbkum^uUpiul+Eh^P-o5+j
+z)2HnX=7%4C_^vFyaJ_aBzW(~_o;`b76zegq<?N>}ZagJiv`wgoXX~N9y@>_tK@&#e
+zX5mqckXHFktVtvh<UvM^RKIOmx>4V06*zL_2m(i2?iAK}6On7VmJPJwekL-2m}n!Y
+z_!lRUt_Uk%$lC=!G#GBsjmb2m47OZ5-UdTkZ8>GI{NMlnw|DQ}cDcayy}wMJ{&+#-
+zX`#_Z@|~QK6)ZMdy!G7H*eK`sC__9+#Fj)a3yEKmx&<Ar`puizYrpv7i%*?8RR(W|
+z!zE*1n>}0=q)RxirO9?c8@Y<$U;6l8e~;ldc7=d$*lq+Iwl@_VVYDsH1{Uy=OOQxj
+z^SX3FdvJ}PDUbGQGQ$b&4(p6cqbus6zNMk+CW@qxaNx%P3cV~mia|HlEA7sK;@foU
+z)X6z-rsZ0a`z;deBAJE#J|P(&a#|&py%ygVP>Ub4LteD(C9F2`6Je~4MeS!!{RxKK
+zNB1Wuu)2+@atz<>BH#$4E!#i(<O2o_(5lpVSfh<UOcY$>-wBWOY&uJicKfwPrE!(?
+zP~X(RNby_ha%pJ@^Db`|=tf5iGbHGZ+xOpzZ-qSXNOmK?aM>)NLyqu1+S>%EuU);=
+zJ*aW!sLz|pZ!5XBTJ54~G-N3feR6+;`RqMmz8P%?5YSo>bzj?B8lRu5LM`YXyXS%?
+zb3B&$@OF0@6~_mG`nvjt*AF#XAksI8n<XE`h((EE6aa_Sw!0FE?}nr#`}XZ~xRB)j
+z)j$9F&w_#i?QOzy65f>(6PF6^ag8smMcbT4`~Gtbw@t%+=2Os(27~!D^vq$t;l6@4
+zbII_lw3@VR*%I@L_E+EH7shw;g`TQ-T^i(td|u*(0J-u7Q)qu7EVg`M!9u(SDKE@R
+z+g|`syslJU2&gMxh?{MHAx^${As2>xAso7R_2|(<s|*fSte!FZXg_JJWntvbZq4TU
+z(Qdces4%Ir-crx4XZV>mgjvzttS>*t(-=O4xLJ4<_quYR_A6y%WT0)^Z&q12g6OPT
+zO)#RtbJ8W2)ziAlwFd3t8FI5vUQ9R40ea>>z`y($6Ki1HJ~yrviVvy^RIHUb_o@Dp
+zXjvG(<(y{oO|;wHVN{q_RS)&dx+>J=Gt#j^9&?_)6%E_Xg0GSJKrUkZib<ofuC0C(
+zF549V)Yt@}(&t{;ZLYOwi{Um5x1<}sD=^;xTrdvI(QFuPd)u%dsZz7LdN8MU*8JxN
+zN}^?9XknK|Q#{!-tLdShQb#>WdS(Wk_Qgu2yjilN6>zi8e2SZeALK<vyH!uZWmN$z
+zC?J}jdmvlROu)4TZQpRacrp#G#SeIqQ9u_RKWIE)JlI%URje$R+jl<~``Io2x0UN=
+zU-!~wl4x1TU(iGY_0N4g6Kbm(!tonh<K-AirCZo;-_tnoX5oGzN(LSX>Z!Oa6adti
+zd$geE>RTGF#U;q5A_|rUBif9>T#zp2&l&AtbYNR67X6V}eA}zX&hHnHPNGV^>>G{`
+zl0=I_!xgQqTm$McdFuH^?sdzZ!du_XDt;PkZx-&?l3j%rt5{PDspl_)Wp7Fff^)h`
+zvHj$fT%&fU22<2#(CZT&KeQb2gVus+w5qu^%Ipt%+Wwy!)sbZtKbVL{mQwia;a}m{
+zV?n!Gg9-~?zd}XZ%Jta-&xl$oXn=a@?#;51gt%G7_e<U>QNXfn-Np^e?9H-Vc(qzJ
+z5#virN>(7|T3naC!H6S%qkuNUKSF_`rGIo_M2J_cAYkS}EDmDf09#+Nlnlon;VWW6
+zyLzLF3*Q<n(GKAHrvlHgnkv*4aw=grhrQtiyIDBS_sBsUyONYgV#2k&KnGd)S3&`k
+z9R+PM?I4!^&6UA_m|Nt`b^lLJz;h4IU>3A%Hm!8?J6Boz;Xf951_wZ0scIF(b(i-=
+zTi`nqjsjZg=nux0Ywh)hqh6W%j4+Gn<qE4UJnb<B?O*r*hv~Kl^Nk-c-tE!=kBHpn
+zIk&zy1Zey0_5TVyg94|}t5rqp8tuIZd9X~~2+PHW6eorsh(oSps7Ab1EgO=GwwO*7
+z%YtG-P%I*&a}En`cG3TF(t>tg%gT%2A8K;_eQ(cz0H`rk$EM48yKw$KrBr~qE~S8O
+z|G5QiwNEa5_T-8`I_L5S{(Idn3E1sbyG@n68=8794ai21NgnKccl#3f{PYSi*Yui4
+zTBAf81$DSByXC@B1QuNW;0UJIEb-z}Dh2qBRL{#rVAx2%41Yc$6kx6s;x<{)RwmQL
+zTEFR(tNfs^j^pU1cP-HSlh>$|hu8=SaqaviOP~OAT>{bQ|3u~5XSJ18Fu8&ZmSq_Q
+zblQP-=Zh{-*RxR0&98$1HS|}(HIga7T$4#%%8D##i??Dv&G&DSOAlBMIC%CH2Hl-{
+zc9&@9)z9C0{K-;&8UFJ)SAe;W^BZLOdRn^ej9Wg233HK41;GXp!pL$?ew%y>FxQEA
+zPc7Jn^A<DY2;+=6a*24o{GB6JfVqxTv3UEu1Jv>MRr&jnDZpHlNzE0p0%Qs>*JM(2
+zMXUgs0?aj;)LaoOK&Ak5O(r#0#0ropz+96_%@wf%WC}3XWKwfQtN@t;%r%+RToEfk
+zrT}wICN)>Y3XmzlT$4%76|n+j3NY7XQgcPD0GR^JHJQ|05i3BZ0CP<yHCMz6kSV}i
+zlS$1Lu>xcYFxO;Kb49EGnF7o;nbcenD?p|Ib4?~SSHudCDZpHlNzE0p0%Qs>*JM(2
+zMXUgs0?aj;)LaoOK&Ak5O(r#0#0ropz+96_%@wf%WC}3XWKwfQtN@t;%r%+RToEfk
+zrT}wICN)>Y3XmzlT$4%76|n+j3NY7XQgcPD0GR^JHJQ|05i3BZ0CP<yHCMz6kSV}i
+zlS$1Lu>xcYFxO;Kb49EGnF7o;nbcenD?p|Ib4?~SSHudCDZpHlNzE0p0%Qs>*JM(2
+zMXUgs0?aj;)LaoOK&Ak5O(r#0#0ropz+96_%@wf%WC}3XWKwfQtN@t;%r%+RToEfk
+zrT}wICN)>Y3XmzlT$4%76|n+j3NY7XQgcPD0GR^JHJQ|05i3BZ0CP<yHCMz6kSV}i
+zlS$1Lu>xcYFxO;Kb49EGnF7o;nbcenD?p|Ib4?~SSHudCDZpHlNzE0p0%Qs>*JM(2
+zMXUgs0?aj;)LaoOK&Ak5O(r#0#0ropz+96_%@wf%WC}3XWKwfQtN@t;%r%+RToEfk
+zrT}wICN)>Y3XmzlT$4%76|n+j3NY7XQgcPD0GR^JHJQ|05i3BZ0CP<yHCMz6kSV}i
+zlS$1Lu>xcYFxO;Kb49EGnF7o;nbcenD?p|Ib4?~SSHudCDZpHlNzE0p0%Qs>*JM(2
+zMXUgs0?aj;)LaoOK&Ak5O(r#0#0ropz+96_%@wf%WC}3XWKwfQtN@t;%r%+RToEfk
+zrT}wICN)>Y3XmzlT$4%76|n+j3NY7XQgcPD0GR^JHJQ|05i3BZ0CP<yHCMz6kSV}i
+zlS$1Lu>xcYFxO;Kb49EGnF7o;nbcenD?p|Ib4?~SSHudCDZpHlNzE0p0%Qs>*JM(2
+zMXUgs0?aj;)LaoOK&Ak5O(r#0#0ropz+96_%@wf%WC}3XWKwfQtN@t;%r%+RToEfk
+zrT}wICN)>Y3XmzlT$4%76|n+j3NY7XQgcPD0GR^JHJQ|05i3BZ0CP<yHCMz6kSV}i
+zlS$1Lu>xcYFxO;Kb49EGnF7o;nbcenD?p|Ib4?~SSHudCDZpHlNzE0p0%Qs>*JM(2
+zMXUgs0?aj;)LaoOK&Ak5O(r#0#0ropz+96_%@wf%WC}3XWKwfQtN@t;%r%+RToEfk
+zrT}wICN)>Y3XmzlT$4%76|n+j3NY7XQgcPD0GR^JHJQ|05i3BZ0CP<yHCMz6kSV}i
+zlS$1Lu>xcYFxO;Kb49EGnF7o;nbcenD?p|Ib4?~SSHudCDZpHlNzE0p0%Qs>*JM(2
+zMXUgs0?aj;)LaoOK&Ak5O(r#0#0ropz+96_%@wf%WC}3XWKwfQtN@t;%r%+RToEfk
+zrT}wICN)>Y3XmzlT$4%76|n+j3NY7XQgcPD0GR^JHJQ|05i3BZ0CP<yHCMz6kSV}i
+zlS$1Lu>xcYFxO;Kb49EGnF7o;nbcenD?p|Ib4?~SSHudCDZpHlNzE0p0%Qs>*JM(2
+zMXUgs0?aj;)LaoOK&Ak5O(r#0#0ropz+96_%@wf%WC}3XWKwfQtN@t;%r%+RToEfk
+zrT}wICN)>Y3XmzlT$4%76|n+j3NY7XQgcPD0GR^JHJQ|05i3BZ0CP<yHCMz6kSV}i
+zlS$1Lu>xcYFxO;Kb49EGnF7o;nbcenD?p|Ib4?~SSHudCDZpHlNzE0p0%Qs>*JM(2
+zMXUgs0?aj;)LaoOK&Ak5O(r#0#0ropz+96_%@wf%WC}3XWKwfQtN@t;%r%+RToEfk
+zrT}wICN)>Y3XmzlT$4%76|n+j3NY7XQgcPD0GR^JHJQ|05i3BZ0CP<yHCMz6kSV}i
+zlS$1Lu>xcYFxO;Kb49EGnF7o;nbcenD?p|Ib4?~SSHudCDZpHlNzE0p0%Qs>*JM(2
+zMXUgs0?aj;)LaoOK&Ak5O(r#0#0ropz+96_%@wf%WC}3XWKwfQtN@t;%r%+RToEfk
+zrT}wICN)>Y3XmzlT$4%76|n+j3NY7XQgcPD0GR^JHJQ|05i3BZ0CP<yHCMz6kSV}i
+zlS$1Lu>xcYFxO;Kb49EGnF7o;nbcenD?p|Ib4?~SSHudCDZpHlNzE0p0%QsZuKyoU
+C`mP`V
+
+literal 0
+HcmV?d00001
+
+diff --git a/nsis/icons/welcome.svg b/nsis/icons/welcome.svg
+new file mode 100644
+index 000000000..bf9919430
+--- /dev/null
++++ b/nsis/icons/welcome.svg
+@@ -0,0 +1,268 @@
++<?xml version="1.0" encoding="UTF-8" standalone="no"?>
++<!-- Created with Inkscape (http://www.inkscape.org/) -->
++
++<svg
++   xmlns:dc="http://purl.org/dc/elements/1.1/"
++   xmlns:cc="http://creativecommons.org/ns#"
++   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
++   xmlns:svg="http://www.w3.org/2000/svg"
++   xmlns="http://www.w3.org/2000/svg"
++   xmlns:xlink="http://www.w3.org/1999/xlink"
++   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
++   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
++   width="328"
++   height="628"
++   id="svg2"
++   version="1.1"
++   inkscape:version="0.47 r22583"
++   sodipodi:docname="welcome.svg"
++   inkscape:export-filename="welcome.png"
++   inkscape:export-xdpi="90"
++   inkscape:export-ydpi="90">
++  <defs
++     id="defs4">
++    <filter
++       id="filter3356"
++       inkscape:label="Drop shadow"
++       width="1.5"
++       height="1.5"
++       x="-.25"
++       y="-.25">
++      <feGaussianBlur
++         id="feGaussianBlur3358"
++         in="SourceAlpha"
++         stdDeviation="5.000000"
++         result="blur" />
++      <feColorMatrix
++         id="feColorMatrix3360"
++         result="bluralpha"
++         type="matrix"
++         values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0.600000 0 " />
++      <feOffset
++         id="feOffset3362"
++         in="bluralpha"
++         dx="-10.000000"
++         dy="10.000000"
++         result="offsetBlur" />
++      <feMerge
++         id="feMerge3364">
++        <feMergeNode
++           id="feMergeNode3366"
++           in="offsetBlur" />
++        <feMergeNode
++           id="feMergeNode3368"
++           in="SourceGraphic" />
++      </feMerge>
++    </filter>
++    <filter
++       id="filter3496"
++       inkscape:label="Drop shadow"
++       width="1.5"
++       height="1.5"
++       x="-.25"
++       y="-.25">
++      <feGaussianBlur
++         id="feGaussianBlur3498"
++         in="SourceAlpha"
++         stdDeviation="3.000000"
++         result="blur" />
++      <feColorMatrix
++         id="feColorMatrix3500"
++         result="bluralpha"
++         type="matrix"
++         values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0.600000 0 " />
++      <feOffset
++         id="feOffset3502"
++         in="bluralpha"
++         dx="-5.000000"
++         dy="5.000000"
++         result="offsetBlur" />
++      <feMerge
++         id="feMerge3504">
++        <feMergeNode
++           id="feMergeNode3506"
++           in="offsetBlur" />
++        <feMergeNode
++           id="feMergeNode3508"
++           in="SourceGraphic" />
++      </feMerge>
++    </filter>
++  </defs>
++  <sodipodi:namedview
++     id="base"
++     pagecolor="#ffffff"
++     bordercolor="#666666"
++     borderopacity="1.0"
++     inkscape:pageopacity="1"
++     inkscape:pageshadow="2"
++     inkscape:zoom="1.0716561"
++     inkscape:cx="122.81449"
++     inkscape:cy="381.22777"
++     inkscape:document-units="px"
++     inkscape:current-layer="layer1"
++     showgrid="false"
++     inkscape:window-width="1280"
++     inkscape:window-height="942"
++     inkscape:window-x="0"
++     inkscape:window-y="27"
++     inkscape:window-maximized="1"
++     inkscape:snap-global="true"
++     inkscape:showpageshadow="false" />
++  <metadata
++     id="metadata7">
++    <rdf:RDF>
++      <cc:Work
++         rdf:about="">
++        <dc:format>image/svg+xml</dc:format>
++        <dc:type
++           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
++        <dc:title></dc:title>
++      </cc:Work>
++    </rdf:RDF>
++  </metadata>
++  <g
++     inkscape:label="Layer 1"
++     inkscape:groupmode="layer"
++     id="layer1"
++     transform="translate(0,-424.36218)">
++    <rect
++       style="fill:#eeffcc;fill-opacity:1;stroke:#007f00;stroke-width:2.0138948;stroke-miterlimit:2.6099999;stroke-opacity:1;stroke-dasharray:none"
++       id="rect3510"
++       width="327.98608"
++       height="635.98608"
++       x="-0.99305254"
++       y="420.36914" />
++    <path
++       sodipodi:type="arc"
++       style="fill:#ffffff;fill-opacity:0;stroke:none"
++       id="path3795"
++       sodipodi:cx="92.889717"
++       sodipodi:cy="94.761551"
++       sodipodi:rx="83.062592"
++       sodipodi:ry="84.466469"
++       d="m 175.95231,94.761551 c 0,46.649539 -37.18839,84.466469 -83.062593,84.466469 -45.874202,0 -83.0625915,-37.81693 -83.0625915,-84.466469 0,-46.649543 37.1883895,-84.466469 83.0625915,-84.466469 45.874203,0 83.062593,37.816926 83.062593,84.466469 z"
++       transform="matrix(0,-2.3099964,-2.3548838,0,387.15244,952.93709)" />
++    <text
++       xml:space="preserve"
++       style="font-size:40px;font-style:normal;font-weight:normal;fill:#000000;fill-opacity:1;stroke:none;font-family:Bitstream Vera Sans;filter:url(#filter3496)"
++       id="text3026"><textPath
++         xlink:href="#path3795"
++         startOffset="50%"
++         id="textPath3036"
++         style="font-size:58;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-align:center;text-anchor:middle;font-family:Courier New;-inkscape-font-specification:Courier New Bold;">The editor</textPath></text>
++    <g
++       id="g2968"
++       style="filter:url(#filter3356)">
++      <path
++         inkscape:connector-curvature="0"
++         id="path2999"
++         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.20903109000000000;stroke-miterlimit:2.60999990000000004;stroke-opacity:1;stroke-dasharray:none;"
++         d="M 299.80052,736.9686 162.60646,602.56167 28.199478,739.68603 162.60646,874.16269 299.80052,736.9686" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3003"
++         style="fill:#006b05;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.20903109000000000;stroke-miterlimit:2.60999990000000004;stroke-opacity:1;stroke-dasharray:none;"
++         d="m 286.07415,736.9686 8.22189,0 -131.68958,131.68962 0,-8.2219 123.46769,-123.46772" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3007"
++         style="fill:#007d17;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.20903109000000000;stroke-miterlimit:2.60999990000000004;stroke-opacity:1;stroke-dasharray:none;"
++         d="m 33.703958,739.68603 8.221891,0 120.680611,120.75029 0,8.2219 L 33.703958,739.68603" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3011"
++         style="fill:#66ff99;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.20903109000000000;stroke-miterlimit:2.60999990000000004;stroke-opacity:1;stroke-dasharray:none;"
++         d="m 162.60646,616.21837 0,-8.15223 -128.902502,131.61989 8.221891,0 120.680611,-123.46766" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3015"
++         style="fill:#45ff02;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.20903109000000000;stroke-miterlimit:2.60999990000000004;stroke-opacity:1;stroke-dasharray:none;"
++         d="m 162.60646,608.06614 0,8.15223 123.46769,120.75023 8.22189,0 -131.68958,-128.90246" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3019"
++         style="fill:#009933;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.20903109000000000;stroke-miterlimit:2.60999990000000004;stroke-opacity:1;stroke-dasharray:none;"
++         d="M 162.60646,860.43632 286.07415,736.9686 162.60646,616.21837 41.925849,739.68603 162.60646,860.43632" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3023"
++         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.20903109000000000;stroke-miterlimit:2.60999990000000004;stroke-opacity:1;stroke-dasharray:none;"
++         d="m 188.24761,643.67106 8.22188,8.29158 0,0 -56.71709,57.55326 0,-57.55326 5.50448,0 8.22189,-8.29158 0,-21.87855 -8.22189,-8.29157 -91.416257,0 -8.221894,8.29157 0,21.87855 8.221894,8.29158 6.410285,0 0,186.52539 10.033492,8.22191 28.358547,0 196.558893,-203.03888 0,-21.87855 -8.22189,-8.29157 -89.60466,0 -9.12768,8.29157 0,21.87855" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3027"
++         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.20903109000000000;stroke-miterlimit:2.60999990000000004;stroke-opacity:1;stroke-dasharray:none;"
++         d="m 56.558028,646.45817 -5.504489,-5.50448 0,-16.4438 5.504489,-5.50448 85.981452,-0.0697 5.4348,5.57416 -5.4348,2.64775 -2.78708,-2.64775 -83.194372,13.6567 0,8.29158" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3031"
++         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.20903109000000000;stroke-miterlimit:2.60999990000000004;stroke-opacity:1;stroke-dasharray:none;"
++         d="m 73.001805,841.20547 -6.410285,-5.50448 0,-189.3125 6.410285,-5.4348 0,200.25178" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3035"
++         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.20903109000000000;stroke-miterlimit:2.60999990000000004;stroke-opacity:1;stroke-dasharray:none;"
++         d="m 210.19587,646.45817 5.50448,-5.50448 0,11.00895 -91.48593,93.22786 10.10317,-21.94822 75.87828,-76.78411" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3039"
++         style="fill:#7f7f7f;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.20903109000000000;stroke-miterlimit:2.60999990000000004;stroke-opacity:1;stroke-dasharray:none;"
++         d="m 74.883082,638.23626 -1.881277,2.71743 -6.410285,5.50448 -10.033492,0 0,-11.00895 18.325054,2.78704" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3043"
++         style="fill:#7f7f7f;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.20903109000000000;stroke-miterlimit:2.60999990000000004;stroke-opacity:1;stroke-dasharray:none;"
++         d="m 134.31759,646.45817 0,76.78411 -10.10317,21.87855 0,-104.23681 15.53798,0 2.78708,-2.71743 -2.78708,-13.6567 8.22188,0 0,16.4438 -5.4348,5.50448 -8.22189,0" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3047"
++         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.20903109000000000;stroke-miterlimit:2.60999990000000004;stroke-opacity:1;stroke-dasharray:none;"
++         d="m 199.1869,646.45817 -5.43481,-5.50448 0,-16.4438 6.34061,-5.50448 83.26404,0 6.41029,5.50448 -9.19736,8.2219 -81.38277,5.4348 0,8.29158" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3051"
++         style="fill:#7f7f7f;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.20903109000000000;stroke-miterlimit:2.60999990000000004;stroke-opacity:1;stroke-dasharray:none;"
++         d="m 289.76703,640.95369 -193.005361,200.25177 -23.759864,0 0,-8.2219 17.419257,0 192.935678,-197.53434 -2.78707,-10.93933 9.19736,0 0,16.4438" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3055"
++         style="fill:#7f7f7f;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.20903109000000000;stroke-miterlimit:2.60999990000000004;stroke-opacity:1;stroke-dasharray:none;"
++         d="m 217.51196,638.23626 -1.88128,2.71743 -5.43481,5.50448 -11.00897,0 0,-11.00895 18.32506,2.78704" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3059"
++         style="fill:#cccccc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.20903109000000000;stroke-miterlimit:2.60999990000000004;stroke-opacity:1;stroke-dasharray:none;"
++         d="m 124.21442,745.12082 0,-104.23681 15.53798,0 2.78708,-2.71742 0,-11.00895 -2.78708,-2.71743 -80.476968,0 -2.717404,2.71743 0,11.00895 2.717404,2.71742 13.726373,0 0,192.09955 3.553528,2.71743 15.677333,0 192.029884,-200.25177 0,-7.87353 -2.78708,-3.13548 -79.50149,0 -2.78708,2.71743 0,11.07862 2.78708,2.71743 13.72637,0 0,11.00895 -91.48593,93.15818" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3063"
++         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.20903109000000000;stroke-miterlimit:2.60999990000000004;stroke-opacity:1;stroke-dasharray:none;"
++         d="m 174.10317,745.26018 6.41029,-5.50448 16.44377,0 4.59868,5.50448 -5.50447,16.4438 -6.34062,5.50448 -16.44377,0 -4.66836,-5.50448 5.50448,-16.4438" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3067"
++         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.20903109000000000;stroke-miterlimit:2.60999990000000004;stroke-opacity:1;stroke-dasharray:none;"
++         d="m 179.60765,835.77066 16.51346,-49.33135 -5.50448,0 5.50448,-16.51342 24.59599,0 5.50448,5.50447 3.69289,0 5.43481,-5.50447 18.32505,0 5.50449,5.50447 3.62321,0 5.50448,-5.50447 20.06698,0 7.31609,11.00895 -11.98445,39.01911 5.43481,0 -5.29546,15.81671 -32.95723,0 12.89025,-38.39208 -8.22189,0 -7.59479,22.43602 5.43481,0 -5.1561,15.95606 -32.95724,0 12.82057,-38.39208 -8.22188,0 -7.66448,22.57537 5.50449,0 -5.1561,15.81671 -32.95724,0" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3071"
++         style="fill:#cccccc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.20903109000000000;stroke-miterlimit:2.60999990000000004;stroke-opacity:1;stroke-dasharray:none;"
++         d="m 285.86512,775.43036 4.25029,6.06188 -13.51734,43.3391 5.43481,0 -1.8116,5.43485 -21.94826,0 12.82057,-38.39208 -19.23086,0 -10.93929,32.95723 5.43481,0 -1.81161,5.43485 -21.94826,0 12.82057,-38.39208 -19.23086,0 -10.93929,32.95723 5.50448,0 -1.88127,5.43485 -21.94827,0 16.51346,-49.33135 -5.50449,0 1.8116,-5.50448 20.13667,0 5.50448,5.50448 5.43481,0 5.50448,-5.50448 16.44378,0 5.50449,5.50448 5.50448,0 5.50449,-5.50448 16.58312,0" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3075"
++         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.20903109000000000;stroke-miterlimit:2.60999990000000004;stroke-opacity:1;stroke-dasharray:none;"
++         d="m 193.33403,769.92588 -16.79216,49.95839 5.71351,0 -5.43481,15.88639 -32.88755,0 16.44378,-49.33135 -5.50449,0 38.46172,-16.51343 z m -38.46172,16.51343 5.50449,-16.51343 32.95723,0" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3079"
++         style="fill:#cccccc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.20903109000000000;stroke-miterlimit:2.60999990000000004;stroke-opacity:1;stroke-dasharray:none;"
++         d="m 173.19737,830.26619 1.8116,-5.43485 -5.50448,0 16.51345,-49.40098 -22.85406,0 -1.88128,5.50448 6.41028,0 -16.44378,49.33135 21.94827,0" />
++      <path
++         inkscape:connector-curvature="0"
++         id="path3083"
++         style="fill:#cccccc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.20903109000000000;stroke-miterlimit:2.60999990000000004;stroke-opacity:1;stroke-dasharray:none;"
++         d="m 191.45275,758.98656 3.69288,-11.00896 -1.8116,-2.71743 -11.00897,0 -3.62321,2.71743 -3.69288,11.00896 1.88128,2.71742 11.00897,0 3.55353,-2.71742" />
++    </g>
++  </g>
++</svg>
+diff --git a/nsis/lang/english.nsi b/nsis/lang/english.nsi
+new file mode 100644
+index 000000000..3a2ddc122
+--- /dev/null
++++ b/nsis/lang/english.nsi
+@@ -0,0 +1,235 @@
++﻿# vi:set ts=8 sts=4 sw=4 et fdm=marker:
++#
++# english.nsi: English language strings for gvim NSIS installer.
++#
++# Locale ID    : 1033
++# fileencoding : UTF-8
++# Author       : Guopeng Wen
++
++# The following macro pulls in NSIS language file and defines various
++# constants for multiple language support.  The first argument to the macro is
++# language name.  For a list of languages supported by NSIS, check:
++#   "<nsis>/Contrib/Language files"
++# The second argument is locale name of the language like the one used by GNU
++# gettext.  It's used to make it simpler to specify language on command line.
++# ${LANG_<language>} will be defined as the language id after you inserted the
++# language.  For example, after you insert "English", ${LANG_ENGLISH} will be
++# defined as the language ID so you can use it in the following language
++# string definition.
++#!include "script\helper_util.nsh"
++#${VimAddLanguage} "English" "en"
++!insertmacro MUI_LANGUAGE "English"
++
++
++##############################################################################
++# MUI Configuration Strings                                               {{{1
++##############################################################################
++
++LangString str_dest_folder          ${LANG_ENGLISH} \
++    "Destination Folder (Must end with $\"vim$\")"
++
++LangString str_show_readme          ${LANG_ENGLISH} \
++    "Show README after installation finish"
++
++# Install types:
++LangString str_type_typical         ${LANG_ENGLISH} \
++    "Typical"
++
++LangString str_type_minimal         ${LANG_ENGLISH} \
++    "Minimal"
++
++LangString str_type_full            ${LANG_ENGLISH} \
++    "Full"
++
++
++##############################################################################
++# Section Titles & Description                                            {{{1
++##############################################################################
++
++LangString str_group_old_ver        ${LANG_ENGLISH} \
++    "Uninstall Existing Version(s)"
++LangString str_desc_old_ver         ${LANG_ENGLISH} \
++    "Uninstall existing Vim version(s) from your system."
++
++LangString str_section_exe          ${LANG_ENGLISH} \
++    "Vim GUI"
++LangString str_desc_exe             ${LANG_ENGLISH} \
++    "Vim GUI executables and runtime files.  This component is required."
++
++LangString str_section_console      ${LANG_ENGLISH} \
++    "Vim console program"
++LangString str_desc_console         ${LANG_ENGLISH} \
++    "Console version of Vim (vim.exe)."
++
++LangString str_section_batch        ${LANG_ENGLISH} \
++    "Create .bat files"
++LangString str_desc_batch           ${LANG_ENGLISH} \
++    "Create .bat files for Vim variants in the Windows directory for \
++     command line use."
++
++LangString str_group_icons          ${LANG_ENGLISH} \
++    "Create icons for Vim"
++LangString str_desc_icons           ${LANG_ENGLISH} \
++    "Create icons for Vim at various locations to facilitate easy access."
++
++LangString str_section_desktop      ${LANG_ENGLISH} \
++    "On the Desktop"
++LangString str_desc_desktop         ${LANG_ENGLISH} \
++    "Create icons for gVim executables on the desktop."
++
++LangString str_section_start_menu   ${LANG_ENGLISH} \
++    "In the Start Menu Programs Folder"
++LangString str_desc_start_menu      ${LANG_ENGLISH} \
++    "Add Vim in the programs folder of the start menu.  \
++     Applicable to Windows 95 and later."
++
++LangString str_section_quick_launch ${LANG_ENGLISH} \
++    "In the Quick Launch Bar"
++LangString str_desc_quick_launch    ${LANG_ENGLISH} \
++    "Add Vim shortcut in the quick launch bar."
++
++LangString str_group_edit_with      ${LANG_ENGLISH} \
++    "Add Vim Context Menu"
++LangString str_desc_edit_with       ${LANG_ENGLISH} \
++    "Add Vim to the $\"Open With...$\" context menu list."
++
++LangString str_section_edit_with32  ${LANG_ENGLISH} \
++    "32-bit Version"
++LangString str_desc_edit_with32     ${LANG_ENGLISH} \
++    "Add Vim to the $\"Open With...$\" context menu list \
++     for 32-bit applications."
++
++LangString str_section_edit_with64  ${LANG_ENGLISH} \
++    "64-bit Version"
++LangString str_desc_edit_with64     ${LANG_ENGLISH} \
++    "Add Vim to the $\"Open With...$\" context menu list \
++     for 64-bit applications."
++
++LangString str_section_vim_rc       ${LANG_ENGLISH} \
++    "Create Default Config"
++LangString str_desc_vim_rc          ${LANG_ENGLISH} \
++    "Create a default config file (_vimrc) if one does not already exist."
++
++LangString str_group_plugin         ${LANG_ENGLISH} \
++    "Create Plugin Directories"
++LangString str_desc_plugin          ${LANG_ENGLISH} \
++    "Create plugin directories.  Plugin directories allow extending Vim \
++     by dropping a file into a directory."
++
++LangString str_section_plugin_home  ${LANG_ENGLISH} \
++    "Private"
++LangString str_desc_plugin_home     ${LANG_ENGLISH} \
++    "Create plugin directories in HOME (if you defined one) or Vim \
++     install directory."
++
++LangString str_section_plugin_vim   ${LANG_ENGLISH} \
++    "Shared"
++LangString str_desc_plugin_vim      ${LANG_ENGLISH} \
++    "Create plugin directories in Vim install directory, it is used for \
++     everybody on the system."
++
++LangString str_section_vis_vim      ${LANG_ENGLISH} \
++    "VisVim Extension"
++LangString str_desc_vis_vim         ${LANG_ENGLISH} \
++    "VisVim Extension for Microsoft Visual Studio integration."
++
++LangString str_section_nls          ${LANG_ENGLISH} \
++    "Native Language Support"
++LangString str_desc_nls             ${LANG_ENGLISH} \
++    "Install files for native language support."
++
++LangString str_unsection_register   ${LANG_ENGLISH} \
++    "Unregister Vim"
++LangString str_desc_unregister      ${LANG_ENGLISH} \
++    "Unregister Vim from the system."
++
++LangString str_unsection_exe        ${LANG_ENGLISH} \
++    "Remove Vim Executables/Runtime Files"
++LangString str_desc_rm_exe          ${LANG_ENGLISH} \
++    "Remove all Vim executables and runtime files."
++
++LangString str_vimrc_page_title     ${LANG_ENGLISH} \
++    "Choose _vimrc settings"
++LangString str_vimrc_page_subtitle  ${LANG_ENGLISH} \
++    "Choose the behavior of key remapping and mouse."
++
++##############################################################################
++# Messages                                                                {{{1
++##############################################################################
++
++LangString str_msg_too_many_ver  ${LANG_ENGLISH} \
++    "Found $vim_old_ver_count Vim versions on your system.$\r$\n\
++     This installer can only handle ${VIM_MAX_OLD_VER} versions \
++     at most.$\r$\n\
++     Please remove some versions and start again."
++
++LangString str_msg_invalid_root  ${LANG_ENGLISH} \
++    "Invalid install path: $vim_install_root!$\r$\n\
++     It should end with $\"vim$\"."
++
++LangString str_msg_bin_mismatch  ${LANG_ENGLISH} \
++    "Binary path mismatch!$\r$\n$\r$\n\
++     Expect the binary path to be $\"$vim_bin_path$\",$\r$\n\
++     but system indicates the binary path is $\"$INSTDIR$\"."
++
++LangString str_msg_vim_running   ${LANG_ENGLISH} \
++    "Vim is still running on your system.$\r$\n\
++     Please close all instances of Vim before you continue."
++
++LangString str_msg_register_ole  ${LANG_ENGLISH} \
++    "Attempting to register Vim with OLE. \
++     There is no message indicates whether this works or not."
++
++LangString str_msg_unreg_ole     ${LANG_ENGLISH} \
++    "Attempting to unregister Vim with OLE. \
++     There is no message indicates whether this works or not."
++
++LangString str_msg_rm_start      ${LANG_ENGLISH} \
++    "Uninstalling the following version:"
++
++LangString str_msg_rm_fail       ${LANG_ENGLISH} \
++    "Fail to uninstall the following version:"
++
++LangString str_msg_no_rm_key     ${LANG_ENGLISH} \
++    "Cannot find uninstaller registry key."
++
++LangString str_msg_no_rm_reg     ${LANG_ENGLISH} \
++    "Cannot find uninstaller from registry."
++
++LangString str_msg_no_rm_exe     ${LANG_ENGLISH} \
++    "Cannot access uninstaller."
++
++LangString str_msg_rm_copy_fail  ${LANG_ENGLISH} \
++    "Fail to copy uninstaller to temporary directory."
++
++LangString str_msg_rm_run_fail   ${LANG_ENGLISH} \
++    "Fail to run uninstaller."
++
++LangString str_msg_abort_install ${LANG_ENGLISH} \
++    "Installer will abort."
++
++LangString str_msg_install_fail  ${LANG_ENGLISH} \
++    "Installation failed. Better luck next time."
++
++LangString str_msg_rm_exe_fail   ${LANG_ENGLISH} \
++    "Some files in $vim_bin_path have not been deleted!$\r$\n\
++     You must do it manually."
++
++LangString str_msg_rm_root_fail  ${LANG_ENGLISH} \
++    "WARNING: Cannot remove $\"$vim_install_root$\", it is not empty!"
++
++LangString str_msg_keymap_title   ${LANG_ENGLISH} \
++    " Key remapping "
++LangString str_msg_keymap_default ${LANG_ENGLISH} \
++    " Do not remap keys for Windows behavior (Default)"
++LangString str_msg_keymap_windows ${LANG_ENGLISH} \
++    " Remap a few keys for Windows behavior$\n (<C-V>, <C-C>, <C-A>, <C-S>, <C-F>, etc)"
++
++LangString str_msg_mouse_title   ${LANG_ENGLISH} \
++    " Mouse behavior "
++LangString str_msg_mouse_default ${LANG_ENGLISH} \
++    " Default:$\n     Right button has a popup menu, left button starts visual mode"
++LangString str_msg_mouse_windows ${LANG_ENGLISH} \
++    " Windows:$\n     Right button has a popup menu, left button starts select mode"
++LangString str_msg_mouse_unix    ${LANG_ENGLISH} \
++    " Unix:$\n     Right button extends selection, left button starts visual mode"
+diff --git a/src/dosinst.c b/src/dosinst.c
+index 344d62be3..d8b8af08c 100644
+--- a/src/dosinst.c
++++ b/src/dosinst.c
+@@ -442,7 +442,7 @@ window_cb(HWND hwnd, LPARAM lparam)
+ 
+     title[0] = 0;
+     GetWindowText(hwnd, title, 256);
+-    if (strstr(title, "Vim ") != NULL && strstr(title, "Uninstall:") != NULL)
++    if (strstr(title, "Vim ") != NULL && strstr(title, " Uninstall") != NULL)
+ 	++num_windows;
+     return TRUE;
+ }
+-- 
+2.17.0
+

--- a/patch/0011-nsis-Use-InstallLib-for-installing-DLLs.patch
+++ b/patch/0011-nsis-Use-InstallLib-for-installing-DLLs.patch
@@ -1,0 +1,206 @@
+From 4b2f4056f90e3b4ec10ee2277d5cf2b99ded3556 Mon Sep 17 00:00:00 2001
+From: "K.Takata" <kentkt@csc.jp>
+Date: Mon, 1 Oct 2018 07:16:11 +0900
+Subject: [PATCH 11/22] nsis: Use InstallLib for installing DLLs
+
+It is more reliable and easier to read than the current implementation.
+---
+ nsis/gvim.nsi | 140 +++++++++++++++++++++++++++-----------------------
+ 1 file changed, 76 insertions(+), 64 deletions(-)
+
+diff --git a/nsis/gvim.nsi b/nsis/gvim.nsi
+index d09b9eb4e..dbbad7d3d 100644
+--- a/nsis/gvim.nsi
++++ b/nsis/gvim.nsi
+@@ -502,37 +502,28 @@ Section "Add an Edit-with-Vim context menu entry" sec_gvimext_id
+ 	# installed at the next reboot.  Can't use UpgradeDLL!
+ 	# We don't ask the user to reboot, the old dll will keep on working.
+ 	SetOutPath $0
+-	ClearErrors
+-	SetOverwrite try
+ 
+ 	${If} ${RunningX64}
+ 	  # Install 64-bit gvimext.dll into the GvimExt64 directory.
+ 	  SetOutPath $0\GvimExt64
+ 	  ClearErrors
+-	  File /oname=gvimext.dll ${VIMSRC}\GvimExt\gvimext64.dll
+-
+-	  ${If} ${Errors}
+-	    # Can't copy gvimext.dll, create it under another name and rename it
+-	    # on next reboot.
+-	    GetTempFileName $3 $0\GvimExt64
+-	    File /oname=$3 ${VIMSRC}\GvimExt\gvimext64.dll
+-	    Rename /REBOOTOK $3 $0\GvimExt64\gvimext.dll
+-	  ${EndIf}
++	  !define LIBRARY_SHELL_EXTENSION
++	  !define LIBRARY_X64
++	  !insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
++	      "${VIMSRC}\GvimExt\gvimext64.dll" \
++	      "$0\GvimExt64\gvimext.dll" "$0"
++	  !undef LIBRARY_X64
++	  !undef LIBRARY_SHELL_EXTENSION
+ 	${EndIf}
+ 
+ 	# Install 32-bit gvimext.dll into the GvimExt32 directory.
+ 	SetOutPath $0\GvimExt32
+ 	ClearErrors
+-	File /oname=gvimext.dll ${VIMSRC}\GvimExt\gvimext.dll
+-
+-	${If} ${Errors}
+-	  # Can't copy gvimext.dll, create it under another name and rename it
+-	  # on next reboot.
+-	  GetTempFileName $3 $0\GvimExt32
+-	  File /oname=$3 ${VIMSRC}\GvimExt\gvimext.dll
+-	  Rename /REBOOTOK $3 $0\GvimExt32\gvimext.dll
+-	${EndIf}
+-	SetOverwrite lastused
++	!define LIBRARY_SHELL_EXTENSION
++	!insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
++	    "${VIMSRC}\GvimExt\gvimext.dll" \
++	    "$0\GvimExt32\gvimext.dll" "$0"
++	!undef LIBRARY_SHELL_EXTENSION
+ 
+ 	# We don't have a separate entry for the "Open With..." menu, assume
+ 	# the user wants either both or none.
+@@ -604,64 +595,49 @@ Section "Native Language Support" sec_nls_id
+ 	File ${VIMRT}\keymap\README.txt
+ 	File ${VIMRT}\keymap\*.vim
+ 	SetOutPath $0
+-	File ${GETTEXT}\gettext32\libintl-8.dll
+-	File ${GETTEXT}\gettext32\libiconv-2.dll
+-	#File /nonfatal ${VIMRT}\libwinpthread-1.dll
++	!insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
++	    "${GETTEXT}\gettext32\libintl-8.dll" \
++	    "$0\libintl-8.dll" "$0"
++	!insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
++	    "${GETTEXT}\gettext32\libiconv-2.dll" \
++	    "$0\libiconv-2.dll" "$0"
+   !if /FileExists "${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll"
+ 	# Install libgcc_s_sjlj-1.dll only if it is needed.
+-	File ${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll
++	!insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
++	    "${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll" \
++	    "$0\libgcc_s_sjlj-1.dll" "$0"
+   !endif
+ 
+ 	${If} ${SectionIsSelected} ${sec_gvimext_id}
+-	  SetOverwrite try
+-
+ 	  ${If} ${RunningX64}
+ 	    # Install DLLs for 64-bit gvimext.dll into the GvimExt64 directory.
+ 	    SetOutPath $0\GvimExt64
+ 	    ClearErrors
+-	    File ${GETTEXT}\gettext64\libintl-8.dll
+-	    File ${GETTEXT}\gettext64\libiconv-2.dll
+-
+-	    ${If} ${Errors}
+-	      # Can't copy the DLLs, create it under another name and rename it
+-	      # on next reboot.
+-	      GetTempFileName $3 $0\GvimExt64
+-	      File /oname=$3 ${GETTEXT}\gettext64\libintl-8.dll
+-	      Rename /REBOOTOK $3 $0\GvimExt64\libintl-8.dll
+-	      GetTempFileName $3 $0\GvimExt64
+-	      File /oname=$3 ${GETTEXT}\gettext64\libiconv-2.dll
+-	      Rename /REBOOTOK $3 $0\GvimExt64\libiconv-2.dll
+-	    ${EndIf}
++	    !define LIBRARY_X64
++	    !insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
++		"${GETTEXT}\gettext64\libintl-8.dll" \
++		"$0\GvimExt64\libintl-8.dll" "$0\GvimExt64"
++	    !insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
++		"${GETTEXT}\gettext64\libiconv-2.dll" \
++		"$0\GvimExt64\libiconv-2.dll" "$0\GvimExt64"
++	    !undef LIBRARY_X64
+ 	  ${EndIf}
+ 
+ 	  # Install DLLs for 32-bit gvimext.dll into the GvimExt32 directory.
+ 	  SetOutPath $0\GvimExt32
+ 	  ClearErrors
+-	  File ${GETTEXT}\gettext32\libintl-8.dll
+-	  File ${GETTEXT}\gettext32\libiconv-2.dll
++	  !insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
++	      "${GETTEXT}\gettext32\libintl-8.dll" \
++	      "$0\GvimExt32\libintl-8.dll" "$0\GvimExt32"
++	  !insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
++	      "${GETTEXT}\gettext32\libiconv-2.dll" \
++	      "$0\GvimExt32\libiconv-2.dll" "$0\GvimExt32"
+   !if /FileExists "${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll"
+ 	  # Install libgcc_s_sjlj-1.dll only if it is needed.
+-	  File ${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll
++	  !insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
++	      "${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll" \
++	      "$0\GvimExt32\libgcc_s_sjlj-1.dll" "$0\GvimExt32"
+   !endif
+-
+-	  ${If} ${Errors}
+-	    # Can't copy the DLLs, create it under another name and rename it
+-	    # on next reboot.
+-	    GetTempFileName $3 $0\GvimExt32
+-	    File /oname=$3 ${GETTEXT}\gettext32\libintl-8.dll
+-	    Rename /REBOOTOK $3 $0\GvimExt32\libintl-8.dll
+-	    GetTempFileName $3 $0\GvimExt32
+-	    File /oname=$3 ${GETTEXT}\gettext32\libiconv-2.dll
+-	    Rename /REBOOTOK $3 $0\GvimExt32\libiconv-2.dll
+-  !if /FileExists "${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll"
+-	    # Install libgcc_s_sjlj-1.dll only if it is needed.
+-	    GetTempFileName $3 $0\GvimExt32
+-	    File /oname=$3 ${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll
+-	    Rename /REBOOTOK $3 $0\GvimExt32\libgcc_s_sjlj-1.dll
+-  !endif
+-	  ${EndIf}
+-
+-	  SetOverwrite lastused
+ 	${EndIf}
+ SectionEnd
+ !endif
+@@ -837,9 +813,45 @@ Section "un.$(str_unsection_exe)"
+ 	StrCpy $0 "$INSTDIR"
+ 
+ 	Delete /REBOOTOK $0\*.dll
+-	Delete /REBOOTOK $0\GvimExt32\*.dll
++
++	# Delete 64-bit GvimExt
+ 	${If} ${RunningX64}
+-	  Delete /REBOOTOK $0\GvimExt64\*.dll
++	  !define LIBRARY_X64
++	  ${If} ${FileExists} "$0\GvimExt64\gvimext.dll"
++	    !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
++		"$0\GvimExt64\gvimext.dll"
++	  ${EndIf}
++	  ${If} ${FileExists} "$0\GvimExt64\libiconv-2.dll"
++	    !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
++		"$0\GvimExt64\libiconv-2.dll"
++	  ${EndIf}
++	  ${If} ${FileExists} "$0\GvimExt64\libintl-8.dll"
++	    !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
++		"$0\GvimExt64\libintl-8.dll"
++	  ${EndIf}
++	  ${If} ${FileExists} "$0\GvimExt64\libwinpthread-1.dll"
++	    !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
++		"$0\GvimExt64\libwinpthread-1.dll"
++	  ${EndIf}
++	  !undef LIBRARY_X64
++	${EndIf}
++
++	# Delete 32-bit GvimExt
++	${If} ${FileExists} "$0\GvimExt32\gvimext.dll"
++	  !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
++	      "$0\GvimExt32\gvimext.dll"
++	${EndIf}
++	${If} ${FileExists} "$0\GvimExt32\libiconv-2.dll"
++	  !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
++	      "$0\GvimExt32\libiconv-2.dll"
++	${EndIf}
++	${If} ${FileExists} "$0\GvimExt32\libintl-8.dll"
++	  !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
++	      "$0\GvimExt32\libintl-8.dll"
++	${EndIf}
++	${If} ${FileExists} "$0\GvimExt32\libgcc_s_sjlj-1.dll"
++	  !insertmacro UninstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
++	      "$0\GvimExt32\libgcc_s_sjlj-1.dll"
+ 	${EndIf}
+ 
+ 	ClearErrors
+-- 
+2.17.0
+

--- a/patch/0012-nsis-Support-translation.patch
+++ b/patch/0012-nsis-Support-translation.patch
@@ -1,0 +1,1897 @@
+From ab3132a2ce118eeed766c8e7b3c0b862f51d5675 Mon Sep 17 00:00:00 2001
+From: "K.Takata" <kentkt@csc.jp>
+Date: Tue, 2 Oct 2018 14:51:51 +0900
+Subject: [PATCH 12/22] nsis: Support translation
+
+Import most part from gpwen's work.
+---
+ nsis/gvim.nsi             | 140 ++++++++++++++-------
+ nsis/lang/dutch.nsi       | 243 ++++++++++++++++++++++++++++++++++++
+ nsis/lang/english.nsi     |  27 +++-
+ nsis/lang/german.nsi      | 243 ++++++++++++++++++++++++++++++++++++
+ nsis/lang/italian.nsi     | 252 ++++++++++++++++++++++++++++++++++++++
+ nsis/lang/japanese.nsi    | 238 +++++++++++++++++++++++++++++++++++
+ nsis/lang/simpchinese.nsi | 239 ++++++++++++++++++++++++++++++++++++
+ nsis/lang/tradchinese.nsi | 240 ++++++++++++++++++++++++++++++++++++
+ 8 files changed, 1571 insertions(+), 51 deletions(-)
+ create mode 100644 nsis/lang/dutch.nsi
+ create mode 100644 nsis/lang/german.nsi
+ create mode 100644 nsis/lang/italian.nsi
+ create mode 100644 nsis/lang/japanese.nsi
+ create mode 100644 nsis/lang/simpchinese.nsi
+ create mode 100644 nsis/lang/tradchinese.nsi
+
+diff --git a/nsis/gvim.nsi b/nsis/gvim.nsi
+index dbbad7d3d..a51b385e5 100644
+--- a/nsis/gvim.nsi
++++ b/nsis/gvim.nsi
+@@ -33,9 +33,12 @@ Unicode true
+ # Get it at https://upx.github.io/
+ !define HAVE_UPX
+ 
+-# comment the next line if you do not want to add Native Language Support
++# Comment the next line if you do not want to add Native Language Support
+ !define HAVE_NLS
+ 
++# Comment the following line to create a multilanguage installer:
++!define HAVE_MULTI_LANG
++
+ !include gvim_version.nsh	# for version number
+ 
+ # ----------- No configurable settings below this line -----------
+@@ -89,7 +92,7 @@ XPStyle on
+ !define MUI_UNICON "icons\vim_uninst_16c.ico"
+ 
+ # Show all languages, despite user's codepage:
+-#!define MUI_LANGDLL_ALLLANGUAGES
++!define MUI_LANGDLL_ALLLANGUAGES
+ 
+ !define MUI_WELCOMEFINISHPAGE_BITMAP       "icons\welcome.bmp"
+ !define MUI_UNWELCOMEFINISHPAGE_BITMAP     "icons\uninstall.bmp"
+@@ -97,6 +100,11 @@ XPStyle on
+ !define MUI_HEADERIMAGE_BITMAP             "icons\header.bmp"
+ !define MUI_HEADERIMAGE_UNBITMAP           "icons\un_header.bmp"
+ 
++!define MUI_WELCOMEFINISHPAGE_BITMAP_STRETCH    "AspectFitHeight"
++!define MUI_UNWELCOMEFINISHPAGE_BITMAP_STRETCH  "AspectFitHeight"
++!define MUI_HEADERIMAGE_BITMAP_STRETCH          "AspectFitHeight"
++!define MUI_HEADERIMAGE_UNBITMAP_STRETCH        "AspectFitHeight"
++
+ !define MUI_COMPONENTSPAGE_SMALLDESC
+ !define MUI_LICENSEPAGE_CHECKBOX
+ !define MUI_FINISHPAGE_RUN                 "$0\gvim.exe"
+@@ -157,6 +165,7 @@ Page custom SetCustom ValidateCustom
+     !include "lang\dutch.nsi"
+     !include "lang\german.nsi"
+     !include "lang\italian.nsi"
++    !include "lang\japanese.nsi"
+     !include "lang\simpchinese.nsi"
+     !include "lang\tradchinese.nsi"
+ !endif
+@@ -243,7 +252,7 @@ Function CheckOldVim
+   Exch $0 ; put $0 on top of stack, restore $0 to original value
+ FunctionEnd
+ 
+-Section "Uninstall old version of Vim" sec_old_vim_id
++Section "$(str_section_old_ver)" id_section_old_ver
+ 	SectionIn 1 2 3 RO
+ 
+ 	# run the install program to check for already installed versions
+@@ -269,9 +278,9 @@ Function .onInit
+   Pop $3
+   ${If} $3 == 0
+     # No old versions of Vim found. Unselect and hide the section.
+-    !insertmacro UnselectSection ${sec_old_vim_id}
+-    SectionSetInstTypes ${sec_old_vim_id} 0
+-    SectionSetText ${sec_old_vim_id} ""
++    !insertmacro UnselectSection ${id_section_old_ver}
++    SectionSetInstTypes ${id_section_old_ver} 0
++    SectionSetText ${id_section_old_ver} ""
+   ${EndIf}
+ 
+   # Install will have created a file for us that contains the directory where
+@@ -356,7 +365,7 @@ Function un.GetParent
+ FunctionEnd
+ 
+ ##########################################################
+-Section "Vim executables and runtime files" sec_main_id
++Section "$(str_section_exe)" id_section_exe
+ 	SectionIn 1 2 3 RO
+ 
+ 	# we need also this here if the user changes the instdir
+@@ -460,7 +469,7 @@ Section "Vim executables and runtime files" sec_main_id
+ SectionEnd
+ 
+ ##########################################################
+-Section "Vim console program (vim.exe)" sec_cons_id
++Section "$(str_section_console)" id_section_console
+ 	SectionIn 1 3
+ 
+ 	SetOutPath $0
+@@ -469,28 +478,29 @@ Section "Vim console program (vim.exe)" sec_cons_id
+ SectionEnd
+ 
+ ##########################################################
+-Section "Create .bat files for command line use"
++Section "$(str_section_batch)" id_section_batch
+ 	SectionIn 3
+ 
+ 	StrCpy $1 "$1 -create-batfiles $2"
+ SectionEnd
+ 
+ ##########################################################
+-Section "Create icons on the Desktop"
+-	SectionIn 1 3
++SectionGroup $(str_group_icons) id_group_icons
++	Section "$(str_section_desktop)" id_section_desktop
++		SectionIn 1 3
+ 
+-	StrCpy $1 "$1 -install-icons"
+-SectionEnd
++		StrCpy $1 "$1 -install-icons"
++	SectionEnd
+ 
+-##########################################################
+-Section "Add Vim to the Start Menu"
+-	SectionIn 1 3
++	Section "$(str_section_start_menu)" id_section_startmenu
++		SectionIn 1 3
+ 
+-	StrCpy $1 "$1 -add-start-menu"
+-SectionEnd
++		StrCpy $1 "$1 -add-start-menu"
++	SectionEnd
++SectionGroupEnd
+ 
+ ##########################################################
+-Section "Add an Edit-with-Vim context menu entry" sec_gvimext_id
++Section "$(str_section_edit_with)" id_section_editwith
+ 	SectionIn 1 3
+ 
+ 	# Be aware of this sequence of events:
+@@ -531,7 +541,7 @@ Section "Add an Edit-with-Vim context menu entry" sec_gvimext_id
+ SectionEnd
+ 
+ ##########################################################
+-Section "Create a _vimrc if it doesn't exist" sec_vimrc_id
++Section "$(str_section_vim_rc)" id_section_vimrc
+ 	SectionIn 1 3
+ 
+ 	StrCpy $1 "$1 -create-vimrc"
+@@ -562,21 +572,22 @@ Section "Create a _vimrc if it doesn't exist" sec_vimrc_id
+ SectionEnd
+ 
+ ##########################################################
+-Section "Create plugin directories in HOME or VIM"
+-	SectionIn 1 3
++SectionGroup $(str_group_plugin) id_group_plugin
++	Section "$(str_section_plugin_home)" id_section_pluginhome
++		SectionIn 1 3
+ 
+-	StrCpy $1 "$1 -create-directories home"
+-SectionEnd
++		StrCpy $1 "$1 -create-directories home"
++	SectionEnd
+ 
+-##########################################################
+-Section "Create plugin directories in VIM"
+-	SectionIn 3
++	Section "$(str_section_plugin_vim)" id_section_pluginvim
++		SectionIn 3
+ 
+-	StrCpy $1 "$1 -create-directories vim"
+-SectionEnd
++		StrCpy $1 "$1 -create-directories vim"
++	SectionEnd
++SectionGroupEnd
+ 
+ ##########################################################
+-Section "VisVim Extension for MS Visual Studio" sec_visvim_id
++Section "$(str_section_vis_vim)" id_section_visvim
+ 	SectionIn 3
+ 
+ 	SetOutPath $0
+@@ -586,7 +597,7 @@ SectionEnd
+ 
+ ##########################################################
+ !ifdef HAVE_NLS
+-Section "Native Language Support" sec_nls_id
++Section "$(str_section_nls)" id_section_nls
+ 	SectionIn 1 3
+ 
+ 	SetOutPath $0\lang
+@@ -608,7 +619,7 @@ Section "Native Language Support" sec_nls_id
+ 	    "$0\libgcc_s_sjlj-1.dll" "$0"
+   !endif
+ 
+-	${If} ${SectionIsSelected} ${sec_gvimext_id}
++	${If} ${SectionIsSelected} ${id_section_editwith}
+ 	  ${If} ${RunningX64}
+ 	    # Install DLLs for 64-bit gvimext.dll into the GvimExt64 directory.
+ 	    SetOutPath $0\GvimExt64
+@@ -653,21 +664,21 @@ SectionEnd
+ Section -post
+ 
+ 	# Get estimated install size
+-	SectionGetSize ${sec_main_id} $3
+-	${If} ${SectionIsSelected} ${sec_cons_id}
+-	  SectionGetSize ${sec_cons_id} $4
++	SectionGetSize ${id_section_exe} $3
++	${If} ${SectionIsSelected} ${id_section_console}
++	  SectionGetSize ${id_section_console} $4
+ 	  IntOp $3 $3 + $4
+ 	${EndIf}
+-	${If} ${SectionIsSelected} ${sec_gvimext_id}
+-	  SectionGetSize ${sec_gvimext_id} $4
++	${If} ${SectionIsSelected} ${id_section_editwith}
++	  SectionGetSize ${id_section_editwith} $4
+ 	  IntOp $3 $3 + $4
+ 	${EndIf}
+-	${If} ${SectionIsSelected} ${sec_visvim_id}
+-	  SectionGetSize ${sec_visvim_id} $4
++	${If} ${SectionIsSelected} ${id_section_visvim}
++	  SectionGetSize ${id_section_visvim} $4
+ 	  IntOp $3 $3 + $4
+ 	${EndIf}
+-	${If} ${SectionIsSelected} ${sec_nls_id}
+-	  SectionGetSize ${sec_nls_id} $4
++	${If} ${SectionIsSelected} ${id_section_nls}
++	  SectionGetSize ${id_section_nls} $4
+ 	  IntOp $3 $3 + $4
+ 	${EndIf}
+ 
+@@ -689,7 +700,7 @@ Function SetCustom
+ 	# Display the InstallOptions dialog
+ 
+ 	# Check if a _vimrc should be created
+-	${IfNot} ${SectionIsSelected} ${sec_vimrc_id}
++	${IfNot} ${SectionIsSelected} ${id_section_vimrc}
+ 	  Abort
+ 	${EndIf}
+ 
+@@ -789,7 +800,34 @@ Function ValidateCustom
+ FunctionEnd
+ 
+ ##########################################################
+-Section "un.$(str_unsection_register)"
++# Description for Installer Sections
++
++!insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN
++    !insertmacro MUI_DESCRIPTION_TEXT ${id_section_old_ver}     $(str_desc_old_ver)
++    !insertmacro MUI_DESCRIPTION_TEXT ${id_section_exe}         $(str_desc_exe)
++    !insertmacro MUI_DESCRIPTION_TEXT ${id_section_console}     $(str_desc_console)
++    !insertmacro MUI_DESCRIPTION_TEXT ${id_section_batch}       $(str_desc_batch)
++    !insertmacro MUI_DESCRIPTION_TEXT ${id_group_icons}         $(str_desc_icons)
++    !insertmacro MUI_DESCRIPTION_TEXT ${id_section_desktop}     $(str_desc_desktop)
++    !insertmacro MUI_DESCRIPTION_TEXT ${id_section_startmenu}   $(str_desc_start_menu)
++    !insertmacro MUI_DESCRIPTION_TEXT ${id_section_editwith}    $(str_desc_edit_with)
++    !insertmacro MUI_DESCRIPTION_TEXT ${id_section_vimrc}       $(str_desc_vim_rc)
++    !insertmacro MUI_DESCRIPTION_TEXT ${id_group_plugin}        $(str_desc_plugin)
++    !insertmacro MUI_DESCRIPTION_TEXT ${id_section_pluginhome}  $(str_desc_plugin_home)
++    !insertmacro MUI_DESCRIPTION_TEXT ${id_section_pluginvim}   $(str_desc_plugin_vim)
++
++!ifdef HAVE_VIS_VIM
++    !insertmacro MUI_DESCRIPTION_TEXT ${id_section_visvim}      $(str_desc_vis_vim)
++!endif
++
++!ifdef HAVE_NLS
++    !insertmacro MUI_DESCRIPTION_TEXT ${id_section_nls}         $(str_desc_nls)
++!endif
++!insertmacro MUI_FUNCTION_DESCRIPTION_END
++
++
++##########################################################
++Section "un.$(str_unsection_register)" id_unsection_register
+ 	# Apparently $INSTDIR is set to the directory where the uninstaller is
+ 	# created.  Thus the "vim61" directory is included in it.
+ 	StrCpy $0 "$INSTDIR"
+@@ -808,7 +846,7 @@ Section "un.$(str_unsection_register)"
+ 	BringToFront
+ SectionEnd
+ 
+-Section "un.$(str_unsection_exe)"
++Section "un.$(str_unsection_exe)" id_unsection_exe
+ 
+ 	StrCpy $0 "$INSTDIR"
+ 
+@@ -887,7 +925,7 @@ Section "un.$(str_unsection_exe)"
+ 	RMDir $0
+ SectionEnd
+ 
+-Section "un.Remove vimfiles directory"
++Section "un.$(str_unsection_vimfiles)" id_unsection_vimfiles
+ 	# get the parent dir of the installation
+ 	Push $INSTDIR
+ 	Call un.GetParent
+@@ -908,7 +946,7 @@ Section "un.Remove vimfiles directory"
+ 	${EndIf}
+ SectionEnd
+ 
+-Section "un.Remove the Vim root directory (may contain your _vimrc)"
++Section "un.$(str_unsection_rootdir)" id_unsection_rootdir
+ 	# get the parent dir of the installation
+ 	Push $INSTDIR
+ 	Call un.GetParent
+@@ -926,3 +964,13 @@ Section "un.Remove the Vim root directory (may contain your _vimrc)"
+ 	#Call un.onUnInstSuccess
+ 
+ SectionEnd
++
++##########################################################
++# Description for Uninstaller Sections
++
++!insertmacro MUI_UNFUNCTION_DESCRIPTION_BEGIN
++    !insertmacro MUI_DESCRIPTION_TEXT ${id_unsection_register} $(str_desc_unregister)
++    !insertmacro MUI_DESCRIPTION_TEXT ${id_unsection_exe}      $(str_desc_rm_exe)
++    !insertmacro MUI_DESCRIPTION_TEXT ${id_unsection_vimfiles} $(str_desc_rm_vimfiles)
++    !insertmacro MUI_DESCRIPTION_TEXT ${id_unsection_rootdir}  $(str_desc_rm_rootdir)
++!insertmacro MUI_UNFUNCTION_DESCRIPTION_END
+diff --git a/nsis/lang/dutch.nsi b/nsis/lang/dutch.nsi
+new file mode 100644
+index 000000000..0e08d758a
+--- /dev/null
++++ b/nsis/lang/dutch.nsi
+@@ -0,0 +1,243 @@
++﻿# vi:set ts=8 sts=4 sw=4 et fdm=marker:
++#
++# dutch.nsi : Dutch language strings for gvim NSIS installer.
++#
++# Locale ID    : 1043
++# Locale Name  : nl
++# fileencoding : UTF-8
++# Author       : Peter Odding <peter@peterodding.com>
++
++#!include "script\helper_util.nsh"
++#${VimAddLanguage} "Dutch" "nl"
++!insertmacro MUI_LANGUAGE "Dutch"
++
++
++# Overwite the default translation.
++# These string should be always English.  Otherwise dosinst.c fails.
++LangString ^SetupCaption     ${LANG_DUTCH} \
++        "$(^Name) Setup"
++LangString ^UninstallCaption ${LANG_DUTCH} \
++        "$(^Name) Uninstall"
++
++##############################################################################
++# MUI Configuration Strings                                               {{{1
++##############################################################################
++
++LangString str_dest_folder          ${LANG_DUTCH} \
++    "Doelmap (moet eindigen op $\"vim$\")"
++
++LangString str_show_readme          ${LANG_DUTCH} \
++    "README weergeven na installatie"
++
++# Install types:
++LangString str_type_typical         ${LANG_DUTCH} \
++    "Gebruikelijk"
++
++LangString str_type_minimal         ${LANG_DUTCH} \
++    "Minimaal"
++
++LangString str_type_full            ${LANG_DUTCH} \
++    "Volledig"
++
++
++##############################################################################
++# Section Titles & Description                                            {{{1
++##############################################################################
++
++LangString str_section_old_ver      ${LANG_DUTCH} \
++    "Bestaande versie(s) de-installeren"
++LangString str_desc_old_ver         ${LANG_DUTCH} \
++    "Bestaande Vim versie(s) van je systeem verwijderen."
++
++LangString str_section_exe          ${LANG_DUTCH} \
++    "Vim GUI"
++LangString str_desc_exe             ${LANG_DUTCH} \
++    "Vim GUI uitvoerbare bestanden en runtime bestanden.  Dit component is vereist."
++
++LangString str_section_console      ${LANG_DUTCH} \
++    "Vim console programma"
++LangString str_desc_console         ${LANG_DUTCH} \
++    "Console versie van Vim (vim.exe)."
++
++LangString str_section_batch        ${LANG_DUTCH} \
++    "Creëer .bat bestanden"
++LangString str_desc_batch           ${LANG_DUTCH} \
++    "Creëer .bat bestanden voor Vim varianten in de Windows map voor \
++     commando regel gebruik."
++
++LangString str_group_icons          ${LANG_DUTCH} \
++    "Creëer pictogrammen for Vim"
++LangString str_desc_icons           ${LANG_DUTCH} \
++    "Creëer pictogrammen voor Vim op verschillende locaties voor gemakkelijke toegang."
++
++LangString str_section_desktop      ${LANG_DUTCH} \
++    "Op het bureaublad"
++LangString str_desc_desktop         ${LANG_DUTCH} \
++    "Creëer pictogrammen voor Vim uitvoerbare bestanden op het bureaublad."
++
++LangString str_section_start_menu   ${LANG_DUTCH} \
++    "In de Programma's map in het start menu"
++LangString str_desc_start_menu      ${LANG_DUTCH} \
++    "Voeg Vim toe aan de programma's map in het start menu.  \
++     Van toepassing op Windows 95 en later."
++
++LangString str_section_quick_launch ${LANG_DUTCH} \
++    "In de snel starten balk"
++LangString str_desc_quick_launch    ${LANG_DUTCH} \
++    "Voeg Vim snelkoppeling toe aan de snel starten balk."
++
++LangString str_section_edit_with    ${LANG_DUTCH} \
++    "Voeg Vim contextmenu toe"
++LangString str_desc_edit_with       ${LANG_DUTCH} \
++    "Voeg Vim toe aan de $\"Openen met...$\" contextmenu lijst."
++
++LangString str_section_edit_with32  ${LANG_DUTCH} \
++    "32-bit versie"
++LangString str_desc_edit_with32     ${LANG_DUTCH} \
++    "Voeg Vim toe aan de $\"Openen met...$\" contextmenu lijst \
++     voor 32-bit toepassingen."
++
++LangString str_section_edit_with64  ${LANG_DUTCH} \
++    "64-bit versie"
++LangString str_desc_edit_with64     ${LANG_DUTCH} \
++    "Voeg Vim toe aan de $\"Openen met...$\" contextmenu lijst \
++     voor 64-bit toepassingen."
++
++LangString str_section_vim_rc       ${LANG_DUTCH} \
++    "Creëer standaard configuratie"
++LangString str_desc_vim_rc          ${LANG_DUTCH} \
++    "Creëer een standaard configuratie bestand (_vimrc) als er nog geen bestaat."
++
++LangString str_group_plugin         ${LANG_DUTCH} \
++    "Creëer Plugin mappen"
++LangString str_desc_plugin          ${LANG_DUTCH} \
++    "Creëer plugin mappen.  Plugin mappen maken het mogelijk om \
++     Vim uit te breiden door een bestand in een map te plaatsen."
++
++LangString str_section_plugin_home  ${LANG_DUTCH} \
++    "Privé"
++LangString str_desc_plugin_home     ${LANG_DUTCH} \
++    "Creëer plugin mappen in HOME (als je deze gedefinieerd hebt) \
++     of Vim installatie map."
++
++LangString str_section_plugin_vim   ${LANG_DUTCH} \
++    "Gedeeld"
++LangString str_desc_plugin_vim      ${LANG_DUTCH} \
++    "Creëer plugin mappen in Vim installatie map, deze worden gebruikt \
++     voor iedereen op het systeem."
++
++LangString str_section_vis_vim      ${LANG_DUTCH} \
++    "VisVim extensie"
++LangString str_desc_vis_vim         ${LANG_DUTCH} \
++    "VisVim extensie voor Microsoft Visual Studio integratie."
++
++LangString str_section_nls          ${LANG_DUTCH} \
++    "Ondersteuning voor andere talen"
++LangString str_desc_nls             ${LANG_DUTCH} \
++    "Bestanden voor ondersteuning van andere talen dan Engels installeren."
++
++LangString str_unsection_register   ${LANG_DUTCH} \
++    "Vim afmelden"
++LangString str_desc_unregister      ${LANG_DUTCH} \
++    "Registratie van Vim in het systeem ongedaan maken."
++
++LangString str_unsection_exe        ${LANG_DUTCH} \
++    "Vim uitvoerbare/runtime bestanden verwijderen"
++LangString str_desc_rm_exe          ${LANG_DUTCH} \
++    "Verwijder alle Vim uitvoerbare bestanden en runtime bestanden."
++
++LangString str_unsection_vimfiles   ${LANG_DUTCH} \
++    "Remove vimfiles directory"
++LangString str_desc_rm_vimfiles     ${LANG_DUTCH} \
++    "Remove all files in your vimfiles directory."
++
++LangString str_unsection_rootdir    ${LANG_DUTCH} \
++    "Remove the Vim root directory"
++LangString str_desc_rm_rootdir      ${LANG_DUTCH} \
++    "Remove the Vim root directory. It contains your Vim configuration files!"
++
++LangString str_vimrc_page_title     ${LANG_DUTCH} \
++    "Choose _vimrc settings"
++LangString str_vimrc_page_subtitle  ${LANG_DUTCH} \
++    "Choose the behavior of key remapping and mouse."
++
++
++##############################################################################
++# Messages                                                                {{{1
++##############################################################################
++
++LangString str_msg_too_many_ver  ${LANG_DUTCH} \
++    "Er zijn $vim_old_ver_count Vim versies op je systeem gevonden.$\r$\n\
++     Deze installatie kan omgaan met maximaal ${VIM_MAX_OLD_VER} versies.$\r$\n\
++     Verwijder a.u.b. wat versies en probeer het dan opnieuw."
++
++LangString str_msg_invalid_root  ${LANG_DUTCH} \
++    "Ongeldig installatiepad: $vim_install_root!$\r$\n\
++     Het moet eindelijk op $\"vim$\"."
++
++LangString str_msg_bin_mismatch  ${LANG_DUTCH} \
++    "Binair pad onjuist!$\r$\n$\r$\n\
++     Het binaire pad zou $\"$vim_bin_path$\" moeten zijn,$\r$\n\
++     maar het systeem geeft aan dat het binaire pad $\"$INSTDIR$\" is."
++
++LangString str_msg_vim_running   ${LANG_DUTCH} \
++    "Vim is nog actief op je systeem.$\r$\n\
++     Sluit a.u.b. alle instanties van Vim voordat je verder gaat."
++
++LangString str_msg_register_ole  ${LANG_DUTCH} \
++    "Bezig met proberen om Vim te registreren met OLE. \
++     Er is geen bericht dat aangeeft of deze operatie slaagt."
++
++LangString str_msg_unreg_ole     ${LANG_DUTCH} \
++    "Bezig met proberen om Vim te de-registreren met OLE. \
++     Er is geen bericht dat aangeeft of deze operatie slaagt."
++
++LangString str_msg_rm_start      ${LANG_DUTCH} \
++    "De volgende versies worden verwijderd:"
++
++LangString str_msg_rm_fail       ${LANG_DUTCH} \
++    "De volgende versies konden niet worden verwijderd:"
++
++LangString str_msg_no_rm_key     ${LANG_DUTCH} \
++    "Kan de uninstaller register sleutel niet vinden."
++
++LangString str_msg_no_rm_reg     ${LANG_DUTCH} \
++    "Kan de uninstaller niet vinden via het register."
++
++LangString str_msg_no_rm_exe     ${LANG_DUTCH} \
++    "Kan geen toegang krijgen tot de uninstaller."
++
++LangString str_msg_rm_copy_fail  ${LANG_DUTCH} \
++    "Kon de uninstaller niet naar een tijdelijke map kopiëren."
++
++LangString str_msg_rm_run_fail   ${LANG_DUTCH} \
++    "Kon de uninstaller niet uitvoeren."
++
++LangString str_msg_abort_install ${LANG_DUTCH} \
++    "Installatie wordt gestopt."
++
++LangString str_msg_install_fail  ${LANG_DUTCH} \
++    "Installatie is mislukt."
++
++LangString str_msg_rm_exe_fail   ${LANG_DUTCH} \
++    "Sommige bestanden in $vim_bin_path zijn niet verwijderd!$\r$\n\
++     Dit moet je handmatig doen."
++
++LangString str_msg_rm_root_fail  ${LANG_DUTCH} \
++    "WAARSCHUWING: Kan $\"$vim_install_root$\" niet verwijderen omdat het niet leeg is!"
++
++LangString str_msg_keymap_title   ${LANG_DUTCH} \
++    " Key remapping "
++LangString str_msg_keymap_default ${LANG_DUTCH} \
++    " Do not remap keys for Windows behavior (Default)"
++LangString str_msg_keymap_windows ${LANG_DUTCH} \
++    " Remap a few keys for Windows behavior$\n (<C-V>, <C-C>, <C-A>, <C-S>, <C-F>, etc)"
++
++LangString str_msg_mouse_title   ${LANG_DUTCH} \
++    " Mouse behavior "
++LangString str_msg_mouse_default ${LANG_DUTCH} \
++    " Default:$\n     Right button has a popup menu, left button starts visual mode"
++LangString str_msg_mouse_windows ${LANG_DUTCH} \
++    " Windows:$\n     Right button has a popup menu, left button starts select mode"
++LangString str_msg_mouse_unix    ${LANG_DUTCH} \
++    " Unix:$\n     Right button extends selection, left button starts visual mode"
+diff --git a/nsis/lang/english.nsi b/nsis/lang/english.nsi
+index 3a2ddc122..8ef333eae 100644
+--- a/nsis/lang/english.nsi
++++ b/nsis/lang/english.nsi
+@@ -21,6 +21,13 @@
+ !insertmacro MUI_LANGUAGE "English"
+ 
+ 
++# Overwite the default translation.
++# These string should be always English.  Otherwise dosinst.c fails.
++LangString ^SetupCaption     ${LANG_ENGLISH} \
++        "$(^Name) Setup"
++LangString ^UninstallCaption ${LANG_ENGLISH} \
++        "$(^Name) Uninstall"
++
+ ##############################################################################
+ # MUI Configuration Strings                                               {{{1
+ ##############################################################################
+@@ -46,13 +53,13 @@ LangString str_type_full            ${LANG_ENGLISH} \
+ # Section Titles & Description                                            {{{1
+ ##############################################################################
+ 
+-LangString str_group_old_ver        ${LANG_ENGLISH} \
++LangString str_section_old_ver      ${LANG_ENGLISH} \
+     "Uninstall Existing Version(s)"
+ LangString str_desc_old_ver         ${LANG_ENGLISH} \
+     "Uninstall existing Vim version(s) from your system."
+ 
+ LangString str_section_exe          ${LANG_ENGLISH} \
+-    "Vim GUI"
++    "Vim GUI and runtime files"
+ LangString str_desc_exe             ${LANG_ENGLISH} \
+     "Vim GUI executables and runtime files.  This component is required."
+ 
+@@ -80,15 +87,14 @@ LangString str_desc_desktop         ${LANG_ENGLISH} \
+ LangString str_section_start_menu   ${LANG_ENGLISH} \
+     "In the Start Menu Programs Folder"
+ LangString str_desc_start_menu      ${LANG_ENGLISH} \
+-    "Add Vim in the programs folder of the start menu.  \
+-     Applicable to Windows 95 and later."
++    "Add Vim in the programs folder of the start menu."
+ 
+ LangString str_section_quick_launch ${LANG_ENGLISH} \
+     "In the Quick Launch Bar"
+ LangString str_desc_quick_launch    ${LANG_ENGLISH} \
+     "Add Vim shortcut in the quick launch bar."
+ 
+-LangString str_group_edit_with      ${LANG_ENGLISH} \
++LangString str_section_edit_with    ${LANG_ENGLISH} \
+     "Add Vim Context Menu"
+ LangString str_desc_edit_with       ${LANG_ENGLISH} \
+     "Add Vim to the $\"Open With...$\" context menu list."
+@@ -148,11 +154,22 @@ LangString str_unsection_exe        ${LANG_ENGLISH} \
+ LangString str_desc_rm_exe          ${LANG_ENGLISH} \
+     "Remove all Vim executables and runtime files."
+ 
++LangString str_unsection_vimfiles   ${LANG_ENGLISH} \
++    "Remove vimfiles directory"
++LangString str_desc_rm_vimfiles     ${LANG_ENGLISH} \
++    "Remove all files in your vimfiles directory."
++
++LangString str_unsection_rootdir    ${LANG_ENGLISH} \
++    "Remove the Vim root directory"
++LangString str_desc_rm_rootdir      ${LANG_ENGLISH} \
++    "Remove the Vim root directory. It contains your Vim configuration files!"
++
+ LangString str_vimrc_page_title     ${LANG_ENGLISH} \
+     "Choose _vimrc settings"
+ LangString str_vimrc_page_subtitle  ${LANG_ENGLISH} \
+     "Choose the behavior of key remapping and mouse."
+ 
++
+ ##############################################################################
+ # Messages                                                                {{{1
+ ##############################################################################
+diff --git a/nsis/lang/german.nsi b/nsis/lang/german.nsi
+new file mode 100644
+index 000000000..61be2b665
+--- /dev/null
++++ b/nsis/lang/german.nsi
+@@ -0,0 +1,243 @@
++﻿# vi:set ts=8 sts=4 sw=4 et fdm=marker:
++#
++# german.nsi : German language strings for gvim NSIS installer.
++#
++# Locale ID    : 1031
++# fileencoding : UTF-8
++# Author       : Christian Brabandt, tux
++
++#!include "script\helper_util.nsh"
++#${VimAddLanguage} "German" "de"
++!insertmacro MUI_LANGUAGE "German"
++
++
++# Overwite the default translation.
++# These string should be always English.  Otherwise dosinst.c fails.
++LangString ^SetupCaption     ${LANG_GERMAN} \
++        "$(^Name) Setup"
++LangString ^UninstallCaption ${LANG_GERMAN} \
++        "$(^Name) Uninstall"
++
++##############################################################################
++# MUI Configuration Strings                                               {{{1
++##############################################################################
++
++LangString str_dest_folder          ${LANG_GERMAN} \
++    "Zielverzeichnis auswählen (muss auf $\"vim$\" enden)"
++
++LangString str_show_readme          ${LANG_GERMAN} \
++    "README-Datei nach der Installation anzeigen"
++
++# Install types:
++LangString str_type_typical         ${LANG_GERMAN} \
++    "Typisch"
++
++LangString str_type_minimal         ${LANG_GERMAN} \
++    "Minimal"
++
++LangString str_type_full            ${LANG_GERMAN} \
++    "Vollständig"
++
++
++##############################################################################
++# Section Titles & Description                                            {{{1
++##############################################################################
++
++LangString str_section_old_ver      ${LANG_GERMAN} \
++    "Vorherige Version deinstallieren"
++LangString str_desc_old_ver         ${LANG_GERMAN} \
++    "Vorherige installierte Versionen auf diesem System deinstallieren."
++
++LangString str_section_exe          ${LANG_GERMAN} \
++    "Vim GUI"
++LangString str_desc_exe             ${LANG_GERMAN} \
++    "Vim-GUI-Anwendung und Laufzeitdateien (Dieser Teil ist zwingend\
++     erforderlich)."
++
++LangString str_section_console      ${LANG_GERMAN} \
++    "Vim Konsolenanwendung"
++LangString str_desc_console         ${LANG_GERMAN} \
++    "Konsolenversion von Vim."
++
++LangString str_section_batch        ${LANG_GERMAN} \
++    ".bat-Dateien erstellen"
++LangString str_desc_batch           ${LANG_GERMAN} \
++    ".bat-Dateien erstellen, um Vim in der Konsole auszuführen."
++
++LangString str_group_icons          ${LANG_GERMAN} \
++    "Vim-Verknüpfungen erstellen"
++LangString str_desc_icons           ${LANG_GERMAN} \
++    "Verknüpfungen mit Vim für einfachen Aufruf erstellen."
++
++LangString str_section_desktop      ${LANG_GERMAN} \
++    "Auf dem Desktop"
++LangString str_desc_desktop         ${LANG_GERMAN} \
++    "Icons für GVim auf dem Desktop erstellen."
++
++LangString str_section_start_menu   ${LANG_GERMAN} \
++    "Im Startmenü"
++LangString str_desc_start_menu      ${LANG_GERMAN} \
++    "Vim im Programmverzeichnis des Startmenüs hinzufügen\
++     Windows 95 und höher."
++
++LangString str_section_quick_launch ${LANG_GERMAN} \
++    "In der Schnellstartleiste"
++LangString str_desc_quick_launch    ${LANG_GERMAN} \
++    "Verknüpfung zu Vim in der Schnellstartleiste ablegen."
++
++LangString str_section_edit_with    ${LANG_GERMAN} \
++    "Vim zum Kontextmenü hinzufügen"
++LangString str_desc_edit_with       ${LANG_GERMAN} \
++    "Vim in das $\"Öffnen mit...$\"-Kontextmenü einfügen."
++
++LangString str_section_edit_with32  ${LANG_GERMAN} \
++    "32-Bit-Version"
++LangString str_desc_edit_with32     ${LANG_GERMAN} \
++    "Vim in das $\"Öffnen mit...$\"-Kontextmenü \
++     für 32-Bit-Anwendungen integrieren."
++
++LangString str_section_edit_with64  ${LANG_GERMAN} \
++    "64-Bit-Version"
++LangString str_desc_edit_with64     ${LANG_GERMAN} \
++    "Vim in das $\"Öffnen mit...$\"-Kontextmenü \
++     für 64-Bit-Anwendungen integrieren."
++
++LangString str_section_vim_rc       ${LANG_GERMAN} \
++    "Standard-Konfigurationsdatei erstellen"
++LangString str_desc_vim_rc          ${LANG_GERMAN} \
++    "Eine Standard-Konfigurationsdatei (_vimrc) erstellen, \
++     falls noch keine existiert."
++
++LangString str_group_plugin         ${LANG_GERMAN} \
++    "Plugin-Verzeichnisse anlegen"
++LangString str_desc_plugin          ${LANG_GERMAN} \
++    "Plugin-Verzeichnisse anlegen.  Plugins erlauben es, Vim \
++     um zusätzliche Funktionen zu erweitern."
++
++LangString str_section_plugin_home  ${LANG_GERMAN} \
++    "Privat"
++LangString str_desc_plugin_home     ${LANG_GERMAN} \
++    "Plugin-Verzeichnis im Basisverzeichnis (falls es existiert) oder im \
++     Vim-Installationspfad erstellen."
++
++LangString str_section_plugin_vim   ${LANG_GERMAN} \
++    "Freigegeben"
++LangString str_desc_plugin_vim      ${LANG_GERMAN} \
++    "Plugin-Verzeichnisse im Vim-Installationspfad erstellen. Diese werden \
++     für alle Benutzer dieses Systems genutzt."
++
++LangString str_section_vis_vim      ${LANG_GERMAN} \
++    "VisVim-Erweiterung"
++LangString str_desc_vis_vim         ${LANG_GERMAN} \
++    "VisVim-Erweiterung zur Integration in Microsoft Visual Studio."
++
++LangString str_section_nls          ${LANG_GERMAN} \
++    "Unterstützung für andere Sprachen"
++LangString str_desc_nls             ${LANG_GERMAN} \
++    "Dateien zur Unterstützung anderer Sprachen als Englisch installieren."
++
++LangString str_unsection_register   ${LANG_GERMAN} \
++    "Vim deinstallieren"
++LangString str_desc_unregister      ${LANG_GERMAN} \
++    "Vim vom System entfernen."
++
++LangString str_unsection_exe        ${LANG_GERMAN} \
++    "Vim-Anwendung und Laufzeitdateien entfernen"
++LangString str_desc_rm_exe          ${LANG_GERMAN} \
++    "Alle Vim-Anwendungen und Laufzeitdateien von diesem System entfernen."
++
++LangString str_unsection_vimfiles   ${LANG_GERMAN} \
++    "Remove vimfiles directory"
++LangString str_desc_rm_vimfiles     ${LANG_GERMAN} \
++    "Remove all files in your vimfiles directory."
++
++LangString str_unsection_rootdir    ${LANG_GERMAN} \
++    "Remove the Vim root directory"
++LangString str_desc_rm_rootdir      ${LANG_GERMAN} \
++    "Remove the Vim root directory. It contains your Vim configuration files!"
++
++LangString str_vimrc_page_title     ${LANG_GERMAN} \
++    "Choose _vimrc settings"
++LangString str_vimrc_page_subtitle  ${LANG_GERMAN} \
++    "Choose the behavior of key remapping and mouse."
++
++
++##############################################################################
++# Messages                                                                {{{1
++##############################################################################
++
++LangString str_msg_too_many_ver  ${LANG_GERMAN} \
++    "$vim_old_ver_count Vim-Versionen auf diesem System gefunden..$\r$\n\
++     Dieser Installer kann maximal ${VIM_MAX_OLD_VER} Versionen \
++     handhaben.$\r$\n\
++     Bitte alte Versionen entfernen und noch einmal probieren."
++
++LangString str_msg_invalid_root  ${LANG_GERMAN} \
++    "Nicht gültiges Installationsverzeichnis: $vim_install_root!$\r$\n\
++     Der Pfad muss auf $\"vim$\" enden."
++
++LangString str_msg_bin_mismatch  ${LANG_GERMAN} \
++    "Pfaddiskrepanz!$\r$\n$\r$\n\
++     Erwarte Anwendungsverzeichnis $\"$vim_bin_path$\",$\r$\n\
++     aber fand Anwendungspfad $\"$INSTDIR$\" vor."
++
++LangString str_msg_vim_running   ${LANG_GERMAN} \
++    "Laufender Vim-Prozess erkannt.$\r$\n\
++     Bitte alle laufenden Vim-Prozesse vor dem Fortfahren beenden."
++
++LangString str_msg_register_ole  ${LANG_GERMAN} \
++    "Versuche OLE-Registrierung durchzuführen."
++
++LangString str_msg_unreg_ole     ${LANG_GERMAN} \
++    "Versuche OLE-Registrierung zu löschen."
++
++LangString str_msg_rm_start      ${LANG_GERMAN} \
++    "Deinstalliere die folgende Version:"
++
++LangString str_msg_rm_fail       ${LANG_GERMAN} \
++    "Deinstallation der Version fehlgeschlagen:"
++
++LangString str_msg_no_rm_key     ${LANG_GERMAN} \
++    "Deinstallationsschlüssel in der Registrierungsdatenbank nicht gefunden."
++
++LangString str_msg_no_rm_reg     ${LANG_GERMAN} \
++    "Kein Uninstaller in der Registrierungsdatenbank gefunden."
++
++LangString str_msg_no_rm_exe     ${LANG_GERMAN} \
++    "Kein Zugriff auf den Uninstaller."
++
++LangString str_msg_rm_copy_fail  ${LANG_GERMAN} \
++    "Fehler beim Kopieren des Uninstallers in ein temporäres Verzeichnis."
++
++LangString str_msg_rm_run_fail   ${LANG_GERMAN} \
++    "Fehler beim Aufruf des Uninstallers."
++
++LangString str_msg_abort_install ${LANG_GERMAN} \
++    "Installation wird abgebrochen."
++
++LangString str_msg_install_fail  ${LANG_GERMAN} \
++    "Installation fehlerhaft beendet."
++
++LangString str_msg_rm_exe_fail   ${LANG_GERMAN} \
++    "Einige Dateien im Pfad $vim_bin_path konnten nicht gelöscht werden!$\r$\n\
++     Diese Dateien müssen manuell gelöscht werden."
++
++LangString str_msg_rm_root_fail  ${LANG_GERMAN} \
++    "Achtung: Kann Verzeichnis $\"$vim_install_root$\" nicht entfernen, \
++     weil es nicht leer ist!"
++
++LangString str_msg_keymap_title   ${LANG_GERMAN} \
++    " Key remapping "
++LangString str_msg_keymap_default ${LANG_GERMAN} \
++    " Do not remap keys for Windows behavior (Default)"
++LangString str_msg_keymap_windows ${LANG_GERMAN} \
++    " Remap a few keys for Windows behavior$\n (<C-V>, <C-C>, <C-A>, <C-S>, <C-F>, etc)"
++
++LangString str_msg_mouse_title   ${LANG_GERMAN} \
++    " Mouse behavior "
++LangString str_msg_mouse_default ${LANG_GERMAN} \
++    " Default:$\n     Right button has a popup menu, left button starts visual mode"
++LangString str_msg_mouse_windows ${LANG_GERMAN} \
++    " Windows:$\n     Right button has a popup menu, left button starts select mode"
++LangString str_msg_mouse_unix    ${LANG_GERMAN} \
++    " Unix:$\n     Right button extends selection, left button starts visual mode"
+diff --git a/nsis/lang/italian.nsi b/nsis/lang/italian.nsi
+new file mode 100644
+index 000000000..3ccf835ee
+--- /dev/null
++++ b/nsis/lang/italian.nsi
+@@ -0,0 +1,252 @@
++﻿# vi:set ts=8 sts=4 sw=4 et fdm=marker:
++#
++# italian.nsi : Italian language strings for gvim NSIS installer.
++#
++# Locale ID    : 1040
++# Locale Name  : it
++# fileencoding : latin1
++# Author       : Antonio Colombo
++
++#!include "script\helper_util.nsh"
++#${VimAddLanguage} "Italian" "it"
++!insertmacro MUI_LANGUAGE "Italian"
++
++
++# Overwite the default translation.
++# These string should be always English.  Otherwise dosinst.c fails.
++LangString ^SetupCaption     ${LANG_ITALIAN} \
++        "$(^Name) Setup"
++LangString ^UninstallCaption ${LANG_ITALIAN} \
++        "$(^Name) Uninstall"
++
++##############################################################################
++# MUI Configuration Strings                                               {{{1
++##############################################################################
++
++LangString str_dest_folder          ${LANG_ITALIAN} \
++    "Cartella d'installazione (il nome deve finire con $\"vim$\")"
++
++LangString str_show_readme          ${LANG_ITALIAN} \
++    "Visualizza README al termine dell'installazione"
++
++# Install types:
++LangString str_type_typical         ${LANG_ITALIAN} \
++    "Tipica"
++
++LangString str_type_minimal         ${LANG_ITALIAN} \
++    "Minima"
++
++LangString str_type_full            ${LANG_ITALIAN} \
++    "Completa"
++
++
++##############################################################################
++# Section Titles & Description                                            {{{1
++##############################################################################
++
++LangString str_section_old_ver      ${LANG_ITALIAN} \
++    "Disinstalla versione/i esistente/i"
++LangString str_desc_old_ver         ${LANG_ITALIAN} \
++    "Disinstalla versione/i esistente/i di Vim dal vostro sistema."
++
++LangString str_section_exe          ${LANG_ITALIAN} \
++    "Vim GUI (gvim.exe per Windows)"
++LangString str_desc_exe             ${LANG_ITALIAN} \
++    "Vim GUI programmi e file di supporto.  Questa componente è indispensabile."
++
++LangString str_section_console      ${LANG_ITALIAN} \
++    "Vim console (vim.exe per MS-DOS)"
++LangString str_desc_console         ${LANG_ITALIAN} \
++    "Versione console di Vim (vim.exe)."
++
++LangString str_section_batch        ${LANG_ITALIAN} \
++    "Crea file di invocazione (MS-DOS) .bat"
++LangString str_desc_batch           ${LANG_ITALIAN} \
++    "Crea file di invocazione .bat per varianti di Vim nella directory \
++     di Windows, da utilizzare da linea di comando (MS-DOS)."
++
++LangString str_group_icons          ${LANG_ITALIAN} \
++    "Crea icone per Vim"
++LangString str_desc_icons           ${LANG_ITALIAN} \
++    "Crea icone per Vim in vari posti, per rendere facile l'accesso."
++
++LangString str_section_desktop      ${LANG_ITALIAN} \
++    "Sul Desktop"
++LangString str_desc_desktop         ${LANG_ITALIAN} \
++    "Crea icone per programma gvim sul desktop."
++
++LangString str_section_start_menu   ${LANG_ITALIAN} \
++    "Nella cartella del menù START"
++LangString str_desc_start_menu      ${LANG_ITALIAN} \
++    "Aggiungi Vim alle cartelle del menù START.  \
++     Disponibile solo da Windows 95 in avanti."
++
++LangString str_section_quick_launch ${LANG_ITALIAN} \
++    "Nella barra di Avvio Veloce"
++LangString str_desc_quick_launch    ${LANG_ITALIAN} \
++    "Aggiungi un puntatore a Vim nella barra di Avvio Veloce."
++
++LangString str_section_edit_with    ${LANG_ITALIAN} \
++    "Aggiungi Vim al Menù Contestuale"
++LangString str_desc_edit_with       ${LANG_ITALIAN} \
++    "Aggiungi Vim alla lista contestuale $\"Apri con...$\"."
++
++LangString str_section_edit_with32  ${LANG_ITALIAN} \
++    "Versione a 32-bit"
++LangString str_desc_edit_with32     ${LANG_ITALIAN} \
++    "Aggiungi Vim alla lista contestuale $\"Apri con...$\" \
++     per applicazioni a 32-bit."
++
++LangString str_section_edit_with64  ${LANG_ITALIAN} \
++    "Versione a 64-bit"
++LangString str_desc_edit_with64     ${LANG_ITALIAN} \
++    "Aggiungi Vim alla lista contestuale $\"Apri con...$\" \
++     per applicazioni a 64-bit."
++
++LangString str_section_vim_rc       ${LANG_ITALIAN} \
++    "Crea Configurazione di default"
++LangString str_desc_vim_rc          ${LANG_ITALIAN} \
++    "Crea file configurazione di default (_vimrc) se non ne \
++     esiste già uno."
++
++LangString str_group_plugin         ${LANG_ITALIAN} \
++    "Crea Directory per Plugin"
++LangString str_desc_plugin          ${LANG_ITALIAN} \
++    "Crea Directory per Plugin.  Servono per aggiungere funzionalità \
++     a Vim aggiungendo file a una di queste directory."
++
++LangString str_section_plugin_home  ${LANG_ITALIAN} \
++    "Privato"
++LangString str_desc_plugin_home     ${LANG_ITALIAN} \
++    "Crea Directory Plugin in HOME (se definita) o nella \
++     directory di installazione di Vim."
++
++LangString str_section_plugin_vim   ${LANG_ITALIAN} \
++    "Condiviso"
++LangString str_desc_plugin_vim      ${LANG_ITALIAN} \
++    "Crea Directory Plugin nella directory di installazione di Vim \
++     per uso da parte di tutti gli utenti di questo sistema."
++
++LangString str_section_vis_vim      ${LANG_ITALIAN} \
++    "Estensione VisVim"
++LangString str_desc_vis_vim         ${LANG_ITALIAN} \
++    "Estensione VisVim per integrazione con Microsoft Visual Studio."
++
++LangString str_section_nls          ${LANG_ITALIAN} \
++    "Supporto Multilingue (NLS)"
++LangString str_desc_nls             ${LANG_ITALIAN} \
++    "Installa file per supportare messaggi in diverse lingue."
++
++LangString str_unsection_register   ${LANG_ITALIAN} \
++    "Togli Vim dal Registry"
++LangString str_desc_unregister      ${LANG_ITALIAN} \
++    "Togli Vim dal Registry di configurazione sistema."
++
++LangString str_unsection_exe        ${LANG_ITALIAN} \
++    "Cancella programmi/file_ausiliari Vim"
++LangString str_desc_rm_exe          ${LANG_ITALIAN} \
++    "Cancella tutti i programmi/file_ausiliari di Vim."
++
++LangString str_unsection_rc         ${LANG_ITALIAN} \
++    "Cancella file di configurazione di Vim"
++LangString str_desc_rm_rc           ${LANG_ITALIAN} \
++    "Cancella file di configurazione di Vim $vim_install_root\_vimrc. \
++     Da saltare se avete personalizzato il file di configurazione."
++
++LangString str_unsection_vimfiles   ${LANG_ITALIAN} \
++    "Remove vimfiles directory"
++LangString str_desc_rm_vimfiles     ${LANG_ITALIAN} \
++    "Remove all files in your vimfiles directory."
++
++LangString str_unsection_rootdir    ${LANG_ITALIAN} \
++    "Remove the Vim root directory"
++LangString str_desc_rm_rootdir      ${LANG_ITALIAN} \
++    "Remove the Vim root directory. It contains your Vim configuration files!"
++
++LangString str_vimrc_page_title     ${LANG_ITALIAN} \
++    "Choose _vimrc settings"
++LangString str_vimrc_page_subtitle  ${LANG_ITALIAN} \
++    "Choose the behavior of key remapping and mouse."
++
++
++##############################################################################
++# Messages                                                                {{{1
++##############################################################################
++
++LangString str_msg_too_many_ver  ${LANG_ITALIAN} \
++    "Trovate $vim_old_ver_count versioni di Vim sul vostro sistema.$\r$\n\
++     Questo programma di installazione può gestirne solo \
++     ${VIM_MAX_OLD_VER}.$\r$\n\
++     Disinstallate qualche versione precedente e ricominciate."
++
++LangString str_msg_invalid_root  ${LANG_ITALIAN} \
++    "Nome di directory di installazione non valida: $vim_install_root!$\r$\n\
++     Dovrebbe terminare con $\"vim$\"."
++
++LangString str_msg_bin_mismatch  ${LANG_ITALIAN} \
++    "Incongruenza di installazione!$\r$\n$\r$\n\
++     Cartella di installazione dev'essere $\"$vim_bin_path$\",$\r$\n\
++     ma il sistema segnala invece $\"$INSTDIR$\"."
++
++LangString str_msg_vim_running   ${LANG_ITALIAN} \
++    "Vim ancora in esecuzione sul vostro sistema.$\r$\n\
++     Chiudete tutte le sessioni attive di Vim per continuare."
++
++LangString str_msg_register_ole  ${LANG_ITALIAN} \
++    "Tentativo di registrazione di Vim con OLE. \
++     Non ci sono messaggi che indicano se ha funzionato o no."
++
++LangString str_msg_unreg_ole     ${LANG_ITALIAN} \
++    "Tentativo di togliere da Registry  Vim con OLE. \
++     Non ci sono messaggi che indicano se ha funzionato o no."
++
++LangString str_msg_rm_start      ${LANG_ITALIAN} \
++    "Disinstallazione delle seguenti versioni:"
++
++LangString str_msg_rm_fail       ${LANG_ITALIAN} \
++    "Disinstallazione non riuscita per la seguente versione:"
++
++LangString str_msg_no_rm_key     ${LANG_ITALIAN} \
++    "Non riesco a trovare chiave di disinstallazione nel Registry."
++
++LangString str_msg_no_rm_reg     ${LANG_ITALIAN} \
++    "Non riesco a trovare programma disinstallazione nel Registry."
++
++LangString str_msg_no_rm_exe     ${LANG_ITALIAN} \
++    "Non riesco a utilizzare programma disinstallazione."
++
++LangString str_msg_rm_copy_fail  ${LANG_ITALIAN} \
++    "Non riesco a copiare programma disinstallazione a una \
++     directory temporanea."
++
++LangString str_msg_rm_run_fail   ${LANG_ITALIAN} \
++    "Non riesco a eseguire programma disinstallazione."
++
++LangString str_msg_abort_install ${LANG_ITALIAN} \
++    "Il programma di disinstallazione verrà chiuso senza aver fatto nulla."
++
++LangString str_msg_install_fail  ${LANG_ITALIAN} \
++    "Installazione non riuscita. Miglior fortuna alla prossima!"
++
++LangString str_msg_rm_exe_fail   ${LANG_ITALIAN} \
++    "Alcuni file in $vim_bin_path non sono stati cancellati!$\r$\n\
++     Dovreste cancellarli voi stessi."
++
++LangString str_msg_rm_root_fail  ${LANG_ITALIAN} \
++    "AVVISO: Non posso cancellare $\"$vim_install_root$\", non è vuota!"
++
++LangString str_msg_keymap_title   ${LANG_ITALIAN} \
++    " Key remapping "
++LangString str_msg_keymap_default ${LANG_ITALIAN} \
++    " Do not remap keys for Windows behavior (Default)"
++LangString str_msg_keymap_windows ${LANG_ITALIAN} \
++    " Remap a few keys for Windows behavior$\n (<C-V>, <C-C>, <C-A>, <C-S>, <C-F>, etc)"
++
++LangString str_msg_mouse_title   ${LANG_ITALIAN} \
++    " Mouse behavior "
++LangString str_msg_mouse_default ${LANG_ITALIAN} \
++    " Default:$\n     Right button has a popup menu, left button starts visual mode"
++LangString str_msg_mouse_windows ${LANG_ITALIAN} \
++    " Windows:$\n     Right button has a popup menu, left button starts select mode"
++LangString str_msg_mouse_unix    ${LANG_ITALIAN} \
++    " Unix:$\n     Right button extends selection, left button starts visual mode"
+diff --git a/nsis/lang/japanese.nsi b/nsis/lang/japanese.nsi
+new file mode 100644
+index 000000000..93cae55ce
+--- /dev/null
++++ b/nsis/lang/japanese.nsi
+@@ -0,0 +1,238 @@
++﻿# vi:set ts=8 sts=4 sw=4 et fdm=marker:
++#
++# japanese.nsi: Japanese language strings for gvim NSIS installer.
++#
++# Locale ID    : 1041
++# fileencoding : UTF-8
++# Author       : Ken Takata
++
++#!include "script\helper_util.nsh"
++#${VimAddLanguage} "Japanese" "ja"
++!insertmacro MUI_LANGUAGE "Japanese"
++
++
++# Overwite the default translation.
++# These string should be always English.  Otherwise dosinst.c fails.
++LangString ^SetupCaption     ${LANG_JAPANESE} \
++        "$(^Name) Setup"
++LangString ^UninstallCaption ${LANG_JAPANESE} \
++        "$(^Name) Uninstall"
++
++##############################################################################
++# MUI Configuration Strings                                               {{{1
++##############################################################################
++
++#LangString str_dest_folder          ${LANG_JAPANESE} \
++#    "Destination Folder (Must end with $\"vim$\")"
++
++LangString str_show_readme          ${LANG_JAPANESE} \
++    "インストール完了後に README を表示する"
++
++# Install types:
++LangString str_type_typical         ${LANG_JAPANESE} \
++    "通常"
++
++LangString str_type_minimal         ${LANG_JAPANESE} \
++    "最小"
++
++LangString str_type_full            ${LANG_JAPANESE} \
++    "全て"
++
++
++##############################################################################
++# Section Titles & Description                                            {{{1
++##############################################################################
++
++LangString str_section_old_ver      ${LANG_JAPANESE} \
++    "既存のバージョンをアンインストール"
++LangString str_desc_old_ver         ${LANG_JAPANESE} \
++    "すでにインストールされている Vim をシステムから削除します。"
++
++LangString str_section_exe          ${LANG_JAPANESE} \
++    "Vim GUI とランタイムファイル"
++LangString str_desc_exe             ${LANG_JAPANESE} \
++    "Vim GUI 実行ファイルとラインタイムファイル。このコンポーネントは必須です。"
++
++LangString str_section_console      ${LANG_JAPANESE} \
++    "Vim コンソールプログラム"
++LangString str_desc_console         ${LANG_JAPANESE} \
++    "コンソール版の Vim (vim.exe)。"
++
++LangString str_section_batch        ${LANG_JAPANESE} \
++    ".bat ファイルを作成"
++LangString str_desc_batch           ${LANG_JAPANESE} \
++    "コマンドラインから Vim と関連コマンドを実行できるように、.bat ファイルを Windows ディレクトリに作成します。"
++
++LangString str_group_icons          ${LANG_JAPANESE} \
++    "Vim のアイコンを作成"
++LangString str_desc_icons           ${LANG_JAPANESE} \
++    "Vim を簡単に実行できるように、いくつかの場所にアイコンを作成します。"
++
++LangString str_section_desktop      ${LANG_JAPANESE} \
++    "デスクトップ上"
++LangString str_desc_desktop         ${LANG_JAPANESE} \
++    "gVim 実行ファイルのアイコンをデスクトップ上に作成します。"
++
++LangString str_section_start_menu   ${LANG_JAPANESE} \
++    "スタートメニューのプログラムフォルダー上"
++LangString str_desc_start_menu      ${LANG_JAPANESE} \
++    "Vim のアイコンをスタートメニューのプログラムフォルダー上に作成します。"
++
++LangString str_section_quick_launch ${LANG_JAPANESE} \
++    "In the Quick Launch Bar"
++LangString str_desc_quick_launch    ${LANG_JAPANESE} \
++    "Add Vim shortcut in the quick launch bar."
++
++LangString str_section_edit_with    ${LANG_JAPANESE} \
++    "Vim のコンテキストメニューを追加"
++LangString str_desc_edit_with       ${LANG_JAPANESE} \
++    "$\"Vimで編集する$\" をコンテキストメニューに追加します。"
++
++LangString str_section_edit_with32  ${LANG_JAPANESE} \
++    "32-bit Version"
++LangString str_desc_edit_with32     ${LANG_JAPANESE} \
++    "Add Vim to the $\"Open With...$\" context menu list \
++     for 32-bit applications."
++
++LangString str_section_edit_with64  ${LANG_JAPANESE} \
++    "64-bit Version"
++LangString str_desc_edit_with64     ${LANG_JAPANESE} \
++    "Add Vim to the $\"Open With...$\" context menu list \
++     for 64-bit applications."
++
++LangString str_section_vim_rc       ${LANG_JAPANESE} \
++    "既定のコンフィグを作成"
++LangString str_desc_vim_rc          ${LANG_JAPANESE} \
++    "もし無ければ、既定のコンフィグファイル (_vimrc) を作成します。"
++
++LangString str_group_plugin         ${LANG_JAPANESE} \
++    "プラグインディレクトリを作成"
++LangString str_desc_plugin          ${LANG_JAPANESE} \
++    "プラグインディレクトリを作成します。そこにプラグインファイルを置くことで Vim を拡張することができます。"
++
++LangString str_section_plugin_home  ${LANG_JAPANESE} \
++    "個人用"
++LangString str_desc_plugin_home     ${LANG_JAPANESE} \
++    "プラグインディレクトリを HOME (もし定義していれば)、または Vim のインストールディレクトリに作成します。"
++
++LangString str_section_plugin_vim   ${LANG_JAPANESE} \
++    "共用"
++LangString str_desc_plugin_vim      ${LANG_JAPANESE} \
++    "プラグインディレクトリを Vim のインストールディレクトリに作成します。システムの全員で共有されます。"
++
++LangString str_section_vis_vim      ${LANG_JAPANESE} \
++    "VisVim 拡張"
++LangString str_desc_vis_vim         ${LANG_JAPANESE} \
++    "Microsoft Visual Studio 統合用の VisVim 拡張。"
++
++LangString str_section_nls          ${LANG_JAPANESE} \
++    "多言語サポート"
++LangString str_desc_nls             ${LANG_JAPANESE} \
++    "多言語サポート用のファイルをインストールします。"
++
++LangString str_unsection_register   ${LANG_JAPANESE} \
++    "Vim を登録解除"
++LangString str_desc_unregister      ${LANG_JAPANESE} \
++    "Vim をシステムから登録解除します。"
++
++LangString str_unsection_exe        ${LANG_JAPANESE} \
++    "Vim の実行ファイル/ランタイムファイルを削除"
++LangString str_desc_rm_exe          ${LANG_JAPANESE} \
++    "全ての Vim の実行ファイルとランタイムファイルを削除します。"
++
++LangString str_unsection_vimfiles   ${LANG_JAPANESE} \
++    "vimfiles ディレクトリを削除"
++LangString str_desc_rm_vimfiles     ${LANG_JAPANESE} \
++    "vimfiles ディレクトリとその中の全てのファイルを削除します。"
++
++LangString str_unsection_rootdir    ${LANG_JAPANESE} \
++    "Vim のトップディレクトリを削除"
++LangString str_desc_rm_rootdir      ${LANG_JAPANESE} \
++    "Vim のトップディレクトリを削除します。あなたの Vim の設定ファイルも含まれていることに注意してください！"
++
++LangString str_vimrc_page_title     ${LANG_JAPANESE} \
++    "_vimrc の設定を選んでください"
++LangString str_vimrc_page_subtitle  ${LANG_JAPANESE} \
++    "キーのリマッピングとマウスの動作の設定を選んでください。"
++
++
++##############################################################################
++# Messages                                                                {{{1
++##############################################################################
++
++LangString str_msg_too_many_ver  ${LANG_JAPANESE} \
++    "Found $vim_old_ver_count Vim versions on your system.$\r$\n\
++     This installer can only handle ${VIM_MAX_OLD_VER} versions \
++     at most.$\r$\n\
++     Please remove some versions and start again."
++
++LangString str_msg_invalid_root  ${LANG_JAPANESE} \
++    "Invalid install path: $vim_install_root!$\r$\n\
++     It should end with $\"vim$\"."
++
++LangString str_msg_bin_mismatch  ${LANG_JAPANESE} \
++    "Binary path mismatch!$\r$\n$\r$\n\
++     Expect the binary path to be $\"$vim_bin_path$\",$\r$\n\
++     but system indicates the binary path is $\"$INSTDIR$\"."
++
++LangString str_msg_vim_running   ${LANG_JAPANESE} \
++    "Vim is still running on your system.$\r$\n\
++     Please close all instances of Vim before you continue."
++
++LangString str_msg_register_ole  ${LANG_JAPANESE} \
++    "Attempting to register Vim with OLE. \
++     There is no message indicates whether this works or not."
++
++LangString str_msg_unreg_ole     ${LANG_JAPANESE} \
++    "Attempting to unregister Vim with OLE. \
++     There is no message indicates whether this works or not."
++
++LangString str_msg_rm_start      ${LANG_JAPANESE} \
++    "Uninstalling the following version:"
++
++LangString str_msg_rm_fail       ${LANG_JAPANESE} \
++    "Fail to uninstall the following version:"
++
++LangString str_msg_no_rm_key     ${LANG_JAPANESE} \
++    "Cannot find uninstaller registry key."
++
++LangString str_msg_no_rm_reg     ${LANG_JAPANESE} \
++    "Cannot find uninstaller from registry."
++
++LangString str_msg_no_rm_exe     ${LANG_JAPANESE} \
++    "Cannot access uninstaller."
++
++LangString str_msg_rm_copy_fail  ${LANG_JAPANESE} \
++    "Fail to copy uninstaller to temporary directory."
++
++LangString str_msg_rm_run_fail   ${LANG_JAPANESE} \
++    "Fail to run uninstaller."
++
++LangString str_msg_abort_install ${LANG_JAPANESE} \
++    "Installer will abort."
++
++LangString str_msg_install_fail  ${LANG_JAPANESE} \
++    "Installation failed. Better luck next time."
++
++LangString str_msg_rm_exe_fail   ${LANG_JAPANESE} \
++    "Some files in $vim_bin_path have not been deleted!$\r$\n\
++     You must do it manually."
++
++LangString str_msg_rm_root_fail  ${LANG_JAPANESE} \
++    "WARNING: Cannot remove $\"$vim_install_root$\", it is not empty!"
++
++LangString str_msg_keymap_title   ${LANG_JAPANESE} \
++    " キーのリマッピング "
++LangString str_msg_keymap_default ${LANG_JAPANESE} \
++    " Windows用にキーをリマップしない(既定)"
++LangString str_msg_keymap_windows ${LANG_JAPANESE} \
++    " Windowsの動作に合わせていくつかのキーをリマップする$\n (例: <C-V>, <C-C>, <C-A>, <C-S>, <C-F> など)"
++
++LangString str_msg_mouse_title   ${LANG_JAPANESE} \
++    " マウスの動作 "
++LangString str_msg_mouse_default ${LANG_JAPANESE} \
++    " 既定:$\n     右ボタンはポップアップメニュー、左ボタンはビジュアルモードを開始"
++LangString str_msg_mouse_windows ${LANG_JAPANESE} \
++    " Windows:$\n     右ボタンはポップアップメニュー、左ボタンは選択モードを開始"
++LangString str_msg_mouse_unix    ${LANG_JAPANESE} \
++    " Unix:$\n     右ボタンは選択を拡張、左ボタンはビジュアルモードを開始"
+diff --git a/nsis/lang/simpchinese.nsi b/nsis/lang/simpchinese.nsi
+new file mode 100644
+index 000000000..b4c1e3d32
+--- /dev/null
++++ b/nsis/lang/simpchinese.nsi
+@@ -0,0 +1,239 @@
++﻿# vi:set ts=8 sts=4 sw=4 et fdm=marker:
++#
++# simpchinese.nsi: Simplified Chinese language strings for gvim NSIS
++# installer.
++#
++# Locale ID    : 2052
++# fileencoding : UTF-8
++# Author       : Guopeng Wen
++
++#!include "script\helper_util.nsh"
++#${VimAddLanguage} "SimpChinese" "zh_CN"
++!insertmacro MUI_LANGUAGE "SimpChinese"
++
++
++# Overwite the default translation.
++# These string should be always English.  Otherwise dosinst.c fails.
++LangString ^SetupCaption     ${LANG_SIMPCHINESE} \
++        "$(^Name) Setup"
++LangString ^UninstallCaption ${LANG_SIMPCHINESE} \
++        "$(^Name) Uninstall"
++
++##############################################################################
++# MUI Configuration Strings                                               {{{1
++##############################################################################
++
++LangString str_dest_folder          ${LANG_SIMPCHINESE} \
++    "安装路径 (必须以 vim 结尾)"
++
++LangString str_show_readme          ${LANG_SIMPCHINESE} \
++    "安装完成后显示 README 文件"
++
++# Install types:
++LangString str_type_typical         ${LANG_SIMPCHINESE} \
++    "典型安装"
++
++LangString str_type_minimal         ${LANG_SIMPCHINESE} \
++    "最小安装"
++
++LangString str_type_full            ${LANG_SIMPCHINESE} \
++    "完全安装"
++
++
++##############################################################################
++# Section Titles & Description                                            {{{1
++##############################################################################
++
++LangString str_section_old_ver      ${LANG_SIMPCHINESE} \
++    "卸载旧版本"
++LangString str_desc_old_ver         ${LANG_SIMPCHINESE} \
++    "卸载系统上旧版本的 Vim。"
++
++LangString str_section_exe          ${LANG_SIMPCHINESE} \
++    "安装 Vim 图形界面"
++LangString str_desc_exe             ${LANG_SIMPCHINESE} \
++    "安装 Vim 图形界面及脚本。此为必选安装。"
++
++LangString str_section_console      ${LANG_SIMPCHINESE} \
++    "安装 Vim 命令行程序"
++LangString str_desc_console         ${LANG_SIMPCHINESE} \
++    "安装 Vim 命令行程序 (vim.exe)。该程序在命令行窗口中运行。"
++
++LangString str_section_batch        ${LANG_SIMPCHINESE} \
++    "安装批处理文件"
++LangString str_desc_batch           ${LANG_SIMPCHINESE} \
++    "为 Vim 的各种变体创建批处理程序，以便在命令行下运行 Vim。"
++
++LangString str_group_icons          ${LANG_SIMPCHINESE} \
++    "创建 Vim 图标"
++LangString str_desc_icons           ${LANG_SIMPCHINESE} \
++    "为 Vim 创建若干图标，以方便使用 Vim。"
++
++LangString str_section_desktop      ${LANG_SIMPCHINESE} \
++    "在桌面上"
++LangString str_desc_desktop         ${LANG_SIMPCHINESE} \
++    "在桌面上为 Vim 创建若干图标，以方便启动 Vim。"
++
++LangString str_section_start_menu   ${LANG_SIMPCHINESE} \
++    "在启动菜单的程序菜单下"
++LangString str_desc_start_menu      ${LANG_SIMPCHINESE} \
++    "在启动菜单的程序菜单下添加 Vim 组。适用于 Windows 95 及以上版本。"
++
++LangString str_section_quick_launch ${LANG_SIMPCHINESE} \
++    "在快速启动启动栏中"
++LangString str_desc_quick_launch    ${LANG_SIMPCHINESE} \
++    "在快速启动栏中添加 Vim 图标。"
++
++LangString str_section_edit_with    ${LANG_SIMPCHINESE} \
++    "安装快捷菜单"
++LangString str_desc_edit_with       ${LANG_SIMPCHINESE} \
++    "将 Vim 添加到“打开方式”快捷菜单中。"
++
++LangString str_section_edit_with32  ${LANG_SIMPCHINESE} \
++    "32 位版本"
++LangString str_desc_edit_with32     ${LANG_SIMPCHINESE} \
++    "将 Vim 添加到 32 位程序的“打开方式”快捷菜单中。"
++
++LangString str_section_edit_with64  ${LANG_SIMPCHINESE} \
++    "64 位版本"
++LangString str_desc_edit_with64     ${LANG_SIMPCHINESE} \
++    "将 Vim 添加到 64 位程序的“打开方式”快捷菜单中。"
++
++LangString str_section_vim_rc       ${LANG_SIMPCHINESE} \
++    "创建缺省配置文件"
++LangString str_desc_vim_rc          ${LANG_SIMPCHINESE} \
++    "在安装目录下生成缺省的 Vim 配置文件(_vimrc)。\
++     如果该文件已经存在，则略过此项。"
++
++LangString str_group_plugin         ${LANG_SIMPCHINESE} \
++    "创建插件目录"
++LangString str_desc_plugin          ${LANG_SIMPCHINESE} \
++    "创建(空的)插件目录结构。插件目录用于安装 Vim 扩展插件，\
++     只要将文件复制到相关的子目录中即可。"
++
++LangString str_section_plugin_home  ${LANG_SIMPCHINESE} \
++    "私有插件目录"
++LangString str_desc_plugin_home     ${LANG_SIMPCHINESE} \
++    "在 HOME 目录下创建(空的)插件目录结构。若您未设置 HOME 目录，会在安装\
++     目录下创建该目录结构。"
++
++LangString str_section_plugin_vim   ${LANG_SIMPCHINESE} \
++    "公共插件目录"
++LangString str_desc_plugin_vim      ${LANG_SIMPCHINESE} \
++    "在 Vim 安装目录下创建(空的)插件目录结构，系统上所有用户都能使用安装在\
++     该目录下的扩展插件。"
++
++LangString str_section_vis_vim      ${LANG_SIMPCHINESE} \
++    "安装 VisVim 插件"
++LangString str_desc_vis_vim         ${LANG_SIMPCHINESE} \
++    "安装用于与微软 Microsoft Visual Studio 进行集成的 VisVim 插件。"
++
++LangString str_section_nls          ${LANG_SIMPCHINESE} \
++    "安装多语言支持"
++LangString str_desc_nls             ${LANG_SIMPCHINESE} \
++    "安装用于多语言支持的文件。"
++
++LangString str_unsection_register   ${LANG_SIMPCHINESE} \
++    "删除 Vim 系统配置"
++LangString str_desc_unregister      ${LANG_SIMPCHINESE} \
++    "删除和 Vim 相关的系统配置。"
++
++LangString str_unsection_exe        ${LANG_SIMPCHINESE} \
++    "删除 Vim 执行文件以及脚本"
++LangString str_desc_rm_exe          ${LANG_SIMPCHINESE} \
++    "删除 Vim 的所有执行文件及脚本。"
++
++LangString str_unsection_vimfiles   ${LANG_SIMPCHINESE} \
++    "Remove vimfiles directory"
++LangString str_desc_rm_vimfiles     ${LANG_SIMPCHINESE} \
++    "Remove all files in your vimfiles directory."
++
++LangString str_unsection_rootdir    ${LANG_SIMPCHINESE} \
++    "Remove the Vim root directory"
++LangString str_desc_rm_rootdir      ${LANG_SIMPCHINESE} \
++    "Remove the Vim root directory. It contains your Vim configuration files!"
++
++LangString str_vimrc_page_title     ${LANG_SIMPCHINESE} \
++    "Choose _vimrc settings"
++LangString str_vimrc_page_subtitle  ${LANG_SIMPCHINESE} \
++    "Choose the behavior of key remapping and mouse."
++
++
++##############################################################################
++# Messages                                                                {{{1
++##############################################################################
++
++LangString str_msg_too_many_ver  ${LANG_SIMPCHINESE} \
++    "您的系统上安装了 $vim_old_ver_count 个不同版本的 Vim，$\r$\n\
++     但本安装程序最多只能处理 ${VIM_MAX_OLD_VER} 个版本。$\r$\n\
++     请您手工删除一些旧版本以后再运行本安装程序。"
++
++LangString str_msg_invalid_root  ${LANG_SIMPCHINESE} \
++    "安装路径“$vim_install_root”无效！$\r$\n\
++     该路径必须以 vim 结尾。"
++
++LangString str_msg_bin_mismatch  ${LANG_SIMPCHINESE} \
++    "Vim 执行程序安装路径异常！$\r$\n$\r$\n\
++     该版本 Vim 的执行程序安装路径应该是“$vim_bin_path”,$\r$\n\
++     而系统却指示该路径为“$INSTDIR”。"
++
++LangString str_msg_vim_running   ${LANG_SIMPCHINESE} \
++    "您的系统上仍有 Vim 在运行，$\r$\n\
++     请您在执行后续步骤前退出这些 Vim。"
++
++LangString str_msg_register_ole  ${LANG_SIMPCHINESE} \
++    "试图注册 Vim OLE 服务器。请注意无论成功与否都不再显示进一步的信息。"
++
++LangString str_msg_unreg_ole     ${LANG_SIMPCHINESE} \
++    "试图注销 Vim OLE 服务器。请注意无论成功与否都不再显示进一步的信息。"
++
++LangString str_msg_rm_start      ${LANG_SIMPCHINESE} \
++    "开始卸载以下版本："
++
++LangString str_msg_rm_fail       ${LANG_SIMPCHINESE} \
++    "以下版本卸载失败："
++
++LangString str_msg_no_rm_key     ${LANG_SIMPCHINESE} \
++    "找不到卸载程序的注册表键。"
++
++LangString str_msg_no_rm_reg     ${LANG_SIMPCHINESE} \
++    "在注册表中未找到卸载程序路径。"
++
++LangString str_msg_no_rm_exe     ${LANG_SIMPCHINESE} \
++    "找不到卸载程序。"
++
++LangString str_msg_rm_copy_fail  ${LANG_SIMPCHINESE} \
++    "无法将卸载程序复制到临时目录。"
++
++LangString str_msg_rm_run_fail   ${LANG_SIMPCHINESE} \
++    "执行卸载程序失败。"
++
++LangString str_msg_abort_install ${LANG_SIMPCHINESE} \
++    "安装程序将退出。"
++
++LangString str_msg_install_fail  ${LANG_SIMPCHINESE} \
++    "安装失败。祝您下次好运。"
++
++LangString str_msg_rm_exe_fail   ${LANG_SIMPCHINESE} \
++    "目录“$vim_bin_path”下有部分文件删除失败！$\r$\n\
++     您只能手工删除该目录。"
++
++LangString str_msg_rm_root_fail  ${LANG_SIMPCHINESE} \
++    "警告：无法删除 Vim 安装目录“$vim_install_root”，\
++     该目录下仍有其他文件。"
++
++LangString str_msg_keymap_title   ${LANG_SIMPCHINESE} \
++    " Key remapping "
++LangString str_msg_keymap_default ${LANG_SIMPCHINESE} \
++    " Do not remap keys for Windows behavior (Default)"
++LangString str_msg_keymap_windows ${LANG_SIMPCHINESE} \
++    " Remap a few keys for Windows behavior$\n (<C-V>, <C-C>, <C-A>, <C-S>, <C-F>, etc)"
++
++LangString str_msg_mouse_title   ${LANG_SIMPCHINESE} \
++    " Mouse behavior "
++LangString str_msg_mouse_default ${LANG_SIMPCHINESE} \
++    " Default:$\n     Right button has a popup menu, left button starts visual mode"
++LangString str_msg_mouse_windows ${LANG_SIMPCHINESE} \
++    " Windows:$\n     Right button has a popup menu, left button starts select mode"
++LangString str_msg_mouse_unix    ${LANG_SIMPCHINESE} \
++    " Unix:$\n     Right button extends selection, left button starts visual mode"
+diff --git a/nsis/lang/tradchinese.nsi b/nsis/lang/tradchinese.nsi
+new file mode 100644
+index 000000000..b1a938189
+--- /dev/null
++++ b/nsis/lang/tradchinese.nsi
+@@ -0,0 +1,240 @@
++﻿# vi:set ts=8 sts=4 sw=4 et fdm=marker:
++#
++# tradchinese.nsi: Traditional Chinese language strings for gvim NSIS
++# installer.
++#
++# Locale ID    : 1028
++# fileencoding : UTF-8
++# Author       : Guopeng Wen
++
++#!include "script\helper_util.nsh"
++#${VimAddLanguage} "TradChinese" "zh_TW"
++!insertmacro MUI_LANGUAGE "TradChinese"
++
++
++# Overwite the default translation.
++# These string should be always English.  Otherwise dosinst.c fails.
++LangString ^SetupCaption     ${LANG_TRADCHINESE} \
++        "$(^Name) Setup"
++LangString ^UninstallCaption ${LANG_TRADCHINESE} \
++        "$(^Name) Uninstall"
++
++##############################################################################
++# MUI Configuration Strings                                               {{{1
++##############################################################################
++
++LangString str_dest_folder          ${LANG_TRADCHINESE} \
++    "安裝資料夾 (必須以 vim 結尾)"
++
++LangString str_show_readme          ${LANG_TRADCHINESE} \
++    "安裝完成後顯示 README 檔案"
++
++# Install types:
++LangString str_type_typical         ${LANG_TRADCHINESE} \
++    "典型安裝"
++
++LangString str_type_minimal         ${LANG_TRADCHINESE} \
++    "最小安裝"
++
++LangString str_type_full            ${LANG_TRADCHINESE} \
++    "完全安裝"
++
++
++##############################################################################
++# Section Titles & Description                                            {{{1
++##############################################################################
++
++LangString str_section_old_ver      ${LANG_TRADCHINESE} \
++    "移除舊版本"
++LangString str_desc_old_ver         ${LANG_TRADCHINESE} \
++    "移除閣下電腦上舊版本的 Vim。"
++
++LangString str_section_exe          ${LANG_TRADCHINESE} \
++    "安裝 Vim 圖形界面程式"
++LangString str_desc_exe             ${LANG_TRADCHINESE} \
++    "安裝 Vim 圖形界面程式及腳本。此為必選安裝。"
++
++LangString str_section_console      ${LANG_TRADCHINESE} \
++    "安裝 Vim 命令行程式"
++LangString str_desc_console         ${LANG_TRADCHINESE} \
++    "安裝 Vim 命令行程式 (vim.exe)。該程式在控制臺窗口中運行。"
++
++LangString str_section_batch        ${LANG_TRADCHINESE} \
++    "安裝批次檔案"
++LangString str_desc_batch           ${LANG_TRADCHINESE} \
++    "為 Vim 的各種變體創建批次檔，以便在命令行下啟動 Vim。"
++
++LangString str_group_icons          ${LANG_TRADCHINESE} \
++    "建立 Vim 圖示"
++LangString str_desc_icons           ${LANG_TRADCHINESE} \
++    "建立若干 Vim 圖示，以便于使用 Vim。"
++
++LangString str_section_desktop      ${LANG_TRADCHINESE} \
++    "於桌面"
++LangString str_desc_desktop         ${LANG_TRADCHINESE} \
++    "建立若干 Vim 圖示於桌面上，以方便啟動 Vim。"
++
++LangString str_section_start_menu   ${LANG_TRADCHINESE} \
++    "於「開始」功能表的「程式」集"
++LangString str_desc_start_menu      ${LANG_TRADCHINESE} \
++    "在「開始」功能表的「程式」集中建立 Vim 啟動組。\
++     適用于 Windows 95 及以上版本。"
++
++LangString str_section_quick_launch ${LANG_TRADCHINESE} \
++    "於快速啟動列"
++LangString str_desc_quick_launch    ${LANG_TRADCHINESE} \
++    "在快速啟動列中建立 Vim 圖示。"
++
++LangString str_section_edit_with    ${LANG_TRADCHINESE} \
++    "安裝快捷選單"
++LangString str_desc_edit_with       ${LANG_TRADCHINESE} \
++    "在「打開方式」快捷選單中添加 Vim 項。"
++
++LangString str_section_edit_with32  ${LANG_TRADCHINESE} \
++    "32 位元版本"
++LangString str_desc_edit_with32     ${LANG_TRADCHINESE} \
++    "在 32 位元程式的「打開方式」快捷選單中添加 Vim 項。"
++
++LangString str_section_edit_with64  ${LANG_TRADCHINESE} \
++    "64 位元版本"
++LangString str_desc_edit_with64     ${LANG_TRADCHINESE} \
++    "在 64 位元程式的「打開方式」快捷選單中添加 Vim 項。"
++
++LangString str_section_vim_rc       ${LANG_TRADCHINESE} \
++    "建立默認設定檔"
++LangString str_desc_vim_rc          ${LANG_TRADCHINESE} \
++    "在安裝資料夾下建立默認的 Vim 設定檔(_vimrc)。\
++     若該設定檔已經存在，則略過此項。"
++
++LangString str_group_plugin         ${LANG_TRADCHINESE} \
++    "建立插件資料夾"
++LangString str_desc_plugin          ${LANG_TRADCHINESE} \
++    "建立(空的)插件資料夾結構。插件資料夾用于安裝 Vim 的擴展插件，\
++     只要將檔案復制到相關的子資料夾中即可。"
++
++LangString str_section_plugin_home  ${LANG_TRADCHINESE} \
++    "建立插件資料夾"
++LangString str_desc_plugin_home     ${LANG_TRADCHINESE} \
++    "在 HOME 資料夾下建立(空的)插件資料夾結構。若閣下未設定 HOME 資料夾，會\
++     在安裝資料夾下建立該資料夾結構。"
++
++LangString str_section_plugin_vim   ${LANG_TRADCHINESE} \
++    "建立共享插件資料夾"
++LangString str_desc_plugin_vim      ${LANG_TRADCHINESE} \
++    "在 Vim 安裝資料夾下建立(空的)插件資料夾結構，電腦上所有用戶都能使用安裝\
++     在該資料夾里的擴展插件。"
++
++LangString str_section_vis_vim      ${LANG_TRADCHINESE} \
++    "安裝 VisVim 插件"
++LangString str_desc_vis_vim         ${LANG_TRADCHINESE} \
++    "VisVim 是用于與微軟 Microsoft Visual Studio 軟體進行整合的插件。"
++
++LangString str_section_nls          ${LANG_TRADCHINESE} \
++    "安裝本地語言支持"
++LangString str_desc_nls             ${LANG_TRADCHINESE} \
++    "安裝用于支持本地語言的檔案。"
++
++LangString str_unsection_register   ${LANG_TRADCHINESE} \
++    "移除 Vim 系統設定"
++LangString str_desc_unregister      ${LANG_TRADCHINESE} \
++    "移除與 Vim 相關的系統設定。"
++
++LangString str_unsection_exe        ${LANG_TRADCHINESE} \
++    "移除 Vim 程式及腳本"
++LangString str_desc_rm_exe          ${LANG_TRADCHINESE} \
++    "移除所有的 Vim 程式及腳本。"
++
++LangString str_unsection_vimfiles   ${LANG_TRADCHINESE} \
++    "Remove vimfiles directory"
++LangString str_desc_rm_vimfiles     ${LANG_TRADCHINESE} \
++    "Remove all files in your vimfiles directory."
++
++LangString str_unsection_rootdir    ${LANG_TRADCHINESE} \
++    "Remove the Vim root directory"
++LangString str_desc_rm_rootdir      ${LANG_TRADCHINESE} \
++    "Remove the Vim root directory. It contains your Vim configuration files!"
++
++LangString str_vimrc_page_title     ${LANG_TRADCHINESE} \
++    "Choose _vimrc settings"
++LangString str_vimrc_page_subtitle  ${LANG_TRADCHINESE} \
++    "Choose the behavior of key remapping and mouse."
++
++
++##############################################################################
++# Messages                                                                {{{1
++##############################################################################
++
++LangString str_msg_too_many_ver  ${LANG_TRADCHINESE} \
++    "閣下的電腦上安裝了 $vim_old_ver_count 個不同版本的 Vim，$\r$\n\
++     但是本安裝程式最多只能處理 ${VIM_MAX_OLD_VER} 個版本。$\r$\n\
++     煩請閣下手工移除一些版本以后再運行本安裝程式。"
++
++LangString str_msg_invalid_root  ${LANG_TRADCHINESE} \
++    "安裝資料夾「$vim_install_root」無效！$\r$\n\
++     該資料夾必須以「vim」結尾。"
++
++LangString str_msg_bin_mismatch  ${LANG_TRADCHINESE} \
++    "Vim 執行程式安裝路徑異常！$\r$\n$\r$\n\
++     該版本 Vim 的執行程式安裝路徑應該是「$vim_bin_path」,$\r$\n\
++     而系統卻指示該路徑為「$INSTDIR」。"
++
++LangString str_msg_vim_running   ${LANG_TRADCHINESE} \
++    "閣下的電腦上尚有正在運行之 Vim，$\r$\n\
++     煩請閣下在執行后續步驟前將其全部退出。"
++
++LangString str_msg_register_ole  ${LANG_TRADCHINESE} \
++    "試圖注冊 Vim OLE 伺服程式。請注意不論成功與否都不再顯示進一步的信息。"
++
++LangString str_msg_unreg_ole     ${LANG_TRADCHINESE} \
++    "試圖注銷 Vim OLE 伺服程式。請注意不論成功與否都不再顯示進一步的信息。"
++
++LangString str_msg_rm_start      ${LANG_TRADCHINESE} \
++    "正移除如下版本："
++
++LangString str_msg_rm_fail       ${LANG_TRADCHINESE} \
++    "以下版本移除失敗："
++
++LangString str_msg_no_rm_key     ${LANG_TRADCHINESE} \
++    "找不到反安裝程式的登錄檔入口。"
++
++LangString str_msg_no_rm_reg     ${LANG_TRADCHINESE} \
++    "在登錄檔中未找到反安裝程式路徑。"
++
++LangString str_msg_no_rm_exe     ${LANG_TRADCHINESE} \
++    "找不到反安裝程式。"
++
++LangString str_msg_rm_copy_fail  ${LANG_TRADCHINESE} \
++    "無法將法將反安裝程式复制到臨時目錄。"
++
++LangString str_msg_rm_run_fail   ${LANG_TRADCHINESE} \
++    "執行反安裝程式失敗。"
++
++LangString str_msg_abort_install ${LANG_TRADCHINESE} \
++    "安裝程式將退出。"
++
++LangString str_msg_install_fail  ${LANG_TRADCHINESE} \
++    "安裝失敗。預祝下次好運。"
++
++LangString str_msg_rm_exe_fail   ${LANG_TRADCHINESE} \
++    "資料夾「$vim_bin_path」下有部分檔案未能移除！$\r$\n\
++     閣下只能手工移除該資料夾。"
++
++LangString str_msg_rm_root_fail  ${LANG_TRADCHINESE} \
++    "警告：無法刪除 Vim 安裝資料夾「$vim_install_root」，\
++     該資料夾下仍有其他檔案。"
++
++LangString str_msg_keymap_title   ${LANG_TRADCHINESE} \
++    " Key remapping "
++LangString str_msg_keymap_default ${LANG_TRADCHINESE} \
++    " Do not remap keys for Windows behavior (Default)"
++LangString str_msg_keymap_windows ${LANG_TRADCHINESE} \
++    " Remap a few keys for Windows behavior$\n (<C-V>, <C-C>, <C-A>, <C-S>, <C-F>, etc)"
++
++LangString str_msg_mouse_title   ${LANG_TRADCHINESE} \
++    " Mouse behavior "
++LangString str_msg_mouse_default ${LANG_TRADCHINESE} \
++    " Default:$\n     Right button has a popup menu, left button starts visual mode"
++LangString str_msg_mouse_windows ${LANG_TRADCHINESE} \
++    " Windows:$\n     Right button has a popup menu, left button starts select mode"
++LangString str_msg_mouse_unix    ${LANG_TRADCHINESE} \
++    " Unix:$\n     Right button extends selection, left button starts visual mode"
+-- 
+2.17.0
+

--- a/patch/0013-nsis-Add-workarounds-for-Japanese-NSIS-messages.patch
+++ b/patch/0013-nsis-Add-workarounds-for-Japanese-NSIS-messages.patch
@@ -1,0 +1,32 @@
+From 038a13359b1490fca59966fdf038ff9ccc60bc98 Mon Sep 17 00:00:00 2001
+From: "K.Takata" <kentkt@csc.jp>
+Date: Tue, 2 Oct 2018 15:18:16 +0900
+Subject: [PATCH 13/22] nsis: Add workarounds for Japanese NSIS messages
+
+Some messages are too long and not shown properly.
+These should be fixed by the NSIS upstream, I think.
+---
+ nsis/lang/japanese.nsi | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/nsis/lang/japanese.nsi b/nsis/lang/japanese.nsi
+index 93cae55ce..23cda0e8e 100644
+--- a/nsis/lang/japanese.nsi
++++ b/nsis/lang/japanese.nsi
+@@ -18,6 +18,13 @@ LangString ^SetupCaption     ${LANG_JAPANESE} \
+ LangString ^UninstallCaption ${LANG_JAPANESE} \
+         "$(^Name) Uninstall"
+ 
++# Workarounds for NSIS Japanese translation. The messages are too long.
++# These should be better to be fixed by the NSIS upstream.
++LangString ^SpaceAvailable   ${LANG_JAPANESE} \
++        "利用可能なディスク容量："
++LangString ^SpaceRequired ${LANG_JAPANESE} \
++        "必要なディスク容量："
++
+ ##############################################################################
+ # MUI Configuration Strings                                               {{{1
+ ##############################################################################
+-- 
+2.17.0
+

--- a/patch/0014-nsis-Fix-some-ifdef-conditions.patch
+++ b/patch/0014-nsis-Fix-some-ifdef-conditions.patch
@@ -1,0 +1,85 @@
+From 01ad5d7804175987e87ed8aae32a31e4a774e189 Mon Sep 17 00:00:00 2001
+From: "K.Takata" <kentkt@csc.jp>
+Date: Tue, 2 Oct 2018 15:20:04 +0900
+Subject: [PATCH 14/22] nsis: Fix some !ifdef conditions
+
+---
+ nsis/gvim.nsi | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/nsis/gvim.nsi b/nsis/gvim.nsi
+index a51b385e5..bfb078779 100644
+--- a/nsis/gvim.nsi
++++ b/nsis/gvim.nsi
+@@ -36,6 +36,9 @@ Unicode true
+ # Comment the next line if you do not want to add Native Language Support
+ !define HAVE_NLS
+ 
++# Comment the next line if you do not want to include VisVim extension:
++!define HAVE_VIS_VIM
++
+ # Comment the following line to create a multilanguage installer:
+ !define HAVE_MULTI_LANG
+ 
+@@ -587,6 +590,7 @@ SectionGroup $(str_group_plugin) id_group_plugin
+ SectionGroupEnd
+ 
+ ##########################################################
++!ifdef HAVE_VIS_VIM
+ Section "$(str_section_vis_vim)" id_section_visvim
+ 	SectionIn 3
+ 
+@@ -594,6 +598,7 @@ Section "$(str_section_vis_vim)" id_section_visvim
+ 	!insertmacro UpgradeDLL "${VIMSRC}\VisVim\VisVim.dll" "$0\VisVim.dll" "$0"
+ 	File ${VIMSRC}\VisVim\README_VisVim.txt
+ SectionEnd
++!endif
+ 
+ ##########################################################
+ !ifdef HAVE_NLS
+@@ -673,14 +678,18 @@ Section -post
+ 	  SectionGetSize ${id_section_editwith} $4
+ 	  IntOp $3 $3 + $4
+ 	${EndIf}
++!ifdef HAVE_VIS_VIM
+ 	${If} ${SectionIsSelected} ${id_section_visvim}
+ 	  SectionGetSize ${id_section_visvim} $4
+ 	  IntOp $3 $3 + $4
+ 	${EndIf}
++!endif
++!ifdef HAVE_NLS
+ 	${If} ${SectionIsSelected} ${id_section_nls}
+ 	  SectionGetSize ${id_section_nls} $4
+ 	  IntOp $3 $3 + $4
+ 	${EndIf}
++!endif
+ 
+ 	# Register EstimatedSize.
+ 	# Other information will be set by the install.exe.
+@@ -832,11 +841,13 @@ Section "un.$(str_unsection_register)" id_unsection_register
+ 	# created.  Thus the "vim61" directory is included in it.
+ 	StrCpy $0 "$INSTDIR"
+ 
++!ifdef HAVE_VIS_VIM
+ 	# If VisVim was installed, unregister the DLL.
+ 	${If} ${FileExists} "$0\VisVim.dll"
+ 	  nsExec::Exec "regsvr32.exe /u /s $0\VisVim.dll"
+ 	  Pop $3
+ 	${EndIf}
++!endif
+ 
+ 	# delete the context menu entry and batch files
+ 	nsExec::Exec "$0\uninstal.exe -nsis"
+@@ -907,7 +918,9 @@ Section "un.$(str_unsection_exe)" id_unsection_exe
+ 	RMDir /r $0\syntax
+ 	RMDir /r $0\tools
+ 	RMDir /r $0\tutor
++!ifdef HAVE_VIS_VIM
+ 	RMDir /r $0\VisVim
++!endif
+ 	RMDir /r $0\lang
+ 	RMDir /r $0\keymap
+ 	Delete $0\*.exe
+-- 
+2.17.0
+

--- a/patch/0015-nsis-Fix-installer-directory.patch
+++ b/patch/0015-nsis-Fix-installer-directory.patch
@@ -1,0 +1,176 @@
+From 22d2c2a2b18cdb66db3fd0ff00e1ebb43c17da45 Mon Sep 17 00:00:00 2001
+From: "K.Takata" <kentkt@csc.jp>
+Date: Tue, 2 Oct 2018 16:52:32 +0900
+Subject: [PATCH 15/22] nsis: Fix installer directory
+
+Fix that the installer didn't check the old version of installed
+directory and also $VIM.
+Check $VIM first, then check the old directory from the registry, then
+fallback to $PROGRAMFILES(X86)\Vim.
+---
+ nsis/gvim.nsi | 88 +++++++++++++++++++++++++++++----------------------
+ 1 file changed, 51 insertions(+), 37 deletions(-)
+
+diff --git a/nsis/gvim.nsi b/nsis/gvim.nsi
+index bfb078779..6aace900b 100644
+--- a/nsis/gvim.nsi
++++ b/nsis/gvim.nsi
+@@ -194,6 +194,35 @@ ReserveFile ${VIMSRC}\installw32.exe
+ ##########################################################
+ # Functions
+ 
++# Get parent directory
++# Share this function both on installer and uninstaller
++!macro GetParent un
++Function ${un}GetParent
++  Exch $0 ; old $0 is on top of stack
++  Push $1
++  Push $2
++  StrCpy $1 -1
++  ${Do}
++    StrCpy $2 $0 1 $1
++    ${If} $2 == ""
++    ${OrIf} $2 == "\"
++      ${ExitDo}
++    ${EndIf}
++    IntOp $1 $1 - 1
++  ${Loop}
++  StrCpy $0 $0 $1
++  Pop $2
++  Pop $1
++  Exch $0 ; put $0 on top of stack, restore $0 to original value
++FunctionEnd
++!macroend
++
++!insertmacro GetParent ""
++!insertmacro GetParent "un."
++
++# Check if Vim is already installed.
++# return: Stack #0: Status. 1: installed. 0: not installed.
++#         Stack #1: Installed directory.
+ Function CheckOldVim
+   Push $0
+   Push $R0
+@@ -205,7 +234,7 @@ Function CheckOldVim
+   ${EndIf}
+ 
+   ClearErrors
+-  StrCpy $0 0	  # Found flag
++  StrCpy $0 0     # Found flag
+   StrCpy $R0 0    # Sub-key index
+   StrCpy $R1 ""   # Sub-key
+   ${Do}
+@@ -240,7 +269,11 @@ Function CheckOldVim
+       ${Continue}
+     ${EndIf}
+ 
+-    StrCpy $0 1	  # Found
++    StrCpy $0 1   # Found
++    Push $R2
++    call GetParent
++    call GetParent
++    Pop $R0   # Vim directory
+     ${ExitDo}
+ 
+   ${Loop}
+@@ -251,10 +284,12 @@ Function CheckOldVim
+ 
+   Pop $R2
+   Pop $R1
+-  Pop $R0
+-  Exch $0 ; put $0 on top of stack, restore $0 to original value
++  Exch $R0 # put $R0 on top of stack, restore $R0 to original value
++  Exch
++  Exch $0  # put $0 on top of stack, restore $0 to original value
+ FunctionEnd
+ 
++##########################################################
+ Section "$(str_section_old_ver)" id_section_old_ver
+ 	SectionIn 1 2 3 RO
+ 
+@@ -264,11 +299,13 @@ Section "$(str_section_old_ver)" id_section_old_ver
+ 	nsExec::Exec "$TEMP\install.exe -uninstall-check"
+ 	Pop $3
+ 	Delete $TEMP\install.exe
++	Delete $TEMP\vimini.ini
+ 
+ 	# We may have been put to the background when uninstall did something.
+ 	BringToFront
+ SectionEnd
+ 
++##########################################################
+ Function .onInit
+ #  MessageBox MB_YESNO|MB_ICONQUESTION \
+ #	"This will install Vim ${VER_MAJOR}.${VER_MINOR} on your computer.$\n Continue?" \
+@@ -277,32 +314,28 @@ Function .onInit
+ #	    Abort ; causes installer to quit.
+ #	NoAbort:
+ 
++  # Check $VIM
++  ReadEnvStr $INSTDIR "VIM"
++
+   call CheckOldVim
+-  Pop $3
++  Pop $3  # status
++  Pop $4  # Vim directory
+   ${If} $3 == 0
+     # No old versions of Vim found. Unselect and hide the section.
+     !insertmacro UnselectSection ${id_section_old_ver}
+     SectionSetInstTypes ${id_section_old_ver} 0
+     SectionSetText ${id_section_old_ver} ""
++  ${Else}
++    ${If} $INSTDIR == ""
++      StrCpy $INSTDIR $4
++    ${EndIf}
+   ${EndIf}
+ 
+-  # Install will have created a file for us that contains the directory where
+-  # we should install.  This is $VIM if it's set.  This appears to be the only
+-  # way to get the value of $VIM here!?
+-  ReadINIStr $INSTDIR $TEMP\vimini.ini vimini dir
+-  Delete $TEMP\vimini.ini
+-
+-  # If ReadINIStr failed or did not find a path: use the default dir.
++  # If did not find a path: use the default dir.
+   ${If} $INSTDIR == ""
+     StrCpy $INSTDIR "$PROGRAMFILES\Vim"
+   ${EndIf}
+ 
+-  # Should check for the value of $VIM and use it.  Unfortunately I don't know
+-  # how to obtain the value of $VIM
+-  # IfFileExists "$VIM" 0 No_Vim
+-  #   StrCpy $INSTDIR "$VIM"
+-  # No_Vim:
+-
+   # User variables:
+   # $0 - holds the directory the executables are installed to
+   # $1 - holds the parameters to be passed to install.exe.  Starts with OLE
+@@ -348,25 +381,6 @@ FunctionEnd
+ #  "Vim ${VER_MAJOR}.${VER_MINOR} has been (partly) removed from your system"
+ #FunctionEnd
+ 
+-Function un.GetParent
+-  Exch $0 ; old $0 is on top of stack
+-  Push $1
+-  Push $2
+-  StrCpy $1 -1
+-  ${Do}
+-    StrCpy $2 $0 1 $1
+-    ${If} $2 == ""
+-    ${OrIf} $2 == "\"
+-      ${ExitDo}
+-    ${EndIf}
+-    IntOp $1 $1 - 1
+-  ${Loop}
+-  StrCpy $0 $0 $1
+-  Pop $2
+-  Pop $1
+-  Exch $0 ; put $0 on top of stack, restore $0 to original value
+-FunctionEnd
+-
+ ##########################################################
+ Section "$(str_section_exe)" id_section_exe
+ 	SectionIn 1 2 3 RO
+-- 
+2.17.0
+

--- a/patch/0016-nsis-Remove-old-codes.patch
+++ b/patch/0016-nsis-Remove-old-codes.patch
@@ -1,0 +1,194 @@
+From 318e5ed816383241e922e352d4170b1a4b01ded8 Mon Sep 17 00:00:00 2001
+From: "K.Takata" <kentkt@csc.jp>
+Date: Tue, 2 Oct 2018 17:03:55 +0900
+Subject: [PATCH 16/22] nsis: Remove old codes
+
+---
+ nsis/gvim.nsi | 87 ++-------------------------------------------------
+ 1 file changed, 2 insertions(+), 85 deletions(-)
+
+diff --git a/nsis/gvim.nsi b/nsis/gvim.nsi
+index 6aace900b..150b76133 100644
+--- a/nsis/gvim.nsi
++++ b/nsis/gvim.nsi
+@@ -68,21 +68,6 @@ SetDatablockOptimize on
+ RequestExecutionLevel highest
+ XPStyle on
+ 
+-#ComponentText "This will install Vim ${VER_MAJOR}.${VER_MINOR} on your computer."
+-#DirText "Choose a directory to install Vim (should contain 'vim')"
+-#Icon icons\vim_16c.ico
+-# NSIS2 uses a different strategy with six different images in a strip...
+-#EnabledBitmap icons\enabled.bmp
+-#DisabledBitmap icons\disabled.bmp
+-#UninstallText "This will uninstall Vim ${VER_MAJOR}.${VER_MINOR} from your system."
+-#UninstallIcon icons\vim_uninst_16c.ico
+-
+-# On NSIS 2 using the BGGradient causes trouble on Windows 98, in combination
+-# with the BringToFront.
+-# BGGradient 004000 008200 FFFFFF
+-#LicenseText "You should read the following before installing:"
+-#LicenseData ${VIMRT}\doc\uganda.nsis.txt
+-
+ !ifdef HAVE_UPX
+   !packhdr temp.dat "upx --best --compress-icons=1 temp.dat"
+ !endif
+@@ -125,15 +110,6 @@ InstType $(str_type_full)
+ 
+ SilentInstall normal
+ 
+-# These are the pages we use
+-#Page license
+-#Page components
+-#Page custom SetCustom ValidateCustom ": _vimrc setting"
+-#Page directory "" "" CheckInstallDir
+-#Page instfiles
+-#UninstPage uninstConfirm
+-#UninstPage instfiles
+-
+ # General custom functions for MUI2:
+ #!define MUI_CUSTOMFUNCTION_ABORT   VimOnUserAbort
+ #!define MUI_CUSTOMFUNCTION_UNABORT un.VimOnUserAbort
+@@ -186,9 +162,6 @@ Var vim_mouse_stat
+ 
+ 
+ # Reserve files
+-# Needed for showing the _vimrc setting page faster.
+-#ReserveFile /plugin InstallOptions.dll
+-#ReserveFile vimrc.ini
+ ReserveFile ${VIMSRC}\installw32.exe
+ 
+ ##########################################################
+@@ -307,13 +280,6 @@ SectionEnd
+ 
+ ##########################################################
+ Function .onInit
+-#  MessageBox MB_YESNO|MB_ICONQUESTION \
+-#	"This will install Vim ${VER_MAJOR}.${VER_MINOR} on your computer.$\n Continue?" \
+-#	/SD IDYES \
+-#	IDYES NoAbort
+-#	    Abort ; causes installer to quit.
+-#	NoAbort:
+-
+   # Check $VIM
+   ReadEnvStr $INSTDIR "VIM"
+ 
+@@ -345,42 +311,16 @@ Function .onInit
+   StrCpy $0 "$INSTDIR\vim${VER_MAJOR}${VER_MINOR}"
+   StrCpy $1 "-register-OLE"
+   StrCpy $2 "gvim evim gview gvimdiff vimtutor"
+-
+-#  # Extract InstallOptions files
+-#  # $PLUGINSDIR will automatically be removed when the installer closes
+-#  InitPluginsDir
+-#  File /oname=$PLUGINSDIR\vimrc.ini "vimrc.ini"
+-FunctionEnd
+-
+-#Function .onUserAbort
+-#  MessageBox MB_YESNO|MB_ICONQUESTION "Abort install?" IDYES NoCancelAbort
+-#    Abort ; causes installer to not quit.
+-#  NoCancelAbort:
+-#FunctionEnd
+-
+-# We only accept the directory if it ends in "vim".  Using .onVerifyInstDir has
+-# the disadvantage that the browse dialog is difficult to use.
+-Function CheckInstallDir
+ FunctionEnd
+ 
+ Function .onInstSuccess
+   WriteUninstaller vim${VER_MAJOR}${VER_MINOR}\uninstall-gui.exe
+-  #MessageBox MB_YESNO|MB_ICONQUESTION \
+-  #     "The installation process has been successful. Happy Vimming! \
+-  #     $\n$\n Do you want to see the README file now?" IDNO NoReadme
+-  #    Exec '$0\gvim.exe -R "$0\README.txt"'
+-  #NoReadme:
+ FunctionEnd
+ 
+ Function .onInstFailed
+   MessageBox MB_OK|MB_ICONEXCLAMATION "Installation failed. Better luck next time."
+ FunctionEnd
+ 
+-#Function un.onUnInstSuccess
+-#  MessageBox MB_OK|MB_ICONINFORMATION \
+-#  "Vim ${VER_MAJOR}.${VER_MINOR} has been (partly) removed from your system"
+-#FunctionEnd
+-
+ ##########################################################
+ Section "$(str_section_exe)" id_section_exe
+ 	SectionIn 1 2 3 RO
+@@ -520,14 +460,6 @@ SectionGroupEnd
+ Section "$(str_section_edit_with)" id_section_editwith
+ 	SectionIn 1 3
+ 
+-	# Be aware of this sequence of events:
+-	# - user uninstalls Vim, gvimext.dll can't be removed (it's in use) and
+-	#   is scheduled to be removed at next reboot.
+-	# - user installs Vim in same directory, gvimext.dll still exists.
+-	# If we now skip installing gvimext.dll, it will disappear at the next
+-	# reboot.  Thus when copying gvimext.dll fails always schedule it to be
+-	# installed at the next reboot.  Can't use UpgradeDLL!
+-	# We don't ask the user to reboot, the old dll will keep on working.
+ 	SetOutPath $0
+ 
+ 	${If} ${RunningX64}
+@@ -706,7 +638,7 @@ Section -post
+ !endif
+ 
+ 	# Register EstimatedSize.
+-	# Other information will be set by the install.exe.
++	# Other information will be set by the install.exe (dosinst.c).
+ 	${If} ${RunningX64}
+ 	  SetRegView 64
+ 	${EndIf}
+@@ -720,7 +652,7 @@ SectionEnd
+ 
+ ##########################################################
+ Function SetCustom
+-	# Display the InstallOptions dialog
++	# Display the _vimrc setting dialog using nsDialogs.
+ 
+ 	# Check if a _vimrc should be created
+ 	${IfNot} ${SectionIsSelected} ${id_section_vimrc}
+@@ -838,11 +770,9 @@ FunctionEnd
+     !insertmacro MUI_DESCRIPTION_TEXT ${id_group_plugin}        $(str_desc_plugin)
+     !insertmacro MUI_DESCRIPTION_TEXT ${id_section_pluginhome}  $(str_desc_plugin_home)
+     !insertmacro MUI_DESCRIPTION_TEXT ${id_section_pluginvim}   $(str_desc_plugin_vim)
+-
+ !ifdef HAVE_VIS_VIM
+     !insertmacro MUI_DESCRIPTION_TEXT ${id_section_visvim}      $(str_desc_vis_vim)
+ !endif
+-
+ !ifdef HAVE_NLS
+     !insertmacro MUI_DESCRIPTION_TEXT ${id_section_nls}         $(str_desc_nls)
+ !endif
+@@ -966,9 +896,6 @@ Section "un.$(str_unsection_vimfiles)" id_unsection_vimfiles
+ 
+ 	${If} $1 != ""
+ 	${AndIf} ${FileExists} $1\vimfiles
+-	  #MessageBox MB_YESNO|MB_ICONQUESTION \
+-	  #  "Remove all files in your $1\vimfiles directory?$\n \
+-	  #  $\nCAREFUL: If you have created something there that you want to keep, click No" IDNO Fin
+ 	  RMDir /r $1\vimfiles
+ 	${EndIf}
+ SectionEnd
+@@ -979,17 +906,7 @@ Section "un.$(str_unsection_rootdir)" id_unsection_rootdir
+ 	Call un.GetParent
+ 	Pop $0
+ 
+-	# ask the user if the Vim root dir must be removed
+-	#MessageBox MB_YESNO|MB_ICONQUESTION \
+-	#  "Would you like to remove $0?$\n \
+-	#   $\nIt contains your Vim configuration files!" IDNO NoDelete
+-	#   RMDir /r $0 ; skipped if no
+-	#NoDelete:
+ 	RMDir /r $0
+-
+-	#Fin:
+-	#Call un.onUnInstSuccess
+-
+ SectionEnd
+ 
+ ##########################################################
+-- 
+2.17.0
+

--- a/patch/0017-nsis-Disable-VisVim-by-default.patch
+++ b/patch/0017-nsis-Disable-VisVim-by-default.patch
@@ -1,0 +1,39 @@
+From a6b232022d0c708e0bba47b0f1f1fae5b842ee7a Mon Sep 17 00:00:00 2001
+From: "K.Takata" <kentkt@csc.jp>
+Date: Tue, 2 Oct 2018 17:09:49 +0900
+Subject: [PATCH 17/22] nsis: Disable VisVim by default
+
+VisVim is for VC 6.0.  Does anyone still use it?
+---
+ nsis/gvim.nsi | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/nsis/gvim.nsi b/nsis/gvim.nsi
+index 150b76133..0989e0ecb 100644
+--- a/nsis/gvim.nsi
++++ b/nsis/gvim.nsi
+@@ -36,8 +36,8 @@ Unicode true
+ # Comment the next line if you do not want to add Native Language Support
+ !define HAVE_NLS
+ 
+-# Comment the next line if you do not want to include VisVim extension:
+-!define HAVE_VIS_VIM
++# Uncomment the next line if you want to include VisVim extension:
++#!define HAVE_VIS_VIM
+ 
+ # Comment the following line to create a multilanguage installer:
+ !define HAVE_MULTI_LANG
+@@ -47,7 +47,9 @@ Unicode true
+ # ----------- No configurable settings below this line -----------
+ 
+ !include "Library.nsh"		# For DLL install
+-!include "UpgradeDLL.nsh"	# for VisVim.dll
++!ifdef HAVE_VIS_VIM
++  !include "UpgradeDLL.nsh"	# for VisVim.dll
++!endif
+ !include "LogicLib.nsh"
+ !include "MUI2.nsh"
+ !include "nsDialogs.nsh"
+-- 
+2.17.0
+

--- a/patch/0018-nsis-Remove-XPStyle-on.patch
+++ b/patch/0018-nsis-Remove-XPStyle-on.patch
@@ -1,0 +1,25 @@
+From 58384e3f49119221845eeddc80f1bcd331857415 Mon Sep 17 00:00:00 2001
+From: "K.Takata" <kentkt@csc.jp>
+Date: Tue, 2 Oct 2018 22:24:42 +0900
+Subject: [PATCH 18/22] nsis: Remove "XPStyle on"
+
+This is automatically enabled in MUI2. No need to use explicitly.
+---
+ nsis/gvim.nsi | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/nsis/gvim.nsi b/nsis/gvim.nsi
+index 0989e0ecb..74bf89595 100644
+--- a/nsis/gvim.nsi
++++ b/nsis/gvim.nsi
+@@ -68,7 +68,6 @@ SetCompressorDictSize 64
+ ManifestDPIAware true
+ SetDatablockOptimize on
+ RequestExecutionLevel highest
+-XPStyle on
+ 
+ !ifdef HAVE_UPX
+   !packhdr temp.dat "upx --best --compress-icons=1 temp.dat"
+-- 
+2.17.0
+

--- a/patch/0019-nsis-Fix-some-comments-etc.patch
+++ b/patch/0019-nsis-Fix-some-comments-etc.patch
@@ -1,0 +1,59 @@
+From c0ad78b19a09a492176294669f403f5de36ac658 Mon Sep 17 00:00:00 2001
+From: "K.Takata" <kentkt@csc.jp>
+Date: Tue, 2 Oct 2018 22:26:06 +0900
+Subject: [PATCH 19/22] nsis: Fix some comments, etc.
+
+---
+ nsis/gvim.nsi          | 8 ++++----
+ nsis/lang/japanese.nsi | 2 +-
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/nsis/gvim.nsi b/nsis/gvim.nsi
+index 74bf89595..b71947514 100644
+--- a/nsis/gvim.nsi
++++ b/nsis/gvim.nsi
+@@ -100,8 +100,8 @@ RequestExecutionLevel highest
+ !define MUI_FINISHPAGE_RUN_TEXT            $(str_show_readme)
+ !define MUI_FINISHPAGE_RUN_PARAMETERS      "-R $\"$0\README.txt$\""
+ 
+-# This adds '\vim' to the user choice automagically.  The actual value is
+-# obtained below with ReadINIStr.
++# This adds '\Vim' to the user choice automagically.  The actual value is
++# obtained below with CheckOldVim.
+ InstallDir "$PROGRAMFILES\Vim"
+ 
+ # Types of installs we can perform:
+@@ -273,7 +273,7 @@ Section "$(str_section_old_ver)" id_section_old_ver
+ 	nsExec::Exec "$TEMP\install.exe -uninstall-check"
+ 	Pop $3
+ 	Delete $TEMP\install.exe
+-	Delete $TEMP\vimini.ini
++	Delete $TEMP\vimini.ini   # install.exe creates this, but we don't need it.
+ 
+ 	# We may have been put to the background when uninstall did something.
+ 	BringToFront
+@@ -319,7 +319,7 @@ Function .onInstSuccess
+ FunctionEnd
+ 
+ Function .onInstFailed
+-  MessageBox MB_OK|MB_ICONEXCLAMATION "Installation failed. Better luck next time."
++  MessageBox MB_OK|MB_ICONEXCLAMATION "$(str_msg_install_fail)"
+ FunctionEnd
+ 
+ ##########################################################
+diff --git a/nsis/lang/japanese.nsi b/nsis/lang/japanese.nsi
+index 23cda0e8e..d4a88c5bd 100644
+--- a/nsis/lang/japanese.nsi
++++ b/nsis/lang/japanese.nsi
+@@ -22,7 +22,7 @@ LangString ^UninstallCaption ${LANG_JAPANESE} \
+ # These should be better to be fixed by the NSIS upstream.
+ LangString ^SpaceAvailable   ${LANG_JAPANESE} \
+         "利用可能なディスク容量："
+-LangString ^SpaceRequired ${LANG_JAPANESE} \
++LangString ^SpaceRequired    ${LANG_JAPANESE} \
+         "必要なディスク容量："
+ 
+ ##############################################################################
+-- 
+2.17.0
+

--- a/patch/0020-dosinst-Support-setting-Vi-compatibility-from-comman.patch
+++ b/patch/0020-dosinst-Support-setting-Vi-compatibility-from-comman.patch
@@ -1,0 +1,76 @@
+From 435208e985a8a4ea01d903e866815a8b854945d2 Mon Sep 17 00:00:00 2001
+From: "K.Takata" <kentkt@csc.jp>
+Date: Wed, 3 Oct 2018 13:39:57 +0900
+Subject: [PATCH 20/22] dosinst: Support setting Vi compatibility from command
+ line
+
+Also add nocp setting.
+---
+ src/dosinst.c | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/src/dosinst.c b/src/dosinst.c
+index d8b8af08c..357eebbb4 100644
+--- a/src/dosinst.c
++++ b/src/dosinst.c
+@@ -63,6 +63,7 @@ int		choice_count = 0;	/* number of choices available */
+ enum
+ {
+     compat_vi = 1,
++    compat_vim,
+     compat_some_enhancements,
+     compat_all_enhancements
+ };
+@@ -70,6 +71,7 @@ char	*(compat_choices[]) =
+ {
+     "\nChoose the default way to run Vim:",
+     "Vi compatible",
++    "Vim default",
+     "with some Vim enhancements",
+     "with syntax highlighting and other features switched on",
+ };
+@@ -1161,6 +1163,11 @@ install_vimrc(int idx)
+ 	case compat_vi:
+ 		    fprintf(fd, "set compatible\n");
+ 		    break;
++	case compat_vim:
++		    fprintf(fd, "if &compatible\n");
++		    fprintf(fd, "  set nocompatible\n");
++		    fprintf(fd, "endif\n");
++		    break;
+ 	case compat_some_enhancements:
+ 		    fprintf(fd, "source $VIMRUNTIME/defaults.vim\n");
+ 		    break;
+@@ -2238,6 +2245,8 @@ print_cmd_line_help(void)
+     printf("    Remap keys when creating a default _vimrc file.\n");
+     printf("-vimrc-behave [unix|mswin|default]\n");
+     printf("    Set mouse behavior when creating a default _vimrc file.\n");
++    printf("-vimrc-compat [vi|vim|defaults|all]\n");
++    printf("    Set Vi compatibility when creating a default _vimrc file.\n");
+     printf("-install-popup\n");
+     printf("    Install the Edit-with-Vim context menu entry\n");
+     printf("-install-openwith\n");
+@@ -2315,6 +2324,20 @@ command_line_setup_choices(int argc, char **argv)
+ 	    else if (strcmp(argv[i], "default") == 0)
+ 		mouse_choice = mouse_default;
+ 	}
++	else if (strcmp(argv[i], "-vimrc-compat") == 0)
++	{
++	    if (i + 1 == argc)
++		break;
++	    i++;
++	    if (strcmp(argv[i], "vi") == 0)
++		compat_choice = compat_vi;
++	    else if (strcmp(argv[i], "vim") == 0)
++		compat_choice = compat_vim;
++	    else if (strcmp(argv[i], "defaults") == 0)
++		compat_choice = compat_some_enhancements;
++	    else if (strcmp(argv[i], "all") == 0)
++		compat_choice = compat_all_enhancements;
++	}
+ 	else if (strcmp(argv[i], "-install-popup") == 0)
+ 	{
+ 	    init_popup_choice();
+-- 
+2.17.0
+

--- a/patch/0021-nsis-Add-uninstallation-check.patch
+++ b/patch/0021-nsis-Add-uninstallation-check.patch
@@ -1,0 +1,42 @@
+From 56f4a634987edaa11b02cc39646155b062add1a7 Mon Sep 17 00:00:00 2001
+From: "K.Takata" <kentkt@csc.jp>
+Date: Wed, 3 Oct 2018 22:28:40 +0900
+Subject: [PATCH 21/22] nsis: Add uninstallation check
+
+TODO: Should we run uninstaller again if it seems to be failed?
+---
+ nsis/gvim.nsi | 18 ++++++++++++++++--
+ 1 file changed, 16 insertions(+), 2 deletions(-)
+
+diff --git a/nsis/gvim.nsi b/nsis/gvim.nsi
+index b71947514..82e41d3c5 100644
+--- a/nsis/gvim.nsi
++++ b/nsis/gvim.nsi
+@@ -270,8 +270,22 @@ Section "$(str_section_old_ver)" id_section_old_ver
+ 	# run the install program to check for already installed versions
+ 	SetOutPath $TEMP
+ 	File /oname=install.exe ${VIMSRC}\installw32.exe
+-	nsExec::Exec "$TEMP\install.exe -uninstall-check"
+-	Pop $3
++	${Do}
++	  nsExec::Exec "$TEMP\install.exe -uninstall-check"
++	  Pop $3
++
++	  call CheckOldVim
++	  Pop $3  # status
++	  Pop $4  # Vim directory
++	  ${If} $3 == 0
++	    ${ExitDo}
++	  ${Else}
++	    # It seems that the old version is still remaining.
++	    # TODO: Should we show a warning and run the uninstaller again?
++
++	    ${ExitDo}	# Just ignore for now.
++	  ${EndIf}
++	${Loop}
+ 	Delete $TEMP\install.exe
+ 	Delete $TEMP\vimini.ini   # install.exe creates this, but we don't need it.
+ 
+-- 
+2.17.0
+

--- a/patch/0022-nsis-Support-setting-Vi-compatibility.patch
+++ b/patch/0022-nsis-Support-setting-Vi-compatibility.patch
@@ -1,0 +1,607 @@
+From 875c23886555f824fd0b3afaaaaa788b0a496e2b Mon Sep 17 00:00:00 2001
+From: "K.Takata" <kentkt@csc.jp>
+Date: Thu, 4 Oct 2018 09:51:38 +0900
+Subject: [PATCH 22/22] nsis: Support setting Vi compatibility
+
+---
+ nsis/gvim.nsi             | 88 +++++++++++++++++++++++++++++++++++----
+ nsis/lang/dutch.nsi       | 38 ++++++++++++-----
+ nsis/lang/english.nsi     | 38 ++++++++++++-----
+ nsis/lang/german.nsi      | 38 ++++++++++++-----
+ nsis/lang/italian.nsi     | 38 ++++++++++++-----
+ nsis/lang/japanese.nsi    | 38 ++++++++++++-----
+ nsis/lang/simpchinese.nsi | 38 ++++++++++++-----
+ nsis/lang/tradchinese.nsi | 38 ++++++++++++-----
+ 8 files changed, 268 insertions(+), 86 deletions(-)
+
+diff --git a/nsis/gvim.nsi b/nsis/gvim.nsi
+index 82e41d3c5..0985d67ba 100644
+--- a/nsis/gvim.nsi
++++ b/nsis/gvim.nsi
+@@ -153,11 +153,16 @@ Page custom SetCustom ValidateCustom
+ 
+ # Global variables
+ Var vim_dialog
++Var vim_nsd_compat_1
++Var vim_nsd_compat_2
++Var vim_nsd_compat_3
++Var vim_nsd_compat_4
+ Var vim_nsd_keymap_1
+ Var vim_nsd_keymap_2
+ Var vim_nsd_mouse_1
+ Var vim_nsd_mouse_2
+ Var vim_nsd_mouse_3
++Var vim_compat_stat
+ Var vim_keymap_stat
+ Var vim_mouse_stat
+ 
+@@ -513,12 +518,23 @@ Section "$(str_section_vim_rc)" id_section_vimrc
+ 	${If} ${RunningX64}
+ 	  SetRegView 64
+ 	${EndIf}
++	WriteRegStr HKLM "${UNINST_REG_KEY_VIM}" "compat" "$vim_compat_stat"
+ 	WriteRegStr HKLM "${UNINST_REG_KEY_VIM}" "keyremap" "$vim_keymap_stat"
+ 	WriteRegStr HKLM "${UNINST_REG_KEY_VIM}" "mouse" "$vim_mouse_stat"
+ 	${If} ${RunningX64}
+ 	  SetRegView lastused
+ 	${EndIf}
+ 
++	${If} $vim_compat_stat == "vi"
++	  StrCpy $1 "$1 -vimrc-compat vi"
++	${ElseIf} $vim_compat_stat == "vim"
++	  StrCpy $1 "$1 -vimrc-compat vim"
++	${ElseIf} $vim_compat_stat == "defaults"
++	  StrCpy $1 "$1 -vimrc-compat defaults"
++	${Else}
++	  StrCpy $1 "$1 -vimrc-compat all"
++	${EndIf}
++
+ 	${If} $vim_keymap_stat == "default"
+ 	  StrCpy $1 "$1 -vimrc-remap no"
+ 	${Else}
+@@ -691,17 +707,53 @@ Function SetCustom
+ 	GetFunctionAddress $3 ValidateCustom
+ 	nsDialogs::OnBack $3
+ 
+-	# 1st group - Key remapping
+-	${NSD_CreateGroupBox} 0 0 100% 38% $(str_msg_keymap_title)
++
++	# 1st group - Compatibility
++	${NSD_CreateGroupBox} 0 0 100% 28% $(str_msg_compat_title)
+ 	Pop $3
+ 
+-	${NSD_CreateRadioButton} 5% 8% 90% 8% $(str_msg_keymap_default)
++	${NSD_CreateRadioButton} 5% 8% 40% 8% $(str_msg_compat_vi)
++	Pop $vim_nsd_compat_1
++	${NSD_AddStyle} $vim_nsd_compat_1 ${WS_GROUP}
++
++	${NSD_CreateRadioButton} 50% 8% 40% 8% $(str_msg_compat_vim)
++	Pop $vim_nsd_compat_2
++
++	${NSD_CreateRadioButton} 5% 17% 40% 8% $(str_msg_compat_defaults)
++	Pop $vim_nsd_compat_3
++
++	${NSD_CreateRadioButton} 50% 17% 40% 8% $(str_msg_compat_all)
++	Pop $vim_nsd_compat_4
++
++	# Default button
++	${If} $vim_compat_stat == ""
++	  ReadRegStr $3 HKLM "${UNINST_REG_KEY_VIM}" "compat"
++	${Else}
++	  StrCpy $3 $vim_compat_stat
++	${EndIf}
++	${If} $3 == "defaults"
++	  ${NSD_SetState} $vim_nsd_compat_3 ${BST_CHECKED}
++	${ElseIf} $3 == "vim"
++	  ${NSD_SetState} $vim_nsd_compat_2 ${BST_CHECKED}
++	${ElseIf} $3 == "vi"
++	  ${NSD_SetState} $vim_nsd_compat_1 ${BST_CHECKED}
++	${Else} # defualt
++	  ${NSD_SetState} $vim_nsd_compat_4 ${BST_CHECKED}
++	${EndIf}
++
++
++	# 2nd group - Key remapping
++	${NSD_CreateGroupBox} 0 31% 100% 28% $(str_msg_keymap_title)
++	Pop $3
++
++	${NSD_CreateRadioButton} 5% 39% 90% 8% $(str_msg_keymap_default)
+ 	Pop $vim_nsd_keymap_1
+ 	${NSD_AddStyle} $vim_nsd_keymap_1 ${WS_GROUP}
+ 
+-	${NSD_CreateRadioButton} 5% 18% 90% 16% $(str_msg_keymap_windows)
++	${NSD_CreateRadioButton} 5% 48% 90% 8% $(str_msg_keymap_windows)
+ 	Pop $vim_nsd_keymap_2
+ 
++	# Default button
+ 	${If} $vim_keymap_stat == ""
+ 	  ReadRegStr $3 HKLM "${UNINST_REG_KEY_VIM}" "keyremap"
+ 	${Else}
+@@ -714,20 +766,21 @@ Function SetCustom
+ 	${EndIf}
+ 
+ 
+-	# 2nd group - Mouse behavior
+-	${NSD_CreateGroupBox} 0 42% 100% 58% $(str_msg_mouse_title)
++	# 3rd group - Mouse behavior
++	${NSD_CreateGroupBox} 0 62% 100% 37% $(str_msg_mouse_title)
+ 	Pop $3
+ 
+-	${NSD_CreateRadioButton} 5% 48% 90% 16% $(str_msg_mouse_default)
++	${NSD_CreateRadioButton} 5% 70% 90% 8% $(str_msg_mouse_default)
+ 	Pop $vim_nsd_mouse_1
+ 	${NSD_AddStyle} $vim_nsd_mouse_1 ${WS_GROUP}
+ 
+-	${NSD_CreateRadioButton} 5% 65% 90% 16% $(str_msg_mouse_windows)
++	${NSD_CreateRadioButton} 5% 79% 90% 8% $(str_msg_mouse_windows)
+ 	Pop $vim_nsd_mouse_2
+ 
+-	${NSD_CreateRadioButton} 5% 81% 90% 16% $(str_msg_mouse_unix)
++	${NSD_CreateRadioButton} 5% 88% 90% 8% $(str_msg_mouse_unix)
+ 	Pop $vim_nsd_mouse_3
+ 
++	# Default button
+ 	${If} $vim_mouse_stat == ""
+ 	  ReadRegStr $3 HKLM "${UNINST_REG_KEY_VIM}" "mouse"
+ 	${Else}
+@@ -749,6 +802,23 @@ Function SetCustom
+ FunctionEnd
+ 
+ Function ValidateCustom
++	${NSD_GetState} $vim_nsd_compat_1 $3
++	${If} $3 == ${BST_CHECKED}
++	  StrCpy $vim_compat_stat "vi"
++	${Else}
++	  ${NSD_GetState} $vim_nsd_compat_2 $3
++	  ${If} $3 == ${BST_CHECKED}
++	    StrCpy $vim_compat_stat "vim"
++	  ${Else}
++	    ${NSD_GetState} $vim_nsd_compat_3 $3
++	    ${If} $3 == ${BST_CHECKED}
++	      StrCpy $vim_compat_stat "defaults"
++	    ${Else}
++	      StrCpy $vim_compat_stat "all"
++	    ${EndIf}
++	  ${EndIf}
++	${EndIf}
++
+ 	${NSD_GetState} $vim_nsd_keymap_1 $3
+ 	${If} $3 == ${BST_CHECKED}
+ 	  StrCpy $vim_keymap_stat "default"
+diff --git a/nsis/lang/dutch.nsi b/nsis/lang/dutch.nsi
+index 0e08d758a..86de7d703 100644
+--- a/nsis/lang/dutch.nsi
++++ b/nsis/lang/dutch.nsi
+@@ -156,11 +156,6 @@ LangString str_unsection_rootdir    ${LANG_DUTCH} \
+ LangString str_desc_rm_rootdir      ${LANG_DUTCH} \
+     "Remove the Vim root directory. It contains your Vim configuration files!"
+ 
+-LangString str_vimrc_page_title     ${LANG_DUTCH} \
+-    "Choose _vimrc settings"
+-LangString str_vimrc_page_subtitle  ${LANG_DUTCH} \
+-    "Choose the behavior of key remapping and mouse."
+-
+ 
+ ##############################################################################
+ # Messages                                                                {{{1
+@@ -226,18 +221,39 @@ LangString str_msg_rm_exe_fail   ${LANG_DUTCH} \
+ LangString str_msg_rm_root_fail  ${LANG_DUTCH} \
+     "WAARSCHUWING: Kan $\"$vim_install_root$\" niet verwijderen omdat het niet leeg is!"
+ 
++
++##############################################################################
++# Dialog Box                                                              {{{1
++##############################################################################
++
++LangString str_vimrc_page_title    ${LANG_DUTCH} \
++    "Choose _vimrc settings"
++LangString str_vimrc_page_subtitle ${LANG_DUTCH} \
++    "Choose the default _vimrc settings."
++
++LangString str_msg_compat_title    ${LANG_DUTCH} \
++    " Vi Compatibility "
++LangString str_msg_compat_vi       ${LANG_DUTCH} \
++    " Vi compatible"
++LangString str_msg_compat_vim      ${LANG_DUTCH} \
++    " Vim original"
++LangString str_msg_compat_defaults ${LANG_DUTCH} \
++    " Some enhancements"
++LangString str_msg_compat_all      ${LANG_DUTCH} \
++    " All enhancements (Default)"
++
+ LangString str_msg_keymap_title   ${LANG_DUTCH} \
+-    " Key remapping "
++    " Key remapping for Windows behavior "
+ LangString str_msg_keymap_default ${LANG_DUTCH} \
+-    " Do not remap keys for Windows behavior (Default)"
++    " Do not remap keys (Default)"
+ LangString str_msg_keymap_windows ${LANG_DUTCH} \
+-    " Remap a few keys for Windows behavior$\n (<C-V>, <C-C>, <C-A>, <C-S>, <C-F>, etc)"
++    " Remap a few keys (<C-V>, <C-C>, <C-A>, <C-S>, <C-F>, etc)"
+ 
+ LangString str_msg_mouse_title   ${LANG_DUTCH} \
+     " Mouse behavior "
+ LangString str_msg_mouse_default ${LANG_DUTCH} \
+-    " Default:$\n     Right button has a popup menu, left button starts visual mode"
++    " Default:    Right button has a popup menu, left button starts visual mode"
+ LangString str_msg_mouse_windows ${LANG_DUTCH} \
+-    " Windows:$\n     Right button has a popup menu, left button starts select mode"
++    " Windows: Right button has a popup menu, left button starts select mode"
+ LangString str_msg_mouse_unix    ${LANG_DUTCH} \
+-    " Unix:$\n     Right button extends selection, left button starts visual mode"
++    " Unix:        Right button extends selection, left button starts visual mode"
+diff --git a/nsis/lang/english.nsi b/nsis/lang/english.nsi
+index 8ef333eae..f340e6e1d 100644
+--- a/nsis/lang/english.nsi
++++ b/nsis/lang/english.nsi
+@@ -164,11 +164,6 @@ LangString str_unsection_rootdir    ${LANG_ENGLISH} \
+ LangString str_desc_rm_rootdir      ${LANG_ENGLISH} \
+     "Remove the Vim root directory. It contains your Vim configuration files!"
+ 
+-LangString str_vimrc_page_title     ${LANG_ENGLISH} \
+-    "Choose _vimrc settings"
+-LangString str_vimrc_page_subtitle  ${LANG_ENGLISH} \
+-    "Choose the behavior of key remapping and mouse."
+-
+ 
+ ##############################################################################
+ # Messages                                                                {{{1
+@@ -235,18 +230,39 @@ LangString str_msg_rm_exe_fail   ${LANG_ENGLISH} \
+ LangString str_msg_rm_root_fail  ${LANG_ENGLISH} \
+     "WARNING: Cannot remove $\"$vim_install_root$\", it is not empty!"
+ 
++
++##############################################################################
++# Dialog Box                                                              {{{1
++##############################################################################
++
++LangString str_vimrc_page_title    ${LANG_ENGLISH} \
++    "Choose _vimrc settings"
++LangString str_vimrc_page_subtitle ${LANG_ENGLISH} \
++    "Choose the default _vimrc settings."
++
++LangString str_msg_compat_title    ${LANG_ENGLISH} \
++    " Vi Compatibility "
++LangString str_msg_compat_vi       ${LANG_ENGLISH} \
++    " Vi compatible"
++LangString str_msg_compat_vim      ${LANG_ENGLISH} \
++    " Vim original"
++LangString str_msg_compat_defaults ${LANG_ENGLISH} \
++    " Some enhancements"
++LangString str_msg_compat_all      ${LANG_ENGLISH} \
++    " All enhancements (Default)"
++
+ LangString str_msg_keymap_title   ${LANG_ENGLISH} \
+-    " Key remapping "
++    " Key remapping for Windows behavior "
+ LangString str_msg_keymap_default ${LANG_ENGLISH} \
+-    " Do not remap keys for Windows behavior (Default)"
++    " Do not remap keys (Default)"
+ LangString str_msg_keymap_windows ${LANG_ENGLISH} \
+-    " Remap a few keys for Windows behavior$\n (<C-V>, <C-C>, <C-A>, <C-S>, <C-F>, etc)"
++    " Remap a few keys (<C-V>, <C-C>, <C-A>, <C-S>, <C-F>, etc)"
+ 
+ LangString str_msg_mouse_title   ${LANG_ENGLISH} \
+     " Mouse behavior "
+ LangString str_msg_mouse_default ${LANG_ENGLISH} \
+-    " Default:$\n     Right button has a popup menu, left button starts visual mode"
++    " Default:    Right button has a popup menu, left button starts visual mode"
+ LangString str_msg_mouse_windows ${LANG_ENGLISH} \
+-    " Windows:$\n     Right button has a popup menu, left button starts select mode"
++    " Windows: Right button has a popup menu, left button starts select mode"
+ LangString str_msg_mouse_unix    ${LANG_ENGLISH} \
+-    " Unix:$\n     Right button extends selection, left button starts visual mode"
++    " Unix:        Right button extends selection, left button starts visual mode"
+diff --git a/nsis/lang/german.nsi b/nsis/lang/german.nsi
+index 61be2b665..3d43e6340 100644
+--- a/nsis/lang/german.nsi
++++ b/nsis/lang/german.nsi
+@@ -156,11 +156,6 @@ LangString str_unsection_rootdir    ${LANG_GERMAN} \
+ LangString str_desc_rm_rootdir      ${LANG_GERMAN} \
+     "Remove the Vim root directory. It contains your Vim configuration files!"
+ 
+-LangString str_vimrc_page_title     ${LANG_GERMAN} \
+-    "Choose _vimrc settings"
+-LangString str_vimrc_page_subtitle  ${LANG_GERMAN} \
+-    "Choose the behavior of key remapping and mouse."
+-
+ 
+ ##############################################################################
+ # Messages                                                                {{{1
+@@ -226,18 +221,39 @@ LangString str_msg_rm_root_fail  ${LANG_GERMAN} \
+     "Achtung: Kann Verzeichnis $\"$vim_install_root$\" nicht entfernen, \
+      weil es nicht leer ist!"
+ 
++
++##############################################################################
++# Dialog Box                                                              {{{1
++##############################################################################
++
++LangString str_vimrc_page_title    ${LANG_GERMAN} \
++    "Choose _vimrc settings"
++LangString str_vimrc_page_subtitle ${LANG_GERMAN} \
++    "Choose the default _vimrc settings."
++
++LangString str_msg_compat_title    ${LANG_GERMAN} \
++    " Vi Compatibility "
++LangString str_msg_compat_vi       ${LANG_GERMAN} \
++    " Vi compatible"
++LangString str_msg_compat_vim      ${LANG_GERMAN} \
++    " Vim original"
++LangString str_msg_compat_defaults ${LANG_GERMAN} \
++    " Some enhancements"
++LangString str_msg_compat_all      ${LANG_GERMAN} \
++    " All enhancements (Default)"
++
+ LangString str_msg_keymap_title   ${LANG_GERMAN} \
+-    " Key remapping "
++    " Key remapping for Windows behavior "
+ LangString str_msg_keymap_default ${LANG_GERMAN} \
+-    " Do not remap keys for Windows behavior (Default)"
++    " Do not remap keys (Default)"
+ LangString str_msg_keymap_windows ${LANG_GERMAN} \
+-    " Remap a few keys for Windows behavior$\n (<C-V>, <C-C>, <C-A>, <C-S>, <C-F>, etc)"
++    " Remap a few keys (<C-V>, <C-C>, <C-A>, <C-S>, <C-F>, etc)"
+ 
+ LangString str_msg_mouse_title   ${LANG_GERMAN} \
+     " Mouse behavior "
+ LangString str_msg_mouse_default ${LANG_GERMAN} \
+-    " Default:$\n     Right button has a popup menu, left button starts visual mode"
++    " Default:    Right button has a popup menu, left button starts visual mode"
+ LangString str_msg_mouse_windows ${LANG_GERMAN} \
+-    " Windows:$\n     Right button has a popup menu, left button starts select mode"
++    " Windows: Right button has a popup menu, left button starts select mode"
+ LangString str_msg_mouse_unix    ${LANG_GERMAN} \
+-    " Unix:$\n     Right button extends selection, left button starts visual mode"
++    " Unix:        Right button extends selection, left button starts visual mode"
+diff --git a/nsis/lang/italian.nsi b/nsis/lang/italian.nsi
+index 3ccf835ee..c29d1ef7f 100644
+--- a/nsis/lang/italian.nsi
++++ b/nsis/lang/italian.nsi
+@@ -163,11 +163,6 @@ LangString str_unsection_rootdir    ${LANG_ITALIAN} \
+ LangString str_desc_rm_rootdir      ${LANG_ITALIAN} \
+     "Remove the Vim root directory. It contains your Vim configuration files!"
+ 
+-LangString str_vimrc_page_title     ${LANG_ITALIAN} \
+-    "Choose _vimrc settings"
+-LangString str_vimrc_page_subtitle  ${LANG_ITALIAN} \
+-    "Choose the behavior of key remapping and mouse."
+-
+ 
+ ##############################################################################
+ # Messages                                                                {{{1
+@@ -235,18 +230,39 @@ LangString str_msg_rm_exe_fail   ${LANG_ITALIAN} \
+ LangString str_msg_rm_root_fail  ${LANG_ITALIAN} \
+     "AVVISO: Non posso cancellare $\"$vim_install_root$\", non è vuota!"
+ 
++
++##############################################################################
++# Dialog Box                                                              {{{1
++##############################################################################
++
++LangString str_vimrc_page_title    ${LANG_ITALIAN} \
++    "Choose _vimrc settings"
++LangString str_vimrc_page_subtitle ${LANG_ITALIAN} \
++    "Choose the default _vimrc settings."
++
++LangString str_msg_compat_title    ${LANG_ITALIAN} \
++    " Vi Compatibility "
++LangString str_msg_compat_vi       ${LANG_ITALIAN} \
++    " Vi compatible"
++LangString str_msg_compat_vim      ${LANG_ITALIAN} \
++    " Vim original"
++LangString str_msg_compat_defaults ${LANG_ITALIAN} \
++    " Some enhancements"
++LangString str_msg_compat_all      ${LANG_ITALIAN} \
++    " All enhancements (Default)"
++
+ LangString str_msg_keymap_title   ${LANG_ITALIAN} \
+-    " Key remapping "
++    " Key remapping for Windows behavior "
+ LangString str_msg_keymap_default ${LANG_ITALIAN} \
+-    " Do not remap keys for Windows behavior (Default)"
++    " Do not remap keys (Default)"
+ LangString str_msg_keymap_windows ${LANG_ITALIAN} \
+-    " Remap a few keys for Windows behavior$\n (<C-V>, <C-C>, <C-A>, <C-S>, <C-F>, etc)"
++    " Remap a few keys (<C-V>, <C-C>, <C-A>, <C-S>, <C-F>, etc)"
+ 
+ LangString str_msg_mouse_title   ${LANG_ITALIAN} \
+     " Mouse behavior "
+ LangString str_msg_mouse_default ${LANG_ITALIAN} \
+-    " Default:$\n     Right button has a popup menu, left button starts visual mode"
++    " Default:    Right button has a popup menu, left button starts visual mode"
+ LangString str_msg_mouse_windows ${LANG_ITALIAN} \
+-    " Windows:$\n     Right button has a popup menu, left button starts select mode"
++    " Windows: Right button has a popup menu, left button starts select mode"
+ LangString str_msg_mouse_unix    ${LANG_ITALIAN} \
+-    " Unix:$\n     Right button extends selection, left button starts visual mode"
++    " Unix:        Right button extends selection, left button starts visual mode"
+diff --git a/nsis/lang/japanese.nsi b/nsis/lang/japanese.nsi
+index d4a88c5bd..ab7eeaa89 100644
+--- a/nsis/lang/japanese.nsi
++++ b/nsis/lang/japanese.nsi
+@@ -157,11 +157,6 @@ LangString str_unsection_rootdir    ${LANG_JAPANESE} \
+ LangString str_desc_rm_rootdir      ${LANG_JAPANESE} \
+     "Vim のトップディレクトリを削除します。あなたの Vim の設定ファイルも含まれていることに注意してください！"
+ 
+-LangString str_vimrc_page_title     ${LANG_JAPANESE} \
+-    "_vimrc の設定を選んでください"
+-LangString str_vimrc_page_subtitle  ${LANG_JAPANESE} \
+-    "キーのリマッピングとマウスの動作の設定を選んでください。"
+-
+ 
+ ##############################################################################
+ # Messages                                                                {{{1
+@@ -228,18 +223,39 @@ LangString str_msg_rm_exe_fail   ${LANG_JAPANESE} \
+ LangString str_msg_rm_root_fail  ${LANG_JAPANESE} \
+     "WARNING: Cannot remove $\"$vim_install_root$\", it is not empty!"
+ 
++
++##############################################################################
++# Dialog Box                                                              {{{1
++##############################################################################
++
++LangString str_vimrc_page_title    ${LANG_JAPANESE} \
++    "_vimrc の設定を選んでください"
++LangString str_vimrc_page_subtitle ${LANG_JAPANESE} \
++    "既定の _vimrc の設定を選んでください。"
++
++LangString str_msg_compat_title    ${LANG_JAPANESE} \
++    " Vi との互換性 "
++LangString str_msg_compat_vi       ${LANG_JAPANESE} \
++    " Vi 互換"
++LangString str_msg_compat_vim      ${LANG_JAPANESE} \
++    " Vim 独自"
++LangString str_msg_compat_defaults ${LANG_JAPANESE} \
++    " Vim 独自と多少の拡張"
++LangString str_msg_compat_all      ${LANG_JAPANESE} \
++    " Vim 独自と全ての拡張 (既定)"
++
+ LangString str_msg_keymap_title   ${LANG_JAPANESE} \
+-    " キーのリマッピング "
++    " Windows用のキーのリマッピング "
+ LangString str_msg_keymap_default ${LANG_JAPANESE} \
+-    " Windows用にキーをリマップしない(既定)"
++    " リマップしない (既定)"
+ LangString str_msg_keymap_windows ${LANG_JAPANESE} \
+-    " Windowsの動作に合わせていくつかのキーをリマップする$\n (例: <C-V>, <C-C>, <C-A>, <C-S>, <C-F> など)"
++    " いくつかのキーをリマップする (例: <C-V>, <C-C>, <C-A>, <C-S>, <C-F> など)"
+ 
+ LangString str_msg_mouse_title   ${LANG_JAPANESE} \
+     " マウスの動作 "
+ LangString str_msg_mouse_default ${LANG_JAPANESE} \
+-    " 既定:$\n     右ボタンはポップアップメニュー、左ボタンはビジュアルモードを開始"
++    " 既定:       右ボタンはポップアップメニュー、左ボタンはビジュアルモードを開始"
+ LangString str_msg_mouse_windows ${LANG_JAPANESE} \
+-    " Windows:$\n     右ボタンはポップアップメニュー、左ボタンは選択モードを開始"
++    " Windows: 右ボタンはポップアップメニュー、左ボタンは選択モードを開始"
+ LangString str_msg_mouse_unix    ${LANG_JAPANESE} \
+-    " Unix:$\n     右ボタンは選択を拡張、左ボタンはビジュアルモードを開始"
++    " Unix:       右ボタンは選択を拡張、左ボタンはビジュアルモードを開始"
+diff --git a/nsis/lang/simpchinese.nsi b/nsis/lang/simpchinese.nsi
+index b4c1e3d32..4cc495ea2 100644
+--- a/nsis/lang/simpchinese.nsi
++++ b/nsis/lang/simpchinese.nsi
+@@ -153,11 +153,6 @@ LangString str_unsection_rootdir    ${LANG_SIMPCHINESE} \
+ LangString str_desc_rm_rootdir      ${LANG_SIMPCHINESE} \
+     "Remove the Vim root directory. It contains your Vim configuration files!"
+ 
+-LangString str_vimrc_page_title     ${LANG_SIMPCHINESE} \
+-    "Choose _vimrc settings"
+-LangString str_vimrc_page_subtitle  ${LANG_SIMPCHINESE} \
+-    "Choose the behavior of key remapping and mouse."
+-
+ 
+ ##############################################################################
+ # Messages                                                                {{{1
+@@ -222,18 +217,39 @@ LangString str_msg_rm_root_fail  ${LANG_SIMPCHINESE} \
+     "警告：无法删除 Vim 安装目录“$vim_install_root”，\
+      该目录下仍有其他文件。"
+ 
++
++##############################################################################
++# Dialog Box                                                              {{{1
++##############################################################################
++
++LangString str_vimrc_page_title    ${LANG_SIMPCHINESE} \
++    "Choose _vimrc settings"
++LangString str_vimrc_page_subtitle ${LANG_SIMPCHINESE} \
++    "Choose the default _vimrc settings."
++
++LangString str_msg_compat_title    ${LANG_SIMPCHINESE} \
++    " Vi Compatibility "
++LangString str_msg_compat_vi       ${LANG_SIMPCHINESE} \
++    " Vi compatible"
++LangString str_msg_compat_vim      ${LANG_SIMPCHINESE} \
++    " Vim original"
++LangString str_msg_compat_defaults ${LANG_SIMPCHINESE} \
++    " Some enhancements"
++LangString str_msg_compat_all      ${LANG_SIMPCHINESE} \
++    " All enhancements (Default)"
++
+ LangString str_msg_keymap_title   ${LANG_SIMPCHINESE} \
+-    " Key remapping "
++    " Key remapping for Windows behavior "
+ LangString str_msg_keymap_default ${LANG_SIMPCHINESE} \
+-    " Do not remap keys for Windows behavior (Default)"
++    " Do not remap keys (Default)"
+ LangString str_msg_keymap_windows ${LANG_SIMPCHINESE} \
+-    " Remap a few keys for Windows behavior$\n (<C-V>, <C-C>, <C-A>, <C-S>, <C-F>, etc)"
++    " Remap a few keys (<C-V>, <C-C>, <C-A>, <C-S>, <C-F>, etc)"
+ 
+ LangString str_msg_mouse_title   ${LANG_SIMPCHINESE} \
+     " Mouse behavior "
+ LangString str_msg_mouse_default ${LANG_SIMPCHINESE} \
+-    " Default:$\n     Right button has a popup menu, left button starts visual mode"
++    " Default:    Right button has a popup menu, left button starts visual mode"
+ LangString str_msg_mouse_windows ${LANG_SIMPCHINESE} \
+-    " Windows:$\n     Right button has a popup menu, left button starts select mode"
++    " Windows: Right button has a popup menu, left button starts select mode"
+ LangString str_msg_mouse_unix    ${LANG_SIMPCHINESE} \
+-    " Unix:$\n     Right button extends selection, left button starts visual mode"
++    " Unix:        Right button extends selection, left button starts visual mode"
+diff --git a/nsis/lang/tradchinese.nsi b/nsis/lang/tradchinese.nsi
+index b1a938189..f7299ba46 100644
+--- a/nsis/lang/tradchinese.nsi
++++ b/nsis/lang/tradchinese.nsi
+@@ -154,11 +154,6 @@ LangString str_unsection_rootdir    ${LANG_TRADCHINESE} \
+ LangString str_desc_rm_rootdir      ${LANG_TRADCHINESE} \
+     "Remove the Vim root directory. It contains your Vim configuration files!"
+ 
+-LangString str_vimrc_page_title     ${LANG_TRADCHINESE} \
+-    "Choose _vimrc settings"
+-LangString str_vimrc_page_subtitle  ${LANG_TRADCHINESE} \
+-    "Choose the behavior of key remapping and mouse."
+-
+ 
+ ##############################################################################
+ # Messages                                                                {{{1
+@@ -223,18 +218,39 @@ LangString str_msg_rm_root_fail  ${LANG_TRADCHINESE} \
+     "警告：無法刪除 Vim 安裝資料夾「$vim_install_root」，\
+      該資料夾下仍有其他檔案。"
+ 
++
++##############################################################################
++# Dialog Box                                                              {{{1
++##############################################################################
++
++LangString str_vimrc_page_title    ${LANG_TRADCHINESE} \
++    "Choose _vimrc settings"
++LangString str_vimrc_page_subtitle ${LANG_TRADCHINESE} \
++    "Choose the default _vimrc settings."
++
++LangString str_msg_compat_title    ${LANG_TRADCHINESE} \
++    " Vi Compatibility "
++LangString str_msg_compat_vi       ${LANG_TRADCHINESE} \
++    " Vi compatible"
++LangString str_msg_compat_vim      ${LANG_TRADCHINESE} \
++    " Vim original"
++LangString str_msg_compat_defaults ${LANG_TRADCHINESE} \
++    " Some enhancements"
++LangString str_msg_compat_all      ${LANG_TRADCHINESE} \
++    " All enhancements (Default)"
++
+ LangString str_msg_keymap_title   ${LANG_TRADCHINESE} \
+-    " Key remapping "
++    " Key remapping for Windows behavior "
+ LangString str_msg_keymap_default ${LANG_TRADCHINESE} \
+-    " Do not remap keys for Windows behavior (Default)"
++    " Do not remap keys (Default)"
+ LangString str_msg_keymap_windows ${LANG_TRADCHINESE} \
+-    " Remap a few keys for Windows behavior$\n (<C-V>, <C-C>, <C-A>, <C-S>, <C-F>, etc)"
++    " Remap a few keys (<C-V>, <C-C>, <C-A>, <C-S>, <C-F>, etc)"
+ 
+ LangString str_msg_mouse_title   ${LANG_TRADCHINESE} \
+     " Mouse behavior "
+ LangString str_msg_mouse_default ${LANG_TRADCHINESE} \
+-    " Default:$\n     Right button has a popup menu, left button starts visual mode"
++    " Default:    Right button has a popup menu, left button starts visual mode"
+ LangString str_msg_mouse_windows ${LANG_TRADCHINESE} \
+-    " Windows:$\n     Right button has a popup menu, left button starts select mode"
++    " Windows: Right button has a popup menu, left button starts select mode"
+ LangString str_msg_mouse_unix    ${LANG_TRADCHINESE} \
+-    " Unix:$\n     Right button extends selection, left button starts visual mode"
++    " Unix:        Right button extends selection, left button starts visual mode"
+-- 
+2.17.0
+


### PR DESCRIPTION
Import the new MUI2 based installer as we discussed in vim/vim#3501.
Import the patches into the `patch` directory.

This will generate `gvim_8.1.pppp_x86.exe` as same as before, and also generate `gvim_8.1.pppp_x86-mui2.exe`.

Tested on my local account:
https://ci.appveyor.com/project/k-takata/vim-win32-installer/build/180/job/i5tpt0beixbq8y9l