### PR TITLE
Remove the Experimental and Recommended labels

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,13 +65,14 @@ deploy:
       ### Files:
 
       * [gvim_$(VIMVER)_x64.exe]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64.exe)
-        **Experimental**: 64-bit installer with the modern interface (MUI2)
+        64-bit installer
+      * [gvim_$(VIMVER)_x86.exe]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86.exe)
+        32-bit installer
+        If you don't know what to use, use this one
       * [gvim_$(VIMVER)_x64.zip]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64.zip)
         64-bit zip archive
       * [gvim_$(VIMVER)_x64_pdb.zip]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64_pdb.zip)
         pdb files for debugging the corresponding 64-bit executable
-      * [gvim_$(VIMVER)_x86.exe]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86.exe)
-        **Recommended**: 32-bit installer with the modern interface (MUI2)
       * [gvim_$(VIMVER)_x86.zip]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86.zip)
         32-bit zip archive
       * [gvim_$(VIMVER)_x86_pdb.zip]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86_pdb.zip)


### PR DESCRIPTION
Simply call them 64-bit/32-bit installer, because this is what they are.

Also, slightly reorder them, first the 64/32 bit installers, then the
zip archives with the corresponding pdb archives.

fixes #112 