### PR TITLE
Upload signed files via workflow

### DIFF
--- a/.github/workflows/upload-signed-files.yml
+++ b/.github/workflows/upload-signed-files.yml
@@ -1,0 +1,99 @@
+name: Upload signed files
+
+on:
+  push:
+    branches:
+      - 'upload-signed-files' # XXX: for debugging
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'GitHub Actions run_id when created the corresponding release'
+        required: true
+        type: string
+
+permissions:
+  id-token: write # needed for attestion
+  attestations: write
+  contents: write  # to update a release
+
+jobs:
+  upload-signed-files:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download build info
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = 'workflow_dispatch' ]; then
+            RUN_ID=${{ inputs.run_id }}
+          else
+            # XXX: For debugging
+            RUN_ID=26016790078
+          fi
+
+          gh run download ${RUN_ID} -p "info-*"
+
+      - name: Download signed files
+        shell: bash
+        env:
+          SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+          ORGANIZATION_ID: 47c0047c-0c1d-42b2-a16c-4ea6907dc813
+        run: |
+          mkdir package
+
+          for arch in x86 x64 arm64; do
+            SIGNING_REQUEST_ID=$(cat info-${arch}/signing-request-id.txt)
+            curl -f -H "Authorization: Bearer ${SIGNPATH_API_TOKEN}" \
+                 -o ${arch}.zip \
+                 https://app.signpath.io/API/v1/${ORGANIZATION_ID}/SigningRequests/${SIGNING_REQUEST_ID}/SignedArtifact
+            unzip ${arch}.zip -d package
+          done
+
+          rm package/*_pdb.*
+
+          # rename to *_signed.*
+          for i in package/gvim_*; do
+            n=$(echo "$i" | sed -e 's/\(gvim_.*\)\.\(exe\|zip\)/\1_signed.\2/')
+            mv "$i" "$n"
+          done
+
+          ls -l package
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: signed-package
+          path: ./package
+
+      - name: Attest
+        uses: actions/attest@v4
+        with:
+          subject-path: ./package
+
+      - name: Update release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG=$(cat info-x64/latesttag.txt)
+
+          echo '---------------'
+          gh release view "${TAG}" --json body | jq -r .body | tee body.md
+          echo '---------------'
+          # Remove comments
+          sed -i -e '/^<!--$/d' -e '/^-->/d' -e '/^<!--  *commented out,/d' body.md
+          echo '---------------'
+          cat body.md
+          echo '---------------'
+
+          #for i in package/gvim*.exe gvim*.zip; do
+          #  gh release upload "${TAG}" "$i" --clobber
+          #done
+          #gh release edit "${TAG}" -F body.md
+
+
+# vim: ts=2 sw=2 sts=2 et

--- a/.github/workflows/upload-signed-files.yml
+++ b/.github/workflows/upload-signed-files.yml
@@ -1,9 +1,9 @@
 name: Upload signed files
 
 on:
-  push:
-    branches:
-      - 'upload-signed-files' # XXX: for debugging
+  #push:
+  #  branches:
+  #    - 'upload-signed-files' # XXX: for debugging
   workflow_dispatch:
     inputs:
       run_id:
@@ -30,9 +30,9 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = 'workflow_dispatch' ]; then
             RUN_ID=${{ inputs.run_id }}
-          else
-            # XXX: For debugging
-            RUN_ID=26016790078
+          #else
+          #  # XXX: For debugging
+          #  RUN_ID=26016790078
           fi
 
           gh run download ${RUN_ID} -p "info-*"
@@ -81,19 +81,23 @@ jobs:
         run: |
           TAG=$(cat info-x64/latesttag.txt)
 
+          # Original release notes
           echo '---------------'
           gh release view "${TAG}" --json body | jq -r .body | tee body.md
           echo '---------------'
+
           # Remove comments
           sed -i -e '/^<!--$/d' -e '/^-->/d' -e '/^<!--  *commented out,/d' body.md
+
+          # Updated release notes
           echo '---------------'
           cat body.md
           echo '---------------'
 
-          #for i in package/gvim*.exe gvim*.zip; do
-          #  gh release upload "${TAG}" "$i" --clobber
-          #done
-          #gh release edit "${TAG}" -F body.md
+          for i in package/gvim*.exe gvim*.zip; do
+            gh release upload "${TAG}" "$i" --clobber
+          done
+          gh release edit "${TAG}" -F body.md
 
 
 # vim: ts=2 sw=2 sts=2 et

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build status](https://ci.appveyor.com/api/projects/status/0x8kevh62dkdt7mu?svg=true)](https://ci.appveyor.com/project/chrisbra/vim-win32-installer)
+[![Build Vim](https://github.com/vim/vim-win32-installer/actions/workflows/build-vim.yml/badge.svg)](https://github.com/vim/vim-win32-installer/actions/workflows/build-vim.yml)
 [![GitHub All Releases](https://img.shields.io/github/downloads/vim/vim-win32-installer/total)](https://github.com/vim/vim-win32-installer/releases)
 [![Latest GitHub Release](https://img.shields.io/github/v/release/vim/vim-win32-installer)](https://github.com/vim/vim-win32-installer/releases/latest)
 


### PR DESCRIPTION
Add a workflow to upload signed files to a corresponding release.

This should be used in combination with #421.

If a new release is created via GHA run_id `x` (e.g. [26016790078](https://github.com/vim/vim-win32-installer/actions/runs/26016790078)), maintainer should approve signpath requests, then maintainer should start this workflow by setting run_id `x`.
The workflow will download the build information for run_id `x`, download the signed files from signpath, upload them to the corresponding release, and then update the release notes.