### PR TITLE
Simplify the releases pages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,23 +62,24 @@ deploy:
 
       $(GITLOG)
 
-      Download and execute the most recent gvim_x.y.pppp_x86.exe file to install Vim
-      (where x.y is the release version and pppp is the patch number).
-      You can also download the gvim_x.y.pppp_x86-mui2.exe file. This has a
-      modern interface (MUI2) but it is still in a experimental phase.
+      ### Files:
 
-      The exe files contain the (32bit) installer while the .zip files contain an
-      archive of the 32bit (_x86) or 64bit versions (_x64). To install it, extract
-      the archive and update your PATH variable. The installer will do that
-      automatically and provide some additional extensions (e.g. Edit with Vim menu).
-      The gvim...pdb.zip file only contains the corresponding pdb files for debugging the binaries.
+      * `gvim_x.y.pppp_x64.zip`<br/>
+        64-bit zip archive
+      * `gvim_x.y.pppp_x64_pdb.zip`<br/>
+        pdb files for debugging the corresponding 64-bit executable
+      * `gvim_x.y.pppp_x86.exe`<br/>
+        32-bit installer
+      * `gvim_x.y.pppp_x86-mui2.exe`<br/>
+        **Experimental**: 32-bit installer with the modern interface (MUI2)
+      * `gvim_x.y.pppp_x86.zip`<br/>
+        32-bit zip archive
+      * `gvim_x.y.pppp_x86_pdb.zip`<br/>
+        pdb files for debugging the corresponding 32-bit executable
 
-      If you need a dynamic interface to Perl, Python2, Python3, Ruby, TCL, Lua or Racket/MzScheme,
-      make sure you also install the following. Vim will work without it, but some Plugin
-      might need this additional dependency. (e.g. Gundo needs a working Python2 installation,
-      Command-T needs a working Ruby installation and Neocomplete needs a working Lua
-      installation). This means, those interpreters have to be installed in addition to Vim.
-      Without it Vim won't be able to use that feature! You can find those interperters here:
+      (Where `x.y` is the release version and `pppp` is the patch level.)
+
+      ### Compiled with:
 
       * [Strawberry Perl](http://strawberryperl.com/) 5.28
       * [ActiveTcl](http://www.activestate.com/activetcl/downloads) 8.6.6
@@ -88,7 +89,7 @@ deploy:
       * [Racket](https://download.racket-lang.org/) 6.10.1
       * [RubyInstaller2](http://rubyinstaller.org/downloads/) 2.4
 
-      Make sure that you install the same architecture (32bit/64bit) that matches your Vim installation.
+      See the [README](https://github.com/vim/vim-win32-installer/blob/master/README.md) for detail.
     auth_token:
       # Update the following key, once this is merged to Vim main repository:
       secure: kH0D/3t+1Mc8OChKhe+voKlMO0aMwnlUr64QoZOJC6BaVwy+Us3ZHq9Oo+aBzjYc


### PR DESCRIPTION
Current releases pages are a bit noisy as we discussed at https://github.com/vim/vim-win32-installer/pull/74#issuecomment-427005375.
Remove duplicated description and add explanation for each file.