### PR TITLE
CI: Skip master branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,7 @@ build:
   verbosity: minimal
 
 before_build:
+  - 'if "%APPVEYOR_REPO_BRANCH%"=="master" if not defined APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH appveyor.exe exit'
   - 'call ver'
   - 'set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"'
   - >


### PR DESCRIPTION
Currently, CI is executed twice every day:
* When the master branch is updated.
* When a tag is pushed.

We don't need to run CI when the master branch is updated. Skip it.

Note: If a user created a PR to the master branch, %APPVEYOR_REPO_BRANCH% will be set to "master". To skip only the master branch, we need to check that %APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH% is undefined.