### PR TITLE
appveyor.bat: avoid leading zero in PATCHLEVEL environment variable

### DIFF
--- a/appveyor.bat
+++ b/appveyor.bat
@@ -27,6 +27,13 @@ for /F "delims=.-+ tokens=1-3" %%I in ("%VER_NUM%") do (
   set "PATCHLEVEL=%%K"
 )
 
+:: PATCHLEVEL comes from tags like v9.2.0068.
+:: rc (and the C preprocessor) treat 0-prefixed numbers as octal, so 0068 breaks.
+:: Keep the original padded patchlevel, but normalize PATCHLEVEL to a plain decimal number.
+set "PATCHLEVEL_PADDED=%PATCHLEVEL%"
+for /F "tokens=* delims=0" %%P in ("%PATCHLEVEL_PADDED%") do set "PATCHLEVEL=%%P"
+if not defined PATCHLEVEL set "PATCHLEVEL=0"
+
 if /I "%ARCH%"=="x64" (
   set "BIT=64"
 ) else (


### PR DESCRIPTION
Strip leading zeros from PATCHLEVEL in appveyor.bat. The resource compiler treats numbers starting with 0 as octal, causing failures for patch levels like 0068.

Keep padded value for version strings, use decimal for compilation.

See this failure here:
https://ci.appveyor.com/project/chrisbra/vim-win32-installer/builds/53607430/job/1xjwrgrw8wqsjd03 This happened for patch v9.2.0068, e.g. PATCHLEVEL=0068

```
  cl -c /W3 /GF /nologo -I. -Iproto -DHAVE_PATHDEF -DWIN32
-DHAVE_STDINT_H  -DFEAT_CSCOPE -DFEAT_TERMINAL -DFEAT_SOUND
-DFEAT_NETBEANS_INTG   -DFEAT_XPM_W32 -DHAVE_SODIUM -DDYNAMIC_SODIUM
-DDYNAMIC_SODIUM_DLL=\"libsodium.dll\" /I
"C:\projects\vim-win32-installer\dependencies\libsodium\include"
-DFEAT_JOB_CHANNEL -DFEAT_IPV6 -DHAVE_INET_NTOP    -DWINVER=0x0601
-D_WIN32_WINNT=0x0601  /source-charset:utf-8 /MP /Ox /GL -DNDEBUG  /Zl
/MT -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE -DVIMDLL
-DFEAT_OLE -DFEAT_MBYTE_IME -DDYNAMIC_IME -DFEAT_GUI_MSWIN
-DFEAT_DIRECTX -DDYNAMIC_DIRECTX -DFEAT_DIRECTX_COLOR_EMOJI
-DDYNAMIC_ICONV -DDYNAMIC_GETTEXT -DFEAT_LUA -DDYNAMIC_LUA
-DDYNAMIC_LUA_DLL=\"lua54.dll\" -DFEAT_PYTHON -DDYNAMIC_PYTHON
-DDYNAMIC_PYTHON_DLL=\"python27.dll\" -DFEAT_PYTHON3 -DDYNAMIC_PYTHON3
-DDYNAMIC_PYTHON3_DLL=\"python3.dll\" -DDYNAMIC_PYTHON3_STABLE_ABI
-DFEAT_MZSCHEME -I
"C:\projects\vim-win32-installer\dependencies\racket3m_dcgt6o-x64\include"
-DMZ_PRECISE_GC -DDYNAMIC_MZSCHEME
-DDYNAMIC_MZSCH_DLL=\"libracket3m_dcgt6o.dll\"
-DDYNAMIC_MZGC_DLL=\"libracket3m_dcgt6o.dll\" -DFEAT_PERL
-DPERL_IMPLICIT_CONTEXT -DPERL_IMPLICIT_SYS -DDYNAMIC_PERL
-DDYNAMIC_PERL_DLL=\"perl538.dll\" -DFEAT_RUBY -DDYNAMIC_RUBY
-DDYNAMIC_RUBY_DLL=\"x64-ucrt-ruby340.dll\" -DRUBY_VERSION=34
-DFEAT_HUGE /Fd.\ObjDXOULYHRZAMD64/ /Zi
/Fo.\ObjDXOULYHRZAMD64/os_w32exeg.obj os_w32exe.c
os_w32exe.c
  rc /nologo /l 0x409 /Fo.\ObjDXOULYHRZAMD64/vimg.res
-DVIM_VERSION_PATCHLEVEL=0068 -DNDEBUG -DFEAT_OLE -DFEAT_GUI_MSWIN
-DVIMDLL vim.rc
version.h(39) : error RC2020: illegal digit 8 for base 8
version.h(41) : error RC2020: illegal digit 8 for base 8
vim.rc(68) : error RC2020: illegal digit 8 for base 8
C:\projects\vim-win32-installer\vim\src\ObjDXOULYHRZAMD64\RCa05336(137)
: fatal error RC1116: RC terminating after preprocessor errors
error U1077: 'rc /nologo /l 0x409 /Fo.\ObjDXOULYHRZAMD64/vimg.res
-DVIM_VERSION_PATCHLEVEL=0068 -DNDEBUG -DFEAT_OLE -DFEAT_GUI_MSWIN
-DVIMDLL vim.rc' : return code '0x4'
Stop.
Command exited with code 1
"%APPVEYOR_BUILD_FOLDER%\appveyor.bat" onfailure
```