### PR TITLE
Escape some characters for markdown

### DIFF
--- a/scripts/update-repo.sh
+++ b/scripts/update-repo.sh
@@ -42,7 +42,7 @@ vimlog=$(git log --decorate --graph --pretty=format:%s $vimoldver..HEAD |sed \
     -e 's/ \+/ /g' \
     -e 's/\([0-9]\+ \)Problem: \+/\1/' \
     -e 's/\(.\{100\}\).*/\1/g' \
-    -e 's/\\/&&/g')
+    -e 's/[][_*^<`\\]/\\&/g')
 cd -
 
 # Check if it is updated


### PR DESCRIPTION
E.g. https://github.com/vim/vim-win32-installer/releases/tag/v8.1.2397
`__QNXNTO__` is shown as __QNXNTO__, which is unintended.
`_` and some other characters need to be escaped.