### PR TITLE
Fix #155

### DIFF
--- a/scripts/update-repo.sh
+++ b/scripts/update-repo.sh
@@ -42,7 +42,8 @@ vimlog=$(git log --decorate --graph --pretty=format:%s $vimoldver..HEAD |sed \
     -e 's/ \+/ /g' \
     -e 's/\([0-9]\+ \)Problem: \+/\1/' \
     -e 's/\(.\{100\}\).*/\1/g' \
-    -e 's/[][_*^<`\\]/\\&/g')
+    -e 's/[][_*^<`\\]/\\&/g' \
+    -e 's/^\\\*/*/')
 cd -
 
 # Check if it is updated


### PR DESCRIPTION
Sorry, there was a mistake in my previous PR #155 .
The first `*` was unintentionally escaped.

The commit message of https://github.com/vim/vim-win32-installer/commit/1f76a83170631f05ffb13ae3be3b87b40aae8625 is:

```
vim: Import v8.2.0

\* Vim 8.2 release
```

Obviously, this should have been:

```
vim: Import v8.2.0

* Vim 8.2 release
```