### PR TITLE
Extract Patchlevel correctly from the Appveyor tag into Vims version.h

### DIFF
--- a/appveyor.bat
+++ b/appveyor.bat
@@ -227,7 +227,9 @@ set CL=/D_USING_V110_SDK71_
 :: Replace VIM_VERSION_PATCHLEVEL in version.h with the actual patchlevel
 :: Set CHERE_INVOKING to start Cygwin in the current directory
 set CHERE_INVOKING=1
-c:\cygwin64\bin\bash -lc "sed -i -e /VIM_VERSION_PATCHLEVEL/s/0/$(sed -n -e '/included_patches/{n;n;n;s/ *\([0-9]*\).*/\1/p;q}' version.c)/ version.h"
+::c:\cygwin64\bin\bash -lc "sed -i -e /VIM_VERSION_PATCHLEVEL/s/0/$(sed -n -e '/included_patches/{n;n;n;s/ *\([0-9]*\).*/\1/p;q}' version.c)/ version.h"
+c:\cygwin64\bin\bash -lc ../../scripts/patchlevel.sh
+type version.h
 
 :: Build GUI version
 nmake -f Make_mvc.mak ^

--- a/scripts/patchlevel.sh
+++ b/scripts/patchlevel.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+sed -i "s/#define VIM_VERSION_PATCHLEVEL_STR.*/#define VIM_VERSION_PATCHLEVEL_STR \"$PATCHLEVEL\"\n/" ./version.h


### PR DESCRIPTION
This uses a different approach to get the correct patchlevel. Instead of
extracting the patch from version.c, it uses the tag name for that. This
matters for Patches like 9.0.0049, which previously used the patchlevel
of 49 but it should be '0049'

This patchlevel will be used as DisplayVersion and stored in the Windows
registry. winget makes use of the DisplayVersion field and compares that
against the version in its repository (which will again use the tag
version) to decide whether an update of the package should be done.

But instead of relying on the VIM_TOSTR macros, quote the patchlevel
correctly and replace the VIM_VERSION_PATCHLEVEL_STR macro directly with
the actual (quoted) patchlevel.

So this makes sure we use the proper version string for the installed
Windows Vim installer (also visible in the control panel of add/remove
programs).

closes #276