### PR TITLE
pass extracted tag to winget-releaser

### DIFF
--- a/.github/workflows/winget_nightly.yml
+++ b/.github/workflows/winget_nightly.yml
@@ -22,6 +22,7 @@ jobs:
           latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
           echo "Latest tag: $latest_tag"
           echo "version=${latest_tag#v}" >> "$GITHUB_OUTPUT"
+          echo "tag=${latest_tag}" >> "$GITHUB_OUTPUT"
 
       - name: Run winget-releaser
         uses: vedantmgoyal9/winget-releaser@main
@@ -29,4 +30,5 @@ jobs:
           identifier: vim.vim.nightly
           installers-regex: 'gvim.*(x64|x86|arm64).exe$'
           version: ${{ steps.get-version.outputs.version }}
+          release-tag: ${{ steps.get-version.outputs.tag }}
           token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/winget_stable.yml
+++ b/.github/workflows/winget_stable.yml
@@ -18,13 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          path: repo
           fetch-depth: 0  # Needed to fetch all tags
 
       - name: Get latest tag
         id: get-version
         run: |
-          cd repo
           git fetch --tags
           latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
           echo "Latest tag: $latest_tag"
@@ -34,7 +32,6 @@ jobs:
       - name: Check updates
         id: check-updates
         run: |
-          cd repo
           echo "result=$(scripts/do_next_stable_release.sh $URL)" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/winget_stable.yml
+++ b/.github/workflows/winget_stable.yml
@@ -36,6 +36,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           URL: "https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/v/vim/vim"
+          REF_NAME: ${{ steps.get-version.outputs.tag }}
 
   publish-winget-stable:
     runs-on: ubuntu-latest

--- a/.github/workflows/winget_stable.yml
+++ b/.github/workflows/winget_stable.yml
@@ -13,6 +13,7 @@ jobs:
     outputs:
       needs_update: ${{ steps.check-updates.outputs.result }}
       version: ${{ steps.get-version.outputs.version }}
+      tag: ${{ steps.get-version.outputs.tag }}
 
     steps:
       - uses: actions/checkout@v4
@@ -28,6 +29,7 @@ jobs:
           latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
           echo "Latest tag: $latest_tag"
           echo "version=${latest_tag#v}" >> "$GITHUB_OUTPUT"
+          echo "tag=${latest_tag}" >> "$GITHUB_OUTPUT"
 
       - name: Check updates
         id: check-updates
@@ -49,3 +51,4 @@ jobs:
           installers-regex: 'gvim.*(x64|x86|arm64).exe$'
           token: ${{ secrets.WINGET_TOKEN }}
           version: ${{ needs.check-update-job.outputs.version }}
+          release-tag: ${{ needs.check-update-job.outputs.tag }}

--- a/scripts/do_next_stable_release.sh
+++ b/scripts/do_next_stable_release.sh
@@ -6,7 +6,7 @@
 # and if the release number is smaller than the current Tag name + 100
 # return true, else false
 
-if [[ -z "$GITHUB_REF_NAME" ]]; then
+if [[ -z "$REF_NAME" ]]; then
   echo "not run in Github Actions CI, quitting"
   exit 2
 fi
@@ -22,7 +22,7 @@ DIR="$(dirname $0)"
 LAST_STABLE_RELEASE=$(${DIR}/get_last_windows_release.sh "$URL" | tr -d '.')
 LAST_STABLE_RELEASE=$(( $LAST_STABLE_RELEASE + 100))
 
-TAG_NAME=$(echo ${GITHUB_REF_NAME} |tr -d '.v')
+TAG_NAME=$(echo ${REF_NAME} |tr -d '.v')
 
 if [[ ${TAG_NAME} -ge ${LAST_STABLE_RELEASE} ]]; then
   echo "true"


### PR DESCRIPTION
winget releaser also needs to be passed the extracted tag. 

While at it, also update `scripts/do_next_stable_release.sh` to no longer depend on `$GITHUB_REF_NAME` which seems not to be defined for workflow runs. 

Also clean up winget-stable-releaser and get rid of cloning into the `repo` directory.