### PR TITLE
Update README.md racket details

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You can find those interperters here:
 * [LuaBinaries](http://luabinaries.sourceforge.net/download.html) 5.4
 * [Python](https://www.python.org/downloads/) 2.7
 * [Python 3](https://www.python.org/downloads/) 3.11
-* [Racket](https://download.racket-lang.org/) 8.3 (BC)
+* [Racket](https://download.racket-lang.org/)
 * [RubyInstaller](http://rubyinstaller.org/downloads/) 3.0
 
 Make sure that you install the same architecture (32bit/64bit) for those

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ additional extensions (e.g. Edit with Vim menu).
 The `gvim...pdb.zip` file only contains the corresponding pdb files for debugging the binaries.
 
 If you need a dynamic interface to Perl, Python2, Python3, Ruby, <del>TCL,</del> Lua or
-Racket/MzScheme, make sure you also install the following. Vim will work
+Racket, make sure you also install the following. Vim will work
 without it, but some Plugin might need this additional dependency. (e.g.
 [Gundo](https://github.com/sjl/gundo.vim) needs a working Python2 installation,
 [Command-T](https://github.com/wincent/command-t) needs a working Ruby


### PR DESCRIPTION
Remove old racket version text. Link is correct, and old versions are available from same link