### PR TITLE
Use deploy key to create a release

### DIFF
--- a/.github/workflows/build-vim.yml
+++ b/.github/workflows/build-vim.yml
@@ -977,6 +977,7 @@ jobs:
         body_path: changelog.md
         draft: false
         prerelease: false
+        token: ${{ secrets.VIM_WIN32_INSTALLER_DEPLOY_KEY }}
         files: |
           ./vim-package-x86/gvim_*.exe
           ./vim-package-x86/gvim_*.zip

--- a/.github/workflows/update-release-list.yaml
+++ b/.github/workflows/update-release-list.yaml
@@ -1,12 +1,12 @@
 name: Update Release List
 
 on:
-  #release:
-  #  types: [published]
-  workflow_run:
-    workflows: ["Build Vim"]
-    branches: [master]
-    types: [completed]
+  release:
+    types: [published]
+  #workflow_run:
+  #  workflows: ["Build Vim"]
+  #  branches: [master]
+  #  types: [completed]
 
 permissions:
   contents: write # to update wiki
@@ -25,7 +25,7 @@ env:
 jobs:
   update:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    #if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/winget_nightly.yml
+++ b/.github/workflows/winget_nightly.yml
@@ -1,16 +1,18 @@
 name: Publish to WinGet
 
-# Only run after the release have been pulished
+# Only run after the release have been published
 on:
-  workflow_run:
-    workflows: ["Build Vim"]
-    branches: [master]
-    types: [completed]
+  release:
+    types: [published]
+  #workflow_run:
+  #  workflows: ["Build Vim"]
+  #  branches: [master]
+  #  types: [completed]
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    #if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
If the default GITHUB_TOKEN is used to create a release, it will not trigger a workflow except `on.workflow_run`.
https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow

However, `on.workflow_run` is triggered even if the release job has been canceled or failed.

Use deploy key to use the `on.release` trigger.