### PR TITLE
Fix running winget*.yml

### DIFF
--- a/.github/workflows/build-vim.yml
+++ b/.github/workflows/build-vim.yml
@@ -19,6 +19,7 @@ on:
         type: string
 
 permissions:
+  actions: write # to cancel a workflow run
   id-token: write # needed for attestion
   attestations: write
   artifact-metadata: write
@@ -214,12 +215,15 @@ jobs:
 
     - name: Checkout Vim
       shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         if ! git clone ${VIMREPO}.git --shallow-exclude="$(cat vimver.txt)"; then
           # No new commits since the version written in vimver.txt.
           if [ "${{ github.event_name }}" = 'pull_request' ]; then
             git clone ${VIMREPO}.git --depth=5
           else
+            gh run cancel "${{ github.run_id }}"
             exit 0
           fi
         fi

--- a/.github/workflows/winget_nightly.yml
+++ b/.github/workflows/winget_nightly.yml
@@ -2,12 +2,16 @@ name: Publish to WinGet
 
 # Only run after the release have been pulished
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Build Vim"]
+    branches: [master]
+    types: [completed]
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/winget_stable.yml
+++ b/.github/workflows/winget_stable.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   check-update-job:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     outputs:
       needs_update: ${{ steps.check-updates.outputs.result }}


### PR DESCRIPTION
winget_nightly.yml was not executed after build-vim.yml. on.release doesn't work. Use on.workflow_run instead.

Also, cancel build-vim.yml if there are no updates in the vim repository instead of just exit successfully.