### PR TITLE
Add badge for number of downloads per release

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,6 +59,7 @@ before_deploy:
 deploy:
   - provider: GitHub
     description: |
+      ![Github Downloads (by Release)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/total.svg)
       Nightly Vim Windows build snapshots ([more information](http://vim.wikia.com/wiki/Where_to_download_Vim)).
 
       ### Changes:


### PR DESCRIPTION
Add a badge for the number of downloads per release.

Example visible here:
https://github.com/chrisbra/vim-win32-installer/releases/tag/v8.1_cb6