### PR TITLE
Work-around winget releaser issue

### DIFF
--- a/.github/workflows/winget_nightly.yml
+++ b/.github/workflows/winget_nightly.yml
@@ -6,7 +6,7 @@ jobs:
   publish:
     runs-on: windows-latest # action can only be run on windows
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@v2
+      - uses: vedantmgoyal2009/winget-releaser@f5fe57eeed3b1d0ece9116be65c80c5c53354db9
         with:
           identifier: vim.vim.nightly
           installers-regex: 'gvim.*(x64|x86).exe$'

--- a/.github/workflows/winget_stable.yml
+++ b/.github/workflows/winget_stable.yml
@@ -32,7 +32,7 @@ jobs:
     needs: check-update-job
     if: needs.check-update-job.outputs.needs_update == 'true'
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@v2
+      - uses: vedantmgoyal2009/winget-releaser@f5fe57eeed3b1d0ece9116be65c80c5c53354db9
         with:
           identifier: vim.vim
           installers-regex: 'gvim.*(x64|x86).exe$'


### PR DESCRIPTION
As mentioned in vedantmgoyal2009/winget-releaser#173, work around creating brocken winget releases (by using wrong Architecture links) by pinning the winget-releaser actions to a fixed commit instead of using tag `v2`.