### PR TITLE
Fix link target of downloads images

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,7 +68,7 @@ deploy:
 
   - provider: GitHub
     description: |
-      ![Github Downloads (by Release)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/total.svg)
+      [![$(APPVEYOR_REPO_TAG_NAME)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/total.svg)](https://github.com/$(APPVEYOR_REPO_NAME)/releases/tag/$(APPVEYOR_REPO_TAG_NAME))
       Nightly Vim Windows build snapshots ([more information](https://vim.fandom.com/wiki/Where_to_download_Vim)).
 
       **If you do not know what to use, use the 32bit installer (use the signed one, if available).**
@@ -89,27 +89,27 @@ deploy:
       ### Files:
       <!--  commented out, because will only be enabled once the signed files are uploaded manually.
       #### :lock: Signed Files:
-      * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86_signed.exe.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x86_signed.exe]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86_signed.exe)
+      * [![gvim_$(VIMVER)_x86_signed.exe](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86_signed.exe.svg?label=downloads&logo=vim)]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86_signed.exe)
         Signed 32-bit installer (*If you don't know what to use, use this one*)
-      * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64_signed.exe.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x64_signed.exe]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64_signed.exe)
+      * [![gvim_$(VIMVER)_x64_signed.exe](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64_signed.exe.svg?label=downloads&logo=vim)]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64_signed.exe)
         Signed 64-bit installer
-      * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86_signed.zip.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x86_signed.zip]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86_signed.zip)
+      * [![gvim_$(VIMVER)_x86_signed.zip](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86_signed.zip.svg?label=downloads&logo=vim)]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86_signed.zip)
         Signed 32-bit zip archive
-      * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64_signed.zip.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x64_signed.zip]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64_signed.zip)
+      * [![gvim_$(VIMVER)_x64_signed.zip](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64_signed.zip.svg?label=downloads&logo=vim)]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64_signed.zip)
         Signed 64-bit zip archive
       -->
       #### :unlock: Unsigned Files:
-      * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86.exe.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x86.exe]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86.exe)
+      * [![gvim_$(VIMVER)_x86.exe](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86.exe.svg?label=downloads&logo=vim)]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86.exe)
         32-bit installer (*If you don't know what to use, use this one*)
-      * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64.exe.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x64.exe]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64.exe)
+      * [![gvim_$(VIMVER)_x64.exe](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64.exe.svg?label=downloads&logo=vim)]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64.exe)
         64-bit installer
-      * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86.zip.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x86.zip]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86.zip)
+      * [![gvim_$(VIMVER)_x86.zip](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86.zip.svg?label=downloads&logo=vim)]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86.zip)
         32-bit zip archive
-      * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64.zip.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x64.zip]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64.zip)
+      * [![gvim_$(VIMVER)_x64.zip](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64.zip.svg?label=downloads&logo=vim)]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64.zip)
         64-bit zip archive
-      * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86_pdb.zip.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x86_pdb.zip]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86_pdb.zip)
+      * [![gvim_$(VIMVER)_x86_pdb.zip](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86_pdb.zip.svg?label=downloads&logo=vim)]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x86_pdb.zip)
         pdb files for debugging the corresponding 32-bit executable
-      * ![GitHub Releases (by Asset)](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64_pdb.zip.svg?label=downloads&logo=vim) [gvim_$(VIMVER)_x64_pdb.zip]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64_pdb.zip)
+      * [![gvim_$(VIMVER)_x64_pdb.zip](https://img.shields.io/github/downloads/$(APPVEYOR_REPO_NAME)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64_pdb.zip.svg?label=downloads&logo=vim)]($(URL)/$(APPVEYOR_REPO_TAG_NAME)/gvim_$(VIMVER)_x64_pdb.zip)
         pdb files for debugging the corresponding 64-bit executable
 
       <details>


### PR DESCRIPTION
When someone clicked a downloads image, the image itself was opened.
It was not so useful. This PR changes the link target to each file.