### PR TITLE
Fix ARM64/WIN64 logic and simplify it

### DIFF
--- a/appveyor.bat
+++ b/appveyor.bat
@@ -539,13 +539,11 @@ mklink /J vim\runtime\GvimExt vim\src\GvimExt
 
 pushd vim\nsis
 
-if /I "%ARCH%"=="x64" (
-  set WIN64=1
-  if /I "%PLATFORM%"=="arm64" set ARM64=1
-) else (
-  set WIN64=0
-  set ARM64=0
-)
+set WIN64=0
+set ARM64=0
+
+if /I "%ARCH%"=="x64" set WIN64=1
+if /I "%PLATFORM%"=="arm64" set ARM64=1
 
 nmake.exe -lf Make_mvc.mak "X=OutFile ..\..\gvim_%VER_NUM%_%CUSTOM%.exe" ^
   "GETTEXT=%DEPENDENCIES%" "VIMSRC=..\runtime" "VIMRT=..\runtime" ^


### PR DESCRIPTION
ARM64 may be undefined which causes a build failure (e.g. on non ARM64 but Win64 platform).

So simplify the logic and get rid of the nested logic.

fyi @RestorerZ 