### PR TITLE
Get release logs from latest github release

### DIFF
--- a/scripts/update-repo.sh
+++ b/scripts/update-repo.sh
@@ -23,10 +23,12 @@ if [ ! -d vim/src ]; then
 	git submodule init
 fi
 git submodule update
+# get the last released tag name from this repo
+vimoldver=$(curl -s https://api.github.com/repos/vim/vim-win32-installer/releases/latest  | python -c 'import sys; from json import loads as l; print(l(sys.stdin.read())["tag_name"])')
 
 # Get the latest vim source code
 cd vim
-vimoldver=$(git rev-parse HEAD)
+#vimoldver=$(git rev-parse HEAD)
 git checkout master
 git pull
 vimver=$(git describe --tags --abbrev=0)


### PR DESCRIPTION
Start generating the changelog from the latest release from github,
instead of the latest known git submodule tag. This matters, if a
previous release failed to upload, we want to have included the previous
changes as well.

this is not tested yet.