### PR TITLE
Suppress error messages in if_ver.vim

### DIFF
--- a/scripts/if_ver.vim
+++ b/scripts/if_ver.vim
@@ -2,24 +2,58 @@
 
 redir! > if_ver.txt
 echo "*** Interface versions ***"
+
 echo "\nLua:"
-lua print(_VERSION)
-" echo "\nLuaJIT:"
-" lua print(jit.version)
+if has('lua')
+  lua print(vim.lua_version, jit and "("..jit.version..")" or "")
+else
+  echo "not available"
+endif
+
 echo "\nMzScheme:"
-mzscheme (display (version))
+if has('mzscheme')
+  mzscheme (display (version))
+else
+  echo "not available"
+endif
+
 echo "\nPerl:"
-perl print $^V
+if has('perl')
+  perl print $^V
+else
+  echo "not available"
+endif
+
 echo "\nPython 2:"
-python import sys; print sys.version
+if has('python')
+  python import sys; print sys.version
+else
+  echo "not available"
+endif
+
 echo "\nPython 3:"
-python3 import sys; print(sys.version)
+if has('python3')
+  python3 import sys; print(sys.version)
+else
+  echo "not available"
+endif
+
 echo "\nRuby:"
-ruby print RUBY_VERSION
-" echo "\nTcl:"
-" tcl puts [info patchlevel]
-echo "\n"
-echo "\n $VIMRUNTIME"
+if has('ruby')
+  ruby print RUBY_VERSION
+else
+  echo "not available"
+endif
+
+echo "\nTcl:"
+if has('tcl')
+  tcl puts [info patchlevel]
+else
+  echo "not available"
+endif
+
+echo "\n$VIMRUNTIME:"
 echo $VIMRUNTIME
+
 echo "\n"
 redir END


### PR DESCRIPTION
Fix the version-check script so it only calls interfaces that are actually compiled in.
(Suggested by Copilot.)