### PR TITLE
Switch to Python3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can find those interperters here:
 * [ActiveTcl](http://www.activestate.com/activetcl/downloads) 8.6.6
 * [LuaBinaries](http://luabinaries.sourceforge.net/download.html) 5.3
 * [Python](https://www.python.org/downloads/) 2.7
-* [Python 3](https://www.python.org/downloads/) 3.8
+* [Python 3](https://www.python.org/downloads/) 3.9
 * [Racket](https://download.racket-lang.org/) 6.10.1
 * [RubyInstaller2](http://rubyinstaller.org/downloads/) 2.4
 

--- a/appveyor.bat
+++ b/appveyor.bat
@@ -32,7 +32,10 @@ set PYTHON_32_DIR=C:\python%PYTHON_VER%
 set PYTHON_64_DIR=C:\python%PYTHON_VER%-x64
 set PYTHON_DIR=!PYTHON_%BIT%_DIR!
 :: Python3
-set PYTHON3_VER=38
+set PYTHON3_VER=39
+set PYTHON3_32_URL=https://www.python.org/ftp/python/3.9.0/python-3.9.0.exe
+set PYTHON3_64_URL=https://www.python.org/ftp/python/3.9.0/python-3.9.0-amd64.exe
+set PYTHON3_URL=!PYTHON3_%BIT%_URL!
 set PYTHON3_32_DIR=C:\python%PYTHON3_VER%
 set PYTHON3_64_DIR=C:\python%PYTHON3_VER%-x64
 set PYTHON3_DIR=!PYTHON3_%BIT%_DIR!
@@ -120,6 +123,10 @@ mkdir c:\ActiveTclTemp
 start /wait downloads\tcl.exe /extract:c:\ActiveTclTemp /exenoui /exenoupdates /quiet /norestart
 for /d %%i in (c:\ActiveTclTemp\*) do move %%i %TCL_DIR%
 copy %TCL_DIR%\bin\%TCL_DLL% vim\src\
+
+:: Python 3.9
+call :downloadfile %PYTHON3_URL% downloads\python3.exe
+cmd /c start /wait downloads\python3.exe /quiet TargetDir=%PYTHON3_DIR%  Include_pip=0 Include_tcltk=0 Include_test=0 Include_tools=0 AssociateFiles=0 Shortcuts=0 Include_doc=0 Include_launcher=0 InstallLauncherAllUsers=0
 
 :: Ruby
 :: RubyInstaller is built by MinGW, so we cannot use header files from it.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -111,7 +111,7 @@ deploy:
       * [ActiveTcl](http://www.activestate.com/activetcl/downloads) 8.6.6
       * [LuaBinaries](http://luabinaries.sourceforge.net/download.html) 5.3
       * [Python](https://www.python.org/downloads/) 2.7
-      * [Python3](https://www.python.org/downloads/) 3.8
+      * [Python3](https://www.python.org/downloads/) 3.9
       * [Racket](https://download.racket-lang.org/) 6.10.1
       * [RubyInstaller2](http://rubyinstaller.org/downloads/) 2.4
 


### PR DESCRIPTION
Unfortunately, the appveyor build images for Visual Studio 2015 do not include Python3.9, so we have to install it ourselves. 
Therefore  download python3.9 manually and install it below `c:\python39`.
 
Alternatively, we could switch to Visual Studio 2019, but not sure if this would be okay.

This closes https://github.com/vim/vim-win32-installer/issues/203
