### PR TITLE
Also set the VIM_VERSION_PATCHLEVEL macro to the decimal patchlevel

### DIFF
--- a/scripts/patchlevel.sh
+++ b/scripts/patchlevel.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
 
-sed -i "s/#define VIM_VERSION_PATCHLEVEL_STR.*/#define VIM_VERSION_PATCHLEVEL_STR \"$PATCHLEVEL\"\n/" ./version.h
+PATCHLEVEL_NR=$((10#$PATCHLEVEL))
+
+sed -i \
+  -e "s/^# define VIM_VERSION_PATCHLEVEL\t\+0/#define VIM_VERSION_PATCHLEVEL $PATCHLEVEL_NR/" \
+  -e "s/#define VIM_VERSION_PATCHLEVEL_STR.*/#define VIM_VERSION_PATCHLEVEL_STR \"$PATCHLEVEL\"/" ./version.h


### PR DESCRIPTION
As mentioned in #284, the change db248dd that directly set the VIM_VERSION_PATCHLEVEL_STR did not modify the VIM_VERSION_PATCHLEVEL macro, which causes another breakge.

So in addition, also set the VIM_VERSION_PATCHLEVEL macro to the decimal number (removing leading zeroes).

fixes #284