### PR TITLE
CI: Partially revert #349

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,13 +19,11 @@ shallow_clone: false
 build:
   verbosity: minimal
 
-init:
+before_build:
   - >
     if "%APPVEYOR_REPO_TAG%/%APPVEYOR_REPO_BRANCH%"=="false/master"
     if not defined APPVEYOR_PULL_REQUEST_HEAD_REPO_BRANCH
     appveyor.exe exit
-
-before_build:
   - 'ver'
   - 'set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"'
   - >


### PR DESCRIPTION
Don't call `appveyor exit` at very beginning.
It caused errors on `on_success` and `on_failure`.

https://ci.appveyor.com/project/k-takata/vim-win32-installer/builds/50273455/job/a5790xthkui300uv
```
"%APPVEYOR_BUILD_FOLDER%\appveyor.bat" onsuccess
'"C:\projects\vim-win32-installer\appveyor.bat"' is not recognized as an internal or external command,
operable program or batch file.
Command exited with code 1
"%APPVEYOR_BUILD_FOLDER%\appveyor.bat" onfailure
'"C:\projects\vim-win32-installer\appveyor.bat"' is not recognized as an internal or external command,
operable program or batch file.
Command exited with code 1
```