### PR TITLE
Description

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # Vim Installer and Archives (Win32 and Win64)
 
 This is a project for building Nightly Vim Windows build snapshots
-automatically ([more information](http://vim.fandom.com/wiki/Where_to_download_Vim)).
+automatically ([more information](https://vim.fandom.com/wiki/Where_to_download_Vim)).
 
 [Download](https://github.com/vim/vim-win32-installer/releases) and execute the
 most recent `gvim_x.y.pppp_x86.exe` file to install Vim (where `x.y` is the

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # Vim Installer and Archives (Win32 and Win64)
 
 This is a project for building Nightly Vim Windows build snapshots
-automatically ([more information](http://vim.wikia.com/wiki/Where_to_download_Vim)).
+automatically ([more information](http://vim.fandom.com/wiki/Where_to_download_Vim)).
 
 [Download](https://github.com/vim/vim-win32-installer/releases) and execute the
 most recent `gvim_x.y.pppp_x86.exe` file to install Vim (where `x.y` is the

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -92,18 +92,18 @@ deploy:
         Signed 64-bit zip archive
       -->
       #### :unlock: Unsigned Files:
-      * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64.exe.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x64.exe]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64.exe)
-        64-bit installer
       * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86.exe.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x86.exe]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86.exe)
         32-bit installer (*If you don't know what to use, use this one*)
-      * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64.zip.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x64.zip]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64.zip)
-        64-bit zip archive
+      * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64.exe.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x64.exe]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64.exe)
+        64-bit installer
       * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86.zip.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x86.zip]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86.zip)
         32-bit zip archive
-      * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64_pdb.zip.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x64_pdb.zip]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64_pdb.zip)
-        pdb files for debugging the corresponding 64-bit executable
+      * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64.zip.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x64.zip]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64.zip)
+        64-bit zip archive
       * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86_pdb.zip.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x86_pdb.zip]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86_pdb.zip)
         pdb files for debugging the corresponding 32-bit executable
+      * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64_pdb.zip.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x64_pdb.zip]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64_pdb.zip)
+        pdb files for debugging the corresponding 64-bit executable
 
       ### Compiled with:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,6 +71,8 @@ deploy:
       ![Github Downloads (by Release)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/total.svg)
       Nightly Vim Windows build snapshots ([more information](http://vim.wikia.com/wiki/Where_to_download_Vim)).
 
+      **If you do not know what to use, use the 32bit installer (use the signed one, if available).**
+
       Signed releases will occasionally be provided on a best effort approach.
 
       ### Changes:
@@ -79,7 +81,7 @@ deploy:
 
       ### Files:
       <!--  commented out, because will only be enabled once the signed files are uploaded manually.
-      #### Signed Files:
+      #### :lock: Signed Files:
       * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86_signed.exe.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x86_signed.exe]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86_signed.exe)
         Signed 32-bit installer (*If you don't know what to use, use this one*)
       * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64_signed.exe.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x64_signed.exe]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64_signed.exe)
@@ -89,17 +91,17 @@ deploy:
       * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64_signed.zip.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x64_signed.zip]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64_signed.zip)
         Signed 64-bit zip archive
       -->
-      #### Unsigned Files:
+      #### :unlock: Unsigned Files:
       * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64.exe.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x64.exe]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64.exe)
         64-bit installer
       * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86.exe.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x86.exe]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86.exe)
         32-bit installer (*If you don't know what to use, use this one*)
       * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64.zip.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x64.zip]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64.zip)
         64-bit zip archive
-      * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64_pdb.zip.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x64_pdb.zip]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64_pdb.zip)
-        pdb files for debugging the corresponding 64-bit executable
       * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86.zip.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x86.zip]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86.zip)
         32-bit zip archive
+      * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64_pdb.zip.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x64_pdb.zip]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64_pdb.zip)
+        pdb files for debugging the corresponding 64-bit executable
       * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86_pdb.zip.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x86_pdb.zip]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86_pdb.zip)
         pdb files for debugging the corresponding 32-bit executable
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,7 +69,7 @@ deploy:
   - provider: GitHub
     description: |
       ![Github Downloads (by Release)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/total.svg)
-      Nightly Vim Windows build snapshots ([more information](http://vim.wikia.com/wiki/Where_to_download_Vim)).
+      Nightly Vim Windows build snapshots ([more information](http://vim.fandom.com/wiki/Where_to_download_Vim)).
 
       **If you do not know what to use, use the 32bit installer (use the signed one, if available).**
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,7 +69,7 @@ deploy:
   - provider: GitHub
     description: |
       ![Github Downloads (by Release)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/total.svg)
-      Nightly Vim Windows build snapshots ([more information](http://vim.fandom.com/wiki/Where_to_download_Vim)).
+      Nightly Vim Windows build snapshots ([more information](https://vim.fandom.com/wiki/Where_to_download_Vim)).
 
       **If you do not know what to use, use the 32bit installer (use the signed one, if available).**
 


### PR DESCRIPTION
some updates to the description. 

First of all, recommend more prominently, to use the 32bit installer, 

While updating the description, I noticed, that the link to the wiki still points to wikia.com, while it seems to be now fandom.com, so update that as well.

And finally, reorder the download artifacts a bit. Since we recommend to use the 32bit installer, always put the 32bit artifact first, followed by the corresponding 64bit artifact.