### PR TITLE
Update both numeric and string patchlevel

### DIFF
--- a/scripts/patchlevel.sh
+++ b/scripts/patchlevel.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 
+PATCHLEVEL_STR=`echo $PATCHLEVEL | sed "s/^0*\\([^0].*\\)/\\1/"`
+sed -i "s/# *define VIM_VERSION_PATCHLEVEL[^_].*/#define VIM_VERSION_PATCHLEVEL ${PATCHLEVEL_STR}\n/" ./version.h
 sed -i "s/#define VIM_VERSION_PATCHLEVEL_STR.*/#define VIM_VERSION_PATCHLEVEL_STR \"$PATCHLEVEL\"\n/" ./version.h


### PR DESCRIPTION
The [censored] regex is necessary to remove leading zeroes that would make the number octal to the compiler. The special case is "0000"; this is left unmodified.

If four-digit patchlevels are guaranteed, then `sed "s/^0\\{1,3\\}//"` is enough.

Most likely fixes #284, however, I cannot test it.