### PR TITLE
mui2: Create 64-bit installer

### DIFF
--- a/appveyor.bat
+++ b/appveyor.bat
@@ -280,8 +280,7 @@ mkdir ..\vim\%dir%
 xcopy ..\runtime ..\vim\%dir% /Y /E /V /I /H /R /Q
 7z a ..\..\gvim_%APPVEYOR_REPO_TAG_NAME:~1%_%ARCH%.zip ..\vim
 
-:: Create x86 installer (Skip x64 installer)
-if /i "%ARCH%"=="x64" goto :eof
+:: Create installer
 c:\cygwin\bin\bash -lc "cd `cygpath '%APPVEYOR_BUILD_FOLDER%'`/vim/runtime/doc && touch ../../src/auto/config.mk && make uganda.nsis.txt"
 copy gvim.exe gvim_ole.exe
 copy vim.exe vimw32.exe
@@ -290,8 +289,13 @@ copy xxd\xxd.exe xxdw32.exe
 copy install.exe installw32.exe
 copy uninstal.exe uninstalw32.exe
 pushd ..\nsis
-"%ProgramFiles(x86)%\NSIS\makensis" /DVIMRT=..\runtime /DGETTEXT=c: gvim-orig.nsi "/XOutFile ..\..\gvim_%APPVEYOR_REPO_TAG_NAME:~1%_%ARCH%.exe"
-"%ProgramFiles(x86)%\NSIS\makensis" /DVIMRT=..\runtime /DGETTEXT=c: gvim.nsi "/XOutFile ..\..\gvim_%APPVEYOR_REPO_TAG_NAME:~1%_%ARCH%-mui2.exe"
+if /i "%ARCH%"=="x64" (
+	rem Create only MUI2 installer
+	"%ProgramFiles(x86)%\NSIS\makensis" /DVIMRT=..\runtime /DGETTEXT=c: /DWIN64=1 gvim.nsi "/XOutFile ..\..\gvim_%APPVEYOR_REPO_TAG_NAME:~1%_%ARCH%-mui2.exe"
+) else (
+	"%ProgramFiles(x86)%\NSIS\makensis" /DVIMRT=..\runtime /DGETTEXT=c: gvim-orig.nsi "/XOutFile ..\..\gvim_%APPVEYOR_REPO_TAG_NAME:~1%_%ARCH%.exe"
+	"%ProgramFiles(x86)%\NSIS\makensis" /DVIMRT=..\runtime /DGETTEXT=c: gvim.nsi "/XOutFile ..\..\gvim_%APPVEYOR_REPO_TAG_NAME:~1%_%ARCH%-mui2.exe"
+)
 popd
 
 @echo off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,14 +66,16 @@ deploy:
 
       ### Files:
 
+      * `gvim_$(VIMVER)_x64-mui2.exe`
+        **Experimental**: 64-bit installer with the modern interface (MUI2)
       * `gvim_$(VIMVER)_x64.zip`
         64-bit zip archive
       * `gvim_$(VIMVER)_x64_pdb.zip`
         pdb files for debugging the corresponding 64-bit executable
-      * `gvim_$(VIMVER)_x86.exe`
-        32-bit installer
       * `gvim_$(VIMVER)_x86-mui2.exe`
         **Experimental**: 32-bit installer with the modern interface (MUI2)
+      * `gvim_$(VIMVER)_x86.exe`
+        **Recommended**: 32-bit installer
       * `gvim_$(VIMVER)_x86.zip`
         32-bit zip archive
       * `gvim_$(VIMVER)_x86_pdb.zip`

