### PR TITLE
Remove workaround for suppressing the progress of link

### DIFF
--- a/appveyor.bat
+++ b/appveyor.bat
@@ -225,10 +225,8 @@ set CL=/D_USING_V110_SDK71_
 set CHERE_INVOKING=1
 c:\cygwin64\bin\bash -lc "sed -i -e /VIM_VERSION_PATCHLEVEL/s/0/$(sed -n -e '/included_patches/{n;n;n;s/ *\([0-9]*\).*/\1/p;q}' version.c)/ version.h"
 
-:: Remove progress bar from the build log
-sed -e "s/@<<$/@<< | sed -e 's#.*\\\\r.*##'/" Make_mvc.mak > Make_mvc2.mak
 :: Build GUI version
-nmake -f Make_mvc2.mak ^
+nmake -f Make_mvc.mak ^
 	GUI=yes OLE=yes DIRECTX=yes ^
 	FEATURES=HUGE IME=yes MBYTE=yes ICONV=yes DEBUG=no ^
 	DYNAMIC_PERL=yes PERL=%PERL_DIR% ^
@@ -241,7 +239,7 @@ nmake -f Make_mvc2.mak ^
 	TERMINAL=yes ^
 	|| exit 1
 :: Build CUI version
-nmake -f Make_mvc2.mak ^
+nmake -f Make_mvc.mak ^
 	GUI=no OLE=no DIRECTX=no ^
 	FEATURES=HUGE IME=yes MBYTE=yes ICONV=yes DEBUG=no ^
 	DYNAMIC_PERL=yes PERL=%PERL_DIR% ^


### PR DESCRIPTION
This will be fixed by changing the link option `/LTCG:STATUS` to `/LTCG` in https://github.com/vim/vim/pull/9631.