### PR TITLE
winget: Set max-versions-to-keep

### DIFF
--- a/.github/workflows/winget_nightly.yml
+++ b/.github/workflows/winget_nightly.yml
@@ -37,3 +37,4 @@ jobs:
           version: ${{ steps.get-version.outputs.version }}
           release-tag: ${{ steps.get-version.outputs.tag }}
           token: ${{ secrets.WINGET_TOKEN }}
+          max-versions-to-keep: 200

--- a/.github/workflows/winget_stable.yml
+++ b/.github/workflows/winget_stable.yml
@@ -51,3 +51,4 @@ jobs:
           token: ${{ secrets.WINGET_TOKEN }}
           version: ${{ needs.check-update-job.outputs.version }}
           release-tag: ${{ needs.check-update-job.outputs.tag }}
+          max-versions-to-keep: 100


### PR DESCRIPTION
Currently, we have many versions on winget:

* Nightly:
  About 580 versions. The oldest is 9.0.1642.
* Stable:
  About 250 versions. The oldest is 9.0.0224.

I don't think we need so many versions.
Most users use winget to get the latest version.