--- a/patch/0029-nsis-dosinst-Support-creating-64-bit-installer.patch
+++ b/patch/0029-nsis-dosinst-Support-creating-64-bit-installer.patch
@@ -1,0 +1,124 @@
+From c1718430334fc98d5fcb1efe13ba07f4f444955e Mon Sep 17 00:00:00 2001
+From: "K.Takata" <kentkt@csc.jp>
+Date: Sun, 7 Oct 2018 10:39:11 +0900
+Subject: [PATCH 29/29] nsis,dosinst: Support creating 64-bit installer
+
+* Use $PROGRAMFILES64 for the default folder.
+* Adjust file names.
+* Add " (x64)" to product name for 64-bit.
+---
+ nsis/gvim.nsi | 30 +++++++++++++++++++++++++-----
+ src/dosinst.c |  6 +++++-
+ 2 files changed, 30 insertions(+), 6 deletions(-)
+
+diff --git a/nsis/gvim.nsi b/nsis/gvim.nsi
+index cf4bc4e99..1e93c733f 100644
+--- a/nsis/gvim.nsi
++++ b/nsis/gvim.nsi
+@@ -42,6 +42,9 @@ Unicode true
+ # Comment the following line to create a multilanguage installer:
+ !define HAVE_MULTI_LANG
+ 
++# Uncomment the next line if you want to create a 64-bit installer.
++#!define WIN64
++
+ !include gvim_version.nsh	# for version number
+ 
+ # ----------- No configurable settings below this line -----------
+@@ -60,7 +63,11 @@ Unicode true
+ !define UNINST_REG_KEY	"Software\Microsoft\Windows\CurrentVersion\Uninstall"
+ !define UNINST_REG_KEY_VIM  "${UNINST_REG_KEY}\${PRODUCT}"
+ 
++!ifdef WIN64
++Name "${PRODUCT} (x64)"
++!else
+ Name "${PRODUCT}"
++!endif
+ OutFile gvim${VER_MAJOR}${VER_MINOR}.exe
+ CRCCheck force
+ SetCompressor /SOLID lzma
+@@ -73,6 +80,11 @@ RequestExecutionLevel highest
+   !packhdr temp.dat "upx --best --compress-icons=1 temp.dat"
+ !endif
+ 
++!ifdef WIN64
++!define BIT	64
++!else
++!define BIT	32
++!endif
+ 
+ ##########################################################
+ # MUI2 settings
+@@ -102,7 +114,11 @@ RequestExecutionLevel highest
+ 
+ # This adds '\Vim' to the user choice automagically.  The actual value is
+ # obtained below with CheckOldVim.
++!ifdef WIN64
++InstallDir "$PROGRAMFILES64\Vim"
++!else
+ InstallDir "$PROGRAMFILES\Vim"
++!endif
+ 
+ # Types of installs we can perform:
+ InstType $(str_type_typical)
+@@ -313,7 +329,11 @@ Function .onInit
+ 
+   # If did not find a path: use the default dir.
+   ${If} $INSTDIR == ""
++!ifdef WIN64
++    StrCpy $INSTDIR "$PROGRAMFILES64\Vim"
++!else
+     StrCpy $INSTDIR "$PROGRAMFILES\Vim"
++!endif
+   ${EndIf}
+ 
+   # User variables:
+@@ -356,7 +376,7 @@ Section "$(str_section_exe)" id_section_exe
+ 	File ${VIMRT}\rgb.txt
+ 
+ 	File ${VIMTOOLS}\diff.exe
+-	File ${VIMTOOLS}\winpty32.dll
++	File ${VIMTOOLS}\winpty${BIT}.dll
+ 	File ${VIMTOOLS}\winpty-agent.exe
+ 
+ 	SetOutPath $0\colors
+@@ -583,15 +603,15 @@ Section "$(str_section_nls)" id_section_nls
+ 	File ${VIMRT}\keymap\*.vim
+ 	SetOutPath $0
+ 	!insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
+-	    "${GETTEXT}\gettext32\libintl-8.dll" \
++	    "${GETTEXT}\gettext${BIT}\libintl-8.dll" \
+ 	    "$0\libintl-8.dll" "$0"
+ 	!insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
+-	    "${GETTEXT}\gettext32\libiconv-2.dll" \
++	    "${GETTEXT}\gettext${BIT}\libiconv-2.dll" \
+ 	    "$0\libiconv-2.dll" "$0"
+-  !if /FileExists "${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll"
++  !if /FileExists "${GETTEXT}\gettext${BIT}\libgcc_s_sjlj-1.dll"
+ 	# Install libgcc_s_sjlj-1.dll only if it is needed.
+ 	!insertmacro InstallLib DLL NOTSHARED REBOOT_NOTPROTECTED \
+-	    "${GETTEXT}\gettext32\libgcc_s_sjlj-1.dll" \
++	    "${GETTEXT}\gettext${BIT}\libgcc_s_sjlj-1.dll" \
+ 	    "$0\libgcc_s_sjlj-1.dll" "$0"
+   !endif
+ 
+diff --git a/src/dosinst.c b/src/dosinst.c
+index 357eebbb4..8b8586a19 100644
+--- a/src/dosinst.c
++++ b/src/dosinst.c
+@@ -1596,7 +1596,11 @@ install_registry(void)
+     }
+ 
+     printf("Creating an uninstall entry\n");
+-    sprintf(display_name, "Vim " VIM_VERSION_SHORT);
++    sprintf(display_name, "Vim " VIM_VERSION_SHORT
++#ifdef _WIN64
++	    " (x64)"
++#endif
++	    );
+ 
+     /* For the NSIS installer use the generated uninstaller. */
+     if (interactive)
+-- 
+2.17.0
+


### PR DESCRIPTION
Create also 64-bit MUI2 installer with minimal changes.
It still uses the suffix `w32` even for 64-bit.

Results in my local account:
https://github.com/k-takata/vim-win32-installer/releases/tag/v8.1.0454-64bit-installer3