### PR TITLE
Update gettext-iconv-windows to v0.22.5a-v1.17-r3

### DIFF
--- a/appveyor.bat
+++ b/appveyor.bat
@@ -80,8 +80,8 @@ set "TCL_DIR=%DEPENDENCIES%\Tcl"
 set "TCL_DLL=tcl%TCL_VER%t.dll"
 set "TCL_LIBRARY=%TCL_DIR%\lib\tcl%TCL_VER_LONG%"
 :: Gettext
-set "GETTEXT32_URL=https://github.com/mlocati/gettext-iconv-windows/releases/download/v0.22.5a-v1.17-r2/gettext0.22.5a-iconv1.17-shared-32.zip"
-set "GETTEXT64_URL=https://github.com/mlocati/gettext-iconv-windows/releases/download/v0.22.5a-v1.17-r2/gettext0.22.5a-iconv1.17-shared-64.zip"
+set "GETTEXT32_URL=https://github.com/mlocati/gettext-iconv-windows/releases/download/v0.22.5a-v1.17-r3/gettext0.22.5a-iconv1.17-shared-32.zip"
+set "GETTEXT64_URL=https://github.com/mlocati/gettext-iconv-windows/releases/download/v0.22.5a-v1.17-r3/gettext0.22.5a-iconv1.17-shared-64.zip"
 :: winpty
 set "WINPTY_URL=https://github.com/rprichard/winpty/releases/download/0.4.3/winpty-0.4.3-msvc2015.zip"
 :: UPX


### PR DESCRIPTION
To support Windows 7 again.
https://github.com/mlocati/gettext-iconv-windows/releases/tag/v0.22.5a-v1.17-r3