### PR TITLE
Change Winget Releaser job to `ubuntu-latest`

### DIFF
--- a/.github/workflows/winget_nightly.yml
+++ b/.github/workflows/winget_nightly.yml
@@ -4,7 +4,7 @@ on:
     types: [released]
 jobs:
   publish:
-    runs-on: windows-latest # action can only be run on windows
+    runs-on: ubuntu-latest
     steps:
       - uses: vedantmgoyal2009/winget-releaser@v2
         with:

--- a/.github/workflows/winget_stable.yml
+++ b/.github/workflows/winget_stable.yml
@@ -28,7 +28,7 @@ jobs:
           URL: "https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/v/vim/vim"
 
   publish-winget-stable:
-    runs-on: windows-latest # action can only be run on windows
+    runs-on: ubuntu-latest
     needs: check-update-job
     if: needs.check-update-job.outputs.needs_update == 'true'
     steps:


### PR DESCRIPTION
Winget Releaser now supports non-Windows runners, and `ubuntu-latest` is generally faster.