### PR TITLE
Fix code signing

### DIFF
--- a/.github/workflows/build-vim.yml
+++ b/.github/workflows/build-vim.yml
@@ -201,6 +201,7 @@ jobs:
       id: check
       shell: bash
       env:
+        SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
         GH_TOKEN: ${{ github.token }}
       run: |
         if git diff --exit-code HEAD vimver.txt; then


### PR DESCRIPTION
Code signing didn't work:
https://github.com/vim/vim-win32-installer/actions/runs/26315806576

Fix it by passing `secrets.SIGNPATH_API_TOKEN`.