### PR TITLE
Fix formatting issue in release notes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -108,6 +108,7 @@ deploy:
 
       <details>
       <summary>Interface Information</summary>
+
       * [Strawberry Perl](http://strawberryperl.com/) 5.32
       <!-- * [ActiveTcl](http://www.activestate.com/activetcl/downloads) 8.6.6 -->
       * [LuaBinaries](http://luabinaries.sourceforge.net/download.html) 5.4


### PR DESCRIPTION
The content of Interface Information part have been recognized as HTML, not Markdown.

![image](https://user-images.githubusercontent.com/853977/168443703-1754cd1f-e149-4800-b92c-b4d07eb01d58.png)