### PR TITLE
Nsis update for signpath

### DIFF
--- a/appveyor.bat
+++ b/appveyor.bat
@@ -307,7 +307,7 @@ popd
 :: (the Vim zip archive as well as the installer)
 echo Creating Signpath Zip Archive
 cd %APPVEYOR_BUILD_FOLDER%
-7z a unsigned-gvim_%APPVEYOR_REPO_TAG_NAME:~1%_%ARCH%.zip gvim*.zip gvim*.exe
+7z a unsigned-gvim_%APPVEYOR_REPO_TAG_NAME:~1%_%ARCH%.zip gvim_%APPVEYOR_REPO_TAG_NAME:~1%_%ARCH%.zip gvim*.exe
 
 @echo off
 goto :eof

--- a/appveyor.bat
+++ b/appveyor.bat
@@ -301,6 +301,14 @@ if /i "%ARCH%"=="x64" (
 )
 popd
 
+:: Create zipfile for signing with signpath.io
+:: This will create a single zip file that should be uploaded to signpath
+:: signpath can then sign each artifact inside the zip file
+:: (the Vim zip archive as well as the installer)
+echo Creating Signpath Zip Archive
+cd %APPVEYOR_BUILD_FOLDER%
+7z a unsigned-gvim_%APPVEYOR_REPO_TAG_NAME:~1%_%ARCH%.zip gvim*.zip gvim*.exe
+
 @echo off
 goto :eof
 

--- a/appveyor.bat
+++ b/appveyor.bat
@@ -2,6 +2,8 @@
 :: Batch file for building/testing Vim on AppVeyor
 
 setlocal ENABLEDELAYEDEXPANSION
+FOR /f "delims=. tokens=1-3" %%i in ("%APPVEYOR_REPO_TAG_NAME%") do set PATCHLEVEL=%%k
+
 cd %APPVEYOR_BUILD_FOLDER%
 
 if /I "%ARCH%"=="x64" (
@@ -293,9 +295,9 @@ copy uninstal.exe uninstalw32.exe
 pushd ..\nsis
 7z x icons.zip > nul
 if /i "%ARCH%"=="x64" (
-	"%ProgramFiles(x86)%\NSIS\makensis" /DVIMRT=..\runtime /DGETTEXT=c: /DWIN64=1 gvim.nsi "/XOutFile ..\..\gvim_%APPVEYOR_REPO_TAG_NAME:~1%_%ARCH%.exe"
+	"%ProgramFiles(x86)%\NSIS\makensis" /DVIMRT=..\runtime /DGETTEXT=c: /DWIN64=1 /DPATCHLEVEL=%PATCHLEVEL% gvim.nsi "/XOutFile ..\..\gvim_%APPVEYOR_REPO_TAG_NAME:~1%_%ARCH%.exe"
 ) else (
-	"%ProgramFiles(x86)%\NSIS\makensis" /DVIMRT=..\runtime /DGETTEXT=c: gvim.nsi "/XOutFile ..\..\gvim_%APPVEYOR_REPO_TAG_NAME:~1%_%ARCH%.exe"
+	"%ProgramFiles(x86)%\NSIS\makensis" /DVIMRT=..\runtime /DGETTEXT=c: /DPATCHLEVEL=%PATCHLEVEL%  gvim.nsi "/XOutFile ..\..\gvim_%APPVEYOR_REPO_TAG_NAME:~1%_%ARCH%.exe"
 )
 popd
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,6 +45,8 @@ artifacts:
     name: gVim_x86_installer
   - path: gvim_*_x64.exe
     name: gVim_x64_installer
+  - path: unsigned*.zip
+    name: vim_zip_for_signing
 
 before_deploy:
   - for /f "delims=" %%i in (gitlog.txt) do set GITLOG=%%i
@@ -58,6 +60,7 @@ deploy:
     on_build_success: true
     on_build_failure: false
     on_build_status_changed: false
+    artifact: /unsigned*.zip/
     method: POST
     authorization:
       secure: eX3iWU3dQqDdg8UHR7Br6tqtvlFlhXihHcV0y/oR2YhSj6XZ2Pl/KVLiczUBCc39WWG/Aa5AXafWxaHQC/s40g==
@@ -107,6 +110,8 @@ deploy:
     prerelease: false
     on:
       appveyor_repo_tag: true
+
+      # Cache is being disabled to allow signpath to sign the results
 
       #cache:
       #  - downloads -> appveyor.bat

--- a/patch/01_patchlevel_nsis_installer.patch
+++ b/patch/01_patchlevel_nsis_installer.patch
@@ -1,0 +1,27 @@
+diff --git a/nsis/gvim.nsi b/nsis/gvim.nsi
+index cb2664c09..1be6b671b 100644
+--- a/nsis/gvim.nsi
++++ b/nsis/gvim.nsi
+@@ -47,6 +47,11 @@ Unicode true
+ 
+ !include gvim_version.nsh	# for version number
+ 
++# Definition of Patch for Vim
++!ifndef PATCHLEVEL
++  !define PATCHLEVEL 0
++!endif
++
+ # ----------- No configurable settings below this line -----------
+ 
+ !include "Library.nsh"		# For DLL install
+@@ -181,8 +186,8 @@ VIAddVersionKey /LANG=${LANG_ENGLISH} "CompanyName" "Vim Developers"
+ VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalTrademarks" "Vim"
+ VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalCopyright" "Copyright (C) 1996"
+ VIAddVersionKey /LANG=${LANG_ENGLISH} "FileDescription" "Vi Improved - A Text Editor"
+-VIAddVersionKey /LANG=${LANG_ENGLISH} "FileVersion" "${VER_MAJOR}.${VER_MINOR}.0.0"
+-VIProductVersion "${VER_MAJOR}.${VER_MINOR}.0.0"
++VIAddVersionKey /LANG=${LANG_ENGLISH} "FileVersion" "${VER_MAJOR}.${VER_MINOR}.${PATCHLEVEL}.0"
++VIProductVersion "${VER_MAJOR}.${VER_MINOR}.${PATCHLEVEL}.0"
+ 
+ # Global variables
+ Var vim_dialog


### PR DESCRIPTION
This PR does the following:

1) Add the patchlevel to the product version of the installer, this needs a change in how the nsis installer script is created. In addition this needs a patch for the nsis installer itself, however this second change needs to be applied to the vim repository, so a patch file is created

2) Create a zipfile consisting the exe installer as well as the zip archive of the Vim release. This can then be uploaded to signpath to have all parts signed. However once this is merged, it needs a change in the signpath configuration.