### PR TITLE
Fix URL variable

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,7 +54,7 @@ before_deploy:
   - for /f "delims=" %%i in (gitlog.txt) do set GITLOG=%%i
   # Remove the first 'v' from the tag name.
   - set VIMVER=%APPVEYOR_REPO_TAG_NAME:~1%
-  - set URL=https://%APPVEYOR_REPO_NAME%/releases/download
+  - set URL=https://github.com/%APPVEYOR_REPO_NAME%/releases/download
 
 deploy:
   - provider: GitHub


### PR DESCRIPTION
Commit 09afb79fa63c925fbbfff tried to linkify the files in the description setting of the release page.

Unfortunately, I forgot to add the github.com server name to the link target, so those links are currently broken. So fix this by adding the servername to the URL variable.

Sorry, I did not notice earlier and had a busy week without having time to check the previous PR.