### PR TITLE
Revert "Temporarily enable TCL for 64bits"

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ installed in addition to Vim. Without it Vim won't be able to use that feature!
 You can find those interperters here:
 
 * [Strawberry Perl](http://strawberryperl.com/) 5.28
-* ~~[ActiveTcl](http://www.activestate.com/activetcl/downloads) 8.6.6~~ (Disabled for 32bits now. See [#194](https://github.com/vim/vim-win32-installer/issues/194).)
+* ~~[ActiveTcl](http://www.activestate.com/activetcl/downloads) 8.6.6~~ (Disabled for now. See [#194](https://github.com/vim/vim-win32-installer/issues/194).)
 * [LuaBinaries](http://luabinaries.sourceforge.net/download.html) 5.3
 * [Python](https://www.python.org/downloads/) 2.7
 * [Python 3](https://www.python.org/downloads/) 3.8

--- a/appveyor.bat
+++ b/appveyor.bat
@@ -57,7 +57,7 @@ set RUBY_DIR=!RUBY%BIT%_DIR!
 set TCL_VER_LONG=8.6
 set TCL_VER=%TCL_VER_LONG:.=%
 set TCL32_URL=http://downloads.activestate.com/ActiveTcl/releases/8.6.6.8607/ActiveTcl-8.6.6.8607-MSWin32-x86-403667.exe
-set TCL64_URL=https://camel-builds.s3.amazonaws.com/ActiveTcl/MSWin32-x64/20200901T013213Z/ActiveTcl-8.6.10.0000-MSWin32-x64-893162d6.exe?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJAFTYUXEZJ3HWLEQ%2F20200909%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200909T132036Z&X-Amz-Expires=21600&X-Amz-SignedHeaders=host&X-Amz-Signature=53a2277f96134f76d0e2d97212ec7b1fc73a4b4ab83e977b9fe7dc927d08a3de
+set TCL64_URL=http://downloads.activestate.com/ActiveTcl/releases/8.6.6.8606/ActiveTcl-8.6.6.8606-MSWin32-x64-401995.exe
 set TCL_URL=!TCL%BIT%_URL!
 set TCL_DIR=C:\Tcl
 set TCL_DLL=tcl%TCL_VER%t.dll
@@ -114,14 +114,12 @@ call :downloadfile %PERL_URL% downloads\perl.zip
 :: Extract only the "perl" folder.
 7z x downloads\perl.zip perl -o%PERL_DIR%\.. > nul || exit 1
 
-:: Tcl
-if /I "%ARCH%"=="x64" (
-  call :downloadfile %TCL_URL% downloads\tcl.exe
-  mkdir c:\ActiveTclTemp
-  start /wait downloads\tcl.exe /extract:c:\ActiveTclTemp /exenoui /exenoupdates /quiet /norestart
-  for /d %%i in (c:\ActiveTclTemp\*) do move %%i %TCL_DIR%
-  copy %TCL_DIR%\bin\%TCL_DLL% vim\src\
-)
+rem :: Tcl
+rem call :downloadfile %TCL_URL% downloads\tcl.exe
+rem mkdir c:\ActiveTclTemp
+rem start /wait downloads\tcl.exe /extract:c:\ActiveTclTemp /exenoui /exenoupdates /quiet /norestart
+rem for /d %%i in (c:\ActiveTclTemp\*) do move %%i %TCL_DIR%
+rem copy %TCL_DIR%\bin\%TCL_DLL% vim\src\
 
 :: Ruby
 :: RubyInstaller is built by MinGW, so we cannot use header files from it.
@@ -198,33 +196,6 @@ c:\cygwin64\bin\bash -lc "sed -i -e /VIM_VERSION_PATCHLEVEL/s/0/$(sed -n -e '/in
 :: Remove progress bar from the build log
 sed -e "s/@<<$/@<< | sed -e 's#.*\\\\r.*##'/" Make_mvc.mak > Make_mvc2.mak
 :: Build GUI version
-if /i "%ARCH%"=="x64" (
-nmake -f Make_mvc2.mak ^
-	GUI=yes OLE=yes DIRECTX=yes ^
-	FEATURES=HUGE IME=yes MBYTE=yes ICONV=yes DEBUG=no ^
-	DYNAMIC_PERL=yes PERL=%PERL_DIR% ^
-	DYNAMIC_PYTHON=yes PYTHON=%PYTHON_DIR% ^
-	DYNAMIC_PYTHON3=yes PYTHON3=%PYTHON3_DIR% ^
-	DYNAMIC_LUA=yes LUA=%LUA_DIR% ^
-	DYNAMIC_TCL=yes TCL=%TCL_DIR% ^
-	DYNAMIC_RUBY=yes RUBY=%RUBY_DIR% RUBY_MSVCRT_NAME=msvcrt ^
-	DYNAMIC_MZSCHEME=yes "MZSCHEME=%RACKET_DIR%" ^
-	TERMINAL=yes ^
-	|| exit 1
-:: Build CUI version
-nmake -f Make_mvc2.mak ^
-	GUI=no OLE=no DIRECTX=no ^
-	FEATURES=HUGE IME=yes MBYTE=yes ICONV=yes DEBUG=no ^
-	DYNAMIC_PERL=yes PERL=%PERL_DIR% ^
-	DYNAMIC_PYTHON=yes PYTHON=%PYTHON_DIR% ^
-	DYNAMIC_PYTHON3=yes PYTHON3=%PYTHON3_DIR% ^
-	DYNAMIC_LUA=yes LUA=%LUA_DIR% ^
-	DYNAMIC_TCL=yes TCL=%TCL_DIR% ^
-	DYNAMIC_RUBY=yes RUBY=%RUBY_DIR% RUBY_MSVCRT_NAME=msvcrt ^
-	DYNAMIC_MZSCHEME=yes "MZSCHEME=%RACKET_DIR%" ^
-	TERMINAL=yes ^
-	|| exit 1
-) else (
 nmake -f Make_mvc2.mak ^
 	GUI=yes OLE=yes DIRECTX=yes ^
 	FEATURES=HUGE IME=yes MBYTE=yes ICONV=yes DEBUG=no ^
@@ -236,7 +207,6 @@ nmake -f Make_mvc2.mak ^
 	DYNAMIC_MZSCHEME=yes "MZSCHEME=%RACKET_DIR%" ^
 	TERMINAL=yes ^
 	|| exit 1
-)
 :: Build CUI version
 nmake -f Make_mvc2.mak ^
 	GUI=no OLE=no DIRECTX=no ^

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -108,7 +108,7 @@ deploy:
       <summary>Interface Informations</summary>
 
       * [Strawberry Perl](http://strawberryperl.com/) 5.28
-      * ~~[ActiveTcl](http://www.activestate.com/activetcl/downloads) 8.6.6~~ (Disabled for 32bits now. See [#194](https://github.com/vim/vim-win32-installer/issues/194).)
+      * ~~[ActiveTcl](http://www.activestate.com/activetcl/downloads) 8.6.6~~ (Disabled for now. See [#194](https://github.com/vim/vim-win32-installer/issues/194).)
       * [LuaBinaries](http://luabinaries.sourceforge.net/download.html) 5.3
       * [Python](https://www.python.org/downloads/) 2.7
       * [Python3](https://www.python.org/downloads/) 3.8


### PR DESCRIPTION
This reverts commit d09bcac8b48f43f011abf729ffe0badbe699042b.

The TCL URL does not work currently. In addition, it needs some quoting, so the build currently fails. Let's disable it again until this issue has been resolved with ActiveState.