### PR TITLE
mui2: Show abort warning

### DIFF
--- a/patch/0028-mui2-Show-abort-warning.patch
+++ b/patch/0028-mui2-Show-abort-warning.patch
@@ -1,0 +1,28 @@
+From 5e39e6c63cc852419f897ba40235a6d84ae0de31 Mon Sep 17 00:00:00 2001
+From: "K.Takata" <kentkt@csc.jp>
+Date: Sun, 14 Oct 2018 21:11:29 +0900
+Subject: [PATCH 28/28] mui2: Show abort warning
+
+The original installer shows this, but gpwen's didn't show this.
+Make the same as the original one.
+---
+ nsis/gvim.nsi | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/nsis/gvim.nsi b/nsis/gvim.nsi
+index ad504853c..d57de8d2d 100644
+--- a/nsis/gvim.nsi
++++ b/nsis/gvim.nsi
+@@ -89,6 +89,9 @@ RequestExecutionLevel highest
+ ##########################################################
+ # MUI2 settings
+ 
++!define MUI_ABORTWARNING
++!define MUI_UNABORTWARNING
++
+ !define MUI_ICON   "icons\vim_16c.ico"
+ !define MUI_UNICON "icons\vim_uninst_16c.ico"
+ 
+-- 
+2.17.0
+


### PR DESCRIPTION
The original installer shows this, but gpwen's didn't show this.
Make the same as the original one